### PR TITLE
Decided to include the wireshark diamter xml files within the jar.

### DIFF
--- a/codec-codegen-common/src/main/java/io/snice/codecs/codegen/FileSystemUtils.java
+++ b/codec-codegen-common/src/main/java/io/snice/codecs/codegen/FileSystemUtils.java
@@ -1,0 +1,25 @@
+package io.snice.codecs.codegen;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemAlreadyExistsException;
+import java.nio.file.FileSystems;
+import java.util.HashMap;
+
+public class FileSystemUtils {
+
+    public static FileSystem ensureFileSystem(final URI uri) {
+        try {
+            if ("jar".equals(uri.getScheme())) {
+                final var env = new HashMap<String, Object>();
+                env.put("create", "true");
+                return FileSystems.newFileSystem(uri, env);
+            }
+        } catch (final FileSystemAlreadyExistsException | IOException e) {
+            // ignore
+        }
+
+        return FileSystems.getDefault();
+    }
+}

--- a/codec-diameter-codegen/src/main/java/io/snice/codecs/codegen/diameter/config/CodeConfig2.java
+++ b/codec-diameter-codegen/src/main/java/io/snice/codecs/codegen/diameter/config/CodeConfig2.java
@@ -8,6 +8,7 @@ import io.snice.codecs.codegen.ClassNameConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.*;
 
@@ -22,11 +23,7 @@ public class CodeConfig2 {
 
     private final PackageConfig packageConfig;
     private final Optional<Path> sourceRoot;
-
-    /**
-     * The directory where we'll find all the wireshark dictionary files
-     */
-    private final Optional<Path> wiresharkDictionaryRoot;
+    private final URI dictionaryXml;
 
     private final Optional<GenerationConfig> avpPackageConfig;
     private final Optional<GenerationConfig> cmdPackageConfig;
@@ -38,17 +35,21 @@ public class CodeConfig2 {
     }
 
     private CodeConfig2(final PackageConfig packageConfig,
+                        final URI dictionaryXml,
                         final Optional<Path> sourceRoot,
-                        final Optional<Path> wiresharkDictionaryRoot,
                         final Optional<GenerationConfig> avpPackageConfig,
                         final Optional<GenerationConfig> cmdPackageConfig,
                         final Optional<GenerationConfig> appPackageConfig) {
         this.packageConfig = packageConfig;
-        this.wiresharkDictionaryRoot = wiresharkDictionaryRoot;
+        this.dictionaryXml = dictionaryXml;
         this.sourceRoot = sourceRoot;
         this.avpPackageConfig = avpPackageConfig;
         this.cmdPackageConfig = cmdPackageConfig;
         this.appPackageConfig = appPackageConfig;
+    }
+
+    public URI getDictionaryXml() {
+        return dictionaryXml;
     }
 
     public Optional<GenerationConfig> getAvpPackageConfig() {
@@ -67,9 +68,11 @@ public class CodeConfig2 {
         return sourceRoot;
     }
 
+    /*
     public Optional<Path> getWiresharkDictionaryRoot() {
         return wiresharkDictionaryRoot;
     }
+     */
 
     public PackageConfig getPackageConfig() {
         return packageConfig;
@@ -77,8 +80,8 @@ public class CodeConfig2 {
 
     public Builder copy() {
         final var builder = new Builder();
+        builder.withWiresharkDictionaryXml(dictionaryXml);
         sourceRoot.ifPresent(builder::withSourceRoot);
-        wiresharkDictionaryRoot.ifPresent(builder::withWiresharkDictionaryDir);
         appPackageConfig.ifPresent(builder::withAppGenerationConfig);
         cmdPackageConfig.ifPresent(builder::withCmdGenerationConfig);
         avpPackageConfig.ifPresent(builder::withAvpGenerationConfig);
@@ -179,7 +182,9 @@ public class CodeConfig2 {
          */
         private Path sourceRoot;
 
-        private Path wiresharkDictionaryRootDir;
+        private URI dictionaryXml;
+
+        private URI dictionaryDtd;
 
         /**
          * The diameter sub-directories.
@@ -214,9 +219,8 @@ public class CodeConfig2 {
             return this;
         }
 
-        @JsonProperty("wireshark")
-        public Builder withWiresharkDictionaryDir(final Path dir) {
-            this.wiresharkDictionaryRootDir = dir;
+        public Builder withWiresharkDictionaryXml(final URI xml) {
+            this.dictionaryXml = xml;
             return this;
         }
 
@@ -239,8 +243,8 @@ public class CodeConfig2 {
         }
 
         public CodeConfig2 build() {
-            return new CodeConfig2(packageConfig, Optional.ofNullable(sourceRoot),
-                    Optional.ofNullable(wiresharkDictionaryRootDir),avpGenerationConfig, cmdGenerationConfig, appGenerationConfig);
+            return new CodeConfig2(packageConfig, dictionaryXml, Optional.ofNullable(sourceRoot),
+                    avpGenerationConfig, cmdGenerationConfig, appGenerationConfig);
         }
 
     }

--- a/codec-diameter-codegen/src/main/resources/diameter/AlcatelLucent.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/AlcatelLucent.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vendor vendor-id="ALU"				code="637"	name="ALU Network"/>
+
+<!-- NOTE the Application ID is not assigned by IANA http://www.iana.org/assignments/aaa-parameters/aaa-parameters.xml -->
+<application id="111" name="ALU Sy" uri="none">
+
+	<avp name="Detailed-Result" code="15" mandatory="mustnot" protected="may" vendor-bit="must" vendor-id="ALU" may-encrypt="yes">
+		<grouped>
+			<gavp name="Detailed-Result-Code"/>
+			<gavp name="Detailed-Result-Cause"/>
+		</grouped>
+	</avp>
+	<avp name="Detailed-Result-Cause" code="16" mandatory="mustnot" protected="may" vendor-bit="must" vendor-id="ALU" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Detailed-Result-Code" code="17" mandatory="must" protected="may" vendor-bit="must" vendor-id="ALU" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="DPA-Instruction" code="1016" mandatory="mustnot" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="ALU">
+		<type type-name="Enumerated"/>
+		<enum name="SESSION_CREATED" code="0"/>
+		<enum name="IP_ADDRESS_UPDATED" code="1"/>
+		<enum name="AUX_GX_ESTABLISHMENT" code="2"/>
+	</avp>
+	<avp name="Charging-Policy-Report" code="1134" mandatory="mustnot" protected="may" vendor-bit="must" vendor-id="ALU" may-encrypt="yes">
+		<grouped>
+			<gavp name="Policy-Counter"/>
+		</grouped>
+	</avp>
+	<avp name="Policy-Counter" code="1135" mandatory="must" protected="may" vendor-bit="must" vendor-id="ALU" may-encrypt="yes">
+		<grouped>
+			<gavp name="Policy-Counter-Id"/>
+			<gavp name="Policy-Counter-Value"/>
+		</grouped>
+	</avp>
+	<avp name="Policy-Counter-Id" code="1136" mandatory="mustnot" protected="may" vendor-bit="must" vendor-id="ALU" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Policy-Counter-Value" code="1137" mandatory="mustnot" protected="may" vendor-bit="must" vendor-id="ALU" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Subscriber-User-Id" code="1139" mandatory="mustnot" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="ALU">
+		<type type-name="UTF8String"/>
+	</avp>
+</application>

--- a/codec-diameter-codegen/src/main/resources/diameter/Cisco.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/Cisco.xml
@@ -1,0 +1,1240 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<vendor vendor-id="Cisco" code="5771" name="Cisco">
+
+	<avp name="Cisco-Flow-Description-507" code="507" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must">
+		<type type-name="IPFilterRule"/>
+	</avp>
+
+	<avp name="Cisco-Charging-Rule-Definition" code="131072" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Charging-Rule-Name"/>
+			<gavp name="Service-Name"/>
+			<gavp name="Rating-Group"/>
+			<gavp name="Cisco-Flow-Description"/>
+			<gavp name="Cisco-Flow-Status"/>
+			<gavp name="QoS-Information"/>
+			<gavp name="Online"/>
+			<gavp name="Offline"/>
+			<gavp name="Precedence"/>
+			<gavp name="AF-Charging-Identifier"/>
+			<gavp name="Charging-Rule-Event-Trigger"/>
+			<gavp name="Redirect-Server"/>
+		</grouped>
+	</avp>
+
+	<avp name="Content-Definition" code="131073" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Content-Name"/>
+			<gavp name="Cisco-Flow-Description"/>
+			<gavp name="Content-Scope"/>
+			<gavp name="Content-Idle-Timer"/>
+			<gavp name="Nexthop"/>
+			<gavp name="Nexthop-Reverse"/>
+			<gavp name="L7-Parse-Protocol-Type"/>
+			<gavp name="L7-Parse-Length"/>
+			<gavp name="Billing-Policy-Name"/>
+			<gavp name="Replicate-Session"/>
+			<gavp name="Intermediate-CDR-Threshold"/>
+			<gavp name="CDR-Generation-Delay"/>
+			<gavp name="Content-Pending-Timer"/>
+			<gavp name="Operation-Status"/>
+			<gavp name="Subscriber-IP-Source"/>
+			<gavp name="Flow-Status-Policy-Mismatch"/>
+			<gavp name="Relative-URL"/>
+			<gavp name="Control-URL"/>
+			<gavp name="Domain-Group-Name"/>
+			<gavp name="Mining"/>
+			<gavp name="Nexthop-Media"/>
+			<gavp name="Nexthop-Override"/>
+			<gavp name="Accel"/>
+		</grouped>
+	</avp>
+
+	<avp name="Billing-Policy-Definition" code="131074" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Billing-Policy-Name"/>
+			<gavp name="Policy-Map-Name"/>
+			<gavp name="Accounting"/>
+			<gavp name="Class-Map-Name"/>
+			<gavp name="Header-Group-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="Policy-Map-Definition" code="131075" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Policy-Map-Name"/>
+			<gavp name="Policy-Map-Type"/>
+			<gavp name="Policy-Map-Replace"/>
+			<gavp name="Policy-Map-Match-Remove"/>
+			<gavp name="Policy-Map-Match-Install"/>
+		</grouped>
+	</avp>
+
+
+	<avp name="Service-Definition" code="131076" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Service-Name"/>
+			<gavp name="Online-Billing-Basis"/>
+			<gavp name="Dual-Billing-Basis"/>
+			<gavp name="Service-Reporting-Level"/>
+			<gavp name="Service-CDR-Threshold"/>
+			<gavp name="Service-Activation"/>
+			<gavp name="Advice-Of-Charge"/>
+			<gavp name="Cisco-Service-Class"/>
+			<gavp name="Service-Idle-Time"/>
+			<gavp name="Owner-Id"/>
+			<gavp name="Owner-Name"/>
+			<gavp name="Online-Passthrough-Quota"/>
+			<gavp name="Dual-Passthrough-Quota"/>
+			<gavp name="Online-Reauthorization-Threshold"/>
+			<gavp name="Dual-Reauthorization-Threshold"/>
+			<gavp name="Online-Reauthorization-Timeout"/>
+			<gavp name="Refund-Policy"/>
+			<gavp name="Meter-Exclude"/>
+			<gavp name="Meter-Include-Imap"/>
+			<gavp name="Metering-Granularity"/>
+			<gavp name="Verify"/>
+			<gavp name="Cisco-Quota-Consumption-Time"/>
+			<gavp name="Service-Rating-Group"/>
+			<gavp name="Cisco-QoS-Profile-Uplink"/>
+			<gavp name="Cisco-QoS-Profile-Downlink"/>
+			<gavp name="Header-Group-Name"/>
+			<gavp name="Content-Policy-Map"/>
+		</grouped>
+	</avp>
+
+	<avp name="Content-Policy-Map" code="131077" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Content-Name"/>
+			<gavp name="Billing-Policy-Name"/>
+			<gavp name="Weight"/>
+		</grouped>
+	</avp>
+
+	<avp name="Service-Info" code="131078" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Service-Name"/>
+			<gavp name="Online"/>
+			<gavp name="Virtual-Online"/>
+		</grouped>
+	</avp>
+
+	<avp name="Billing-Plan-Definition" code="131079" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Billing-Plan-Name"/>
+			<gavp name="Online"/>
+			<gavp name="Offline"/>
+			<gavp name="Virtual-Online"/>
+			<gavp name="User-Idle-Timer"/>
+			<gavp name="User-Idle-Pod"/>
+			<gavp name="User-Default"/>
+			<gavp name="Cisco-QoS-Profile-Uplink"/>
+			<gavp name="Cisco-QoS-Profile-Downlink"/>
+			<gavp name="Service-Info"/>
+		</grouped>
+	</avp>
+
+	<avp name="Volume-Threshold" code="131080" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Time-Threshold" code="131081" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Content-Idle-Timer" code="131082" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Nexthop-Uplink" code="131083" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="Nexthop-Downlink" code="131084" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="L7-Parse-Protocol-Type" code="131085" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="HTTP" code="0"/>
+		<enum name="IMAP" code="1"/>
+		<enum name="OTHER" code="2"/>
+		<enum name="POP3" code="3"/>
+		<enum name="RTSP" code="4"/>
+		<enum name="SMTP" code="5"/>
+		<enum name="WAP-CONNECTION-ORIENTED" code="6"/>
+		<enum name="WAP-CONNECTION-LESS" code="7"/>
+		<enum name="SIP" code="8"/>
+		<enum name="FTP" code="9"/>
+		<enum name="NBAR" code="10"/>
+		<enum name="DNS" code="11"/>
+		<enum name="HTTP-INSERT" code="12"/>
+	</avp>
+
+	<avp name="Service-Status" code="131086" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Service-Name"/>
+			<gavp name="Cisco-Flow-Status"/>
+			<gavp name="Service-Rating-Group"/>
+			<gavp name="Service-QoS"/>
+			<gavp name="Redirect-Server"/>
+			<gavp name="Service-Group-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="Service-Name" code="131087" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+
+	</avp>
+		<avp name="Billing-Policy-Name" code="131088" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+		<avp name="Policy-Map-Name" code="131089" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Policy-Map-Match" code="131090" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Match-String"/>
+			<gavp name="Attribute-String"/>
+		</grouped>
+	</avp>
+
+	<avp name="Match-String" code="131091" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="Attribute-String" code="131092" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="Online-Billing-Basis" code="131093" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="EVENT" code="1"/>
+		<enum name="IP_BYTE" code="2"/>
+		<enum name="TCP_BYTE" code="3"/>
+		<enum name="DURATION" code="4"/>
+		<enum name="DURATION-CONNECT" code="5"/>
+		<enum name="DURATION-TRANSACTION" code="6"/>
+	</avp>
+
+	<avp name="Service-Activation" code="131094" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="USER_PROFILE" code="0"/>
+		<enum name="AUTOMATIC" code="1"/>
+	</avp>
+
+	<avp name="CDR-Volume-Threshold" code="131095" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="CDR-Time-Threshold" code="131096" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Advice-Of-Charge" code="131097" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Append-URL"/>
+			<gavp name="Confirm-Token-131099"/>
+		</grouped>
+	</avp>
+
+	<avp name="Append-URL" code="131098" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="DISABLE_APPEND_URL" code="0"/>
+		<enum name="ENABLE_APPEND_URL" code="1"/>
+	</avp>
+
+	<avp name="Confirm-Token-131099" code="131099" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+
+	</avp>
+
+	<avp name="Cisco-Service-Class" code="131100" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Service-Idle-Time" code="131101" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+
+	</avp>
+
+	<avp name="Owner-Id" code="131102" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Owner-Name" code="131103" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Online-Passthrough-Quota" code="131104" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Online-Reauthorization-Threshold" code="131105" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+
+	</avp>
+
+	<avp name="Online-Reauthorization-Timeout" code="131106" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Initial-Timeout"/>
+			<gavp name="Maximum-Timeout"/>
+		</grouped>
+	</avp>
+
+	<avp name="Initial-Timeout" code="131107" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Maximum-Timeout" code="131108" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+
+	</avp>
+
+	<avp name="Refund-Policy" code="131109" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+
+	</avp>
+
+	<avp name="Meter-Exclude" code="131110" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="MMS_WAP" code="0"/>
+		<enum name="RTSP_PAUSE" code="1"/>
+		<enum name="SERVICE_IDLE" code="2"/>
+		<enum name="NETWORK_INIT_SIP" code="3"/>
+	</avp>
+
+	<avp name="Meter-Include-Imap" code="131111" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="BODY_AND_HEADER" code="0"/>
+		<enum name="BODY_ONLY" code="1"/>
+		<enum name="BODY_AND_OTHER" code="2"/>
+	</avp>
+
+	<avp name="Metering-Granularity" code="131112" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Meter-Increment"/>
+			<gavp name="Meter-Initial"/>
+			<gavp name="Meter-Minimum"/>
+		</grouped>
+	</avp>
+
+	<avp name="Meter-Increment" code="131113" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Meter-Initial" code="131114" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Meter-Minimum" code="131115" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Verify" code="131116" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Confirm-Token-131117"/>
+		</grouped>
+	</avp>
+
+	<avp name="Confirm-Token-131117" code="131117" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Weight" code="131118" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="User-Idle-Timer" code="131119" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Policy-Preload-Req-Type" code="131120" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="POLICY_PRELOAD_REQ" code="0"/>
+		<enum name="POLICY_PRELOAD_RESP" code="1"/>
+		<enum name="POLICY_PRELOAD_PUSH" code="2"/>
+		<enum name="POLICY_PRELOAD_PUSH_ACK" code="3"/>
+	</avp>
+
+	<avp name="Policy-Preload-Object-Type" code="131121" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="POLICY_MAP" code="0"/>
+		<enum name="BILLING_POLICY" code="1"/>
+		<enum name="CONTENT" code="2"/>
+		<enum name="SERVICE" code="3"/>
+		<enum name="BILLING_PLAN" code="4"/>
+		<enum name="DOMAIN_GROUP" code="5"/>
+		<enum name="HEADER_INSERT" code="6"/>
+		<enum name="HEADER_GROUP" code="7"/>
+		<enum name="QOS_PROFILE" code="8"/>
+	</avp>
+
+	<avp name="Policy-Preload-Status" code="131122" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="INITIATE" code="0"/>
+		<enum name="COMPLETE" code="1"/>
+	</avp>
+
+	<avp name="Charging-Rule-Trigger-Type" code="131123" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="NO_CHARGING_RULE_EVENT_TRIGGERS" code="0"/>
+		<enum name="VOLUME_THRESHOLD" code="1"/>
+		<enum name="TIME_THRESHOLD" code="2"/>
+		<enum name="SVC_FLOW_DETECTION" code="3"/>
+		<enum name="CHARGING_RULE_REMOVE" code="4"/>
+	</avp>
+
+	<avp name="Charging-Rule-Event" code="131124" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Charging-Rule-Name"/>
+			<gavp name="Charging-Rule-Trigger-Type"/>
+			<gavp name="Volume-Usage"/>
+			<gavp name="Cisco-Time-Usage"/>
+			<gavp name="Cisco-Report-Usage"/>
+		</grouped>
+	</avp>
+
+	<avp name="Service-Reporting-Level" code="131125" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="TRANSACTION" code="0"/>
+		<enum name="SERVICE" code="1"/>
+	</avp>
+
+	<avp name="Accounting" code="131126" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Accounting-Customer-String"/>
+		</grouped>
+	</avp>
+
+	<avp name="Accounting-Customer-String" code="131127" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="L7-Parse-Length" code="131128" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Service-CDR-Threshold" code="131129" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="CDR-Volume-Threshold"/>
+			<gavp name="CDR-Time-Threshold"/>
+		</grouped>
+	</avp>
+
+	<avp name="Intermediate-CDR-Threshold" code="131130" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="CDR-Volume-Threshold"/>
+			<gavp name="CDR-Time-Threshold"/>
+		</grouped>
+	</avp>
+
+	<avp name="CDR-Generation-Delay" code="131131" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Replicate-Session" code="131132" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Replicate-Session-Delay"/>
+		</grouped>
+	</avp>
+
+	<avp name="Replicate-Session-Delay" code="131133" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Content-Pending-Timer" code="131134" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Operation-Status" code="131135" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="OUT_OF_SERVICE" code="0"/>
+		<enum name="IN_SERVICE" code="1"/>
+	</avp>
+
+	<avp name="Subscriber-IP-Source" code="131136" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="DEFAULT" code="0"/>
+		<enum name="HTTP_X_FORWARDED_FOR" code="1"/>
+	</avp>
+
+	<avp name="Nexthop" code="131137" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="Nexthop-Reverse" code="131138" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="Charging-Rule-Event-Trigger" code="131139" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Charging-Rule-Trigger-Type"/>
+			<gavp name="Volume-Threshold"/>
+			<gavp name="Time-Threshold"/>
+			<gavp name="Cisco-Report-Usage"/>
+			<gavp name="Volume-Threshold-64"/>
+		</grouped>
+	</avp>
+
+	<avp name="Billing-Plan-Name" code="131140" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Content-Flow-Description" code="131141" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Content-Flow-Filter"/>
+			<gavp name="VRF-Name"/>
+			<gavp name="VLAN-Id"/>
+		</grouped>
+	</avp>
+
+	<avp name="Content-Flow-Filter" code="131142" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Client-Group-Id"/>
+			<gavp name="Destination-IP-Address"/>
+			<gavp name="Destination-Mask"/>
+			<gavp name="Protocol-ID"/>
+			<gavp name="Start-of-Port-Range"/>
+			<gavp name="End-of-Port-Range"/>
+		</grouped>
+	</avp>
+
+	<avp name="Client-Group-Id" code="131143" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="ACL-Number"/>
+			<gavp name="ACL-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="ACL-Number" code="131144" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="ACL-Name" code="131145" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Destination-IP-Address" code="131146" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="Destination-Mask" code="131147" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="Protocol-ID" code="131148" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Start-of-Port-Range" code="131149" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="End-of-Port-Range" code="131150" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Content-Name" code="131151" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Failed-Preload-Object" code="131152" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Policy-Preload-Object-Type"/>
+			<gavp name="Failed-Preload-Obj-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="VRF-Name" code="131153" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="VLAN-Id" code="131154" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Volume-Usage" code="131155" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned64"/>
+	</avp>
+
+	<avp name="Cisco-Time-Usage" code="131156" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Duration"/>
+			<gavp name="First-Packet-Timestanp"/>
+			<gavp name="Last-Packet-Timestanp"/>
+		</grouped>
+	</avp>
+
+	<avp name="Duration" code="131157" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="First-Packet-Timestanp" code="131158" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Last-Packet-Timestanp" code="131159" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Cisco-Flow-Description" code="131160" vendor-id="Cisco" mandatory="must" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Cisco-Flow-Description-507"/>
+			<gavp name="Content-Name"/>
+			<gavp name="Precedence"/>
+			<gavp name="Flow-Information"/>
+		</grouped>
+	</avp>
+
+	<avp name="Terminate-Bearer" code="131161" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Bearer-Identifier"/>
+		</grouped>
+	</avp>
+
+	<avp name="Service-Rating-Group" code="131162" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+
+	<avp name="Content-Scope" code="131163" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="GLOBAL" code="0"/>
+		<enum name="USER" code="1"/>
+	</avp>
+
+	<avp name="Flow-Status-Policy-Mismatch" code="131164" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="FORWARD" code="0"/>
+		<enum name="BLOCK" code="1"/>
+	</avp>
+
+	<avp name="Policy-Map-Type" code="131165" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="URL_MAP" code="0"/>
+		<enum name="HEADER_MAP" code="1"/>
+		<enum name="METHOD_MAP" code="2"/>
+		<enum name="ATTRIBUTE_MAP" code="3"/>
+	</avp>
+
+	<avp name="Policy-Map-Match-Install" code="131166" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Policy-Map-Match"/>
+		</grouped>
+	</avp>
+
+	<avp name="Policy-Map-Match-Remove" code="131167" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Policy-Map-Match"/>
+		</grouped>
+	</avp>
+
+	<avp name="Policy-Map-Replace" code="131168" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="DISABLED" code="0"/>
+		<enum name="ENABLED" code="1"/>
+	</avp>
+
+	<avp name="Cisco-Flow-Status" code="131169" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="FORWARD" code="0"/>
+		<enum name="BLOCK" code="1"/>
+		<enum name="REDIRECT" code="2"/>
+	</avp>
+
+	<avp name="Service-QoS" code="131170" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="QoS-Rate-Limit-UL"/>
+			<gavp name="QoS-Rate-Limit-DL"/>
+		</grouped>
+	</avp>
+
+	<avp name="QoS-Rate-Limit-UL" code="131171" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="QoS-Rate-Limit"/>
+		</grouped>
+	</avp>
+
+	<avp name="QoS-Rate-Limit-DL" code="131172" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="QoS-Rate-Limit"/>
+		</grouped>
+	</avp>
+
+	<avp name="QoS-Rate-Limit" code="131173" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Max-Bandwidth"/>
+			<gavp name="Max-Burst-Size"/>
+			<gavp name="Rate-Limit-Conform-Action"/>
+			<gavp name="Rate-Limit-Exceed-Action"/>
+		</grouped>
+	</avp>
+
+	<avp name="Max-Bandwidth" code="131174" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Rate-Limit-Conform-Action" code="131175" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Cisco-Rate-Limit-Action"/>
+			<gavp name="Cisco-DSCP"/>
+		</grouped>
+	</avp>
+
+	<avp name="Rate-Limit-Exceed-Action" code="131176" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Cisco-Rate-Limit-Action"/>
+			<gavp name="Cisco-DSCP"/>
+		</grouped>
+	</avp>
+
+	<avp name="Cisco-Rate-Limit-Action" code="131177" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="FORWARD" code="0"/>
+		<enum name="DROP" code="1"/>
+		<enum name="MARK_DSCP" code="2"/>
+	</avp>
+
+	<avp name="Cisco-DSCP" code="131178" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Policy-Map-Install" code="131179" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Policy-Map-Definition"/>
+		</grouped>
+	</avp>
+
+	<avp name="Policy-Map-Remove" code="131180" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Policy-Map-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="Billing-Policy-Install" code="131181" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Billing-Policy-Definition"/>
+		</grouped>
+	</avp>
+
+	<avp name="Billing-Policy-Remove" code="131182" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Billing-Policy-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="Content-Install" code="131183" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Content-Definition"/>
+		</grouped>
+	</avp>
+
+	<avp name="Content-Remove" code="131184" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Content-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="Service-Install" code="131185" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Service-Definition"/>
+		</grouped>
+	</avp>
+
+	<avp name="Service-Remove" code="131186" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Service-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="Billing-Plan-Install" code="131187" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Billing-Plan-Definition"/>
+		</grouped>
+	</avp>
+
+	<avp name="Billing-Plan-Remove" code="131188" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Billing-Plan-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="Policy-Preload-Error-Code" code="131189" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="INCONSISTENT_PRELOAD_DATA" code="0"/>
+		<enum name="MANDATORY_AVP_MISSING" code="1"/>
+		<enum name="FAILURE_TO_ENFORCE" code="2"/>
+		<enum name="WRONG_ORDER" code="3"/>
+		<enum name="CONFLICT_WITH_STATIC_CONFIG" code="4"/>
+	</avp>
+
+	<avp name="Max-Burst-Size" code="131190" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Failed-Preload-Obj-Name" code="131191" vendor-id="Cisco" mandatory="must" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Policy-Preload-Error-Code"/>
+			<gavp name="Policy-Map-Name"/>
+			<gavp name="Billing-Policy-Name"/>
+			<gavp name="Content-Name"/>
+			<gavp name="Service-Name"/>
+			<gavp name="Billing-Plan-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="Cisco-Event-Trigger-Type" code="131192" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="NO_Cisco_TRIGGERS" code="0"/>
+		<enum name="TCP_SYN_DETECTION" code="1"/>
+		<enum name="VOLUME_THRESHOLD" code="2"/>
+		<enum name="TIME_THRESHOLD" code="3"/>
+		<enum name="USER_AGENT_DETECTION" code="4"/>
+		<enum name="Volume-Threshold-64" code="5"/>
+	</avp>
+
+	<avp name="Cisco-Event-Trigger" code="131193" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Cisco-Event-Trigger-Type"/>
+			<gavp name="Volume-Threshold"/>
+			<gavp name="Time-Threshold"/>
+			<gavp name="Cisco-Report-Usage"/>
+			<gavp name="Volume-Threshold-64"/>
+		</grouped>
+	</avp>
+
+	<avp name="TCP-SYN" code="131194" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Cisco-Event" code="131195" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Cisco-Event-Trigger-Type"/>
+			<gavp name="TCP-SYN"/>
+			<gavp name="Volume-Usage"/>
+			<gavp name="Cisco-Time-Usage"/>
+			<gavp name="Cisco-Report-Usage"/>
+			<gavp name="User-Agent"/>
+		</grouped>
+	</avp>
+
+	<avp name="Interleaved" code="131196" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="DISABLED" code="0"/>
+		<enum name="ENABLED" code="1"/>
+	</avp>
+
+	<avp name="Control-URL" code="131197" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Interleaved"/>
+		</grouped>
+	</avp>
+
+	<avp name="Relative-URL" code="131198" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="DISABLED" code="0"/>
+		<enum name="ENABLED" code="1"/>
+	</avp>
+
+	<avp name="Mining" code="131199" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="DISABLED" code="0"/>
+		<enum name="ENABLED" code="1"/>
+	</avp>
+
+	<avp name="User-Default" code="131200" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="DISABLED" code="0"/>
+		<enum name="ENABLED" code="1"/>
+	</avp>
+
+	<avp name="Cisco-Priority" code="131201" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Domain-Group-Name" code="131202" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Domain-Group-Definition" code="131203" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Domain-Group-Name"/>
+			<gavp name="Cisco-Priority"/>
+			<gavp name="Match-String"/>
+		</grouped>
+	</avp>
+
+	<avp name="Domain-Group-Install" code="131204" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Domain-Group-Definition"/>
+		</grouped>
+	</avp>
+
+	<avp name="Domain-Group-Remove" code="131205" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Domain-Group-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="Domain-Group-Activation" code="131206" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="DISABLED" code="0"/>
+		<enum name="ENABLED" code="1"/>
+	</avp>
+
+	<avp name="Dual-Billing-Basis" code="131207" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="EVENT" code="1"/>
+		<enum name="IP_BYTE" code="2"/>
+		<enum name="TCP_BYTE" code="3"/>
+		<enum name="DURATION" code="4"/>
+		<enum name="DURATION-CONNECT" code="5"/>
+		<enum name="DURATION-TRANSACTION" code="6"/>
+	</avp>
+
+	<avp name="Dual-Passthrough-Quota" code="131208" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Dual-Reauthorization-Threshold" code="131209" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Virtual-Online" code="131210" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="DISABLED" code="0"/>
+		<enum name="ENABLED" code="1"/>
+	</avp>
+
+	<avp name="Nexthop-Media" code="131211" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="Nexthop-Override" code="131212" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="DISABLED" code="0"/>
+		<enum name="ENABLED" code="1"/>
+	</avp>
+
+	<avp name="Cisco-Quota-Consumption-Time" code="131213" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Class-Map-Name" code="131214" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="Header-Group-Name" code="131215" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="Header-Group-Definition" code="131216" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Header-Group-Name"/>
+			<gavp name="Header-Insert-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="Header-Group-Install" code="131217" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Header-Group-Definition"/>
+		</grouped>
+	</avp>
+
+	<avp name="Header-Group-Remove" code="131218" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Header-Group-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="Header-Insert-Name" code="131219" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="Header-Field-Name" code="131220" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="Header-Class-Name" code="131221" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="Header-Class-Mode" code="131222" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="EXCLUDE" code="0"/>
+		<enum name="INCLUDE" code="1"/>
+	</avp>
+
+	<avp name="Header-Class" code="131223" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Header-Class-Name"/>
+			<gavp name="Header-Class-Mode"/>
+		</grouped>
+	</avp>
+
+	<avp name="Radius-Attribute-Type" code="131224" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Radius-Vsa-Vendor-Id" code="131225" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Radius-Vsa-Subattribute-Type" code="131226" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Header-Item-Radius" code="131227" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Radius-Attribute-Type"/>
+			<gavp name="Radius-Vsa-Vendor-Id"/>
+			<gavp name="Radius-Vsa-Subattribute-Type"/>
+		</grouped>
+	</avp>
+
+	<avp name="Header-Item" code="131228" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="TIMESTAMP" code="0"/>
+		<enum name="QUOTA_SERVER " code="1"/>
+	</avp>
+
+	<avp name="Header-Item-String" code="131229" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="Header-Items-Encrypted" code="131230" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Header-Item"/>
+			<gavp name="Header-Item-String"/>
+			<gavp name="Header-Item-Radius"/>
+		</grouped>
+	</avp>
+
+	<avp name="Header-Insert-Definition" code="131231" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Header-Insert-Name"/>
+			<gavp name="Header-Field-Name"/>
+			<gavp name="Header-Class"/>
+			<gavp name="Header-Items-Encrypted"/>
+			<gavp name="Header-Item-String"/>
+			<gavp name="Header-Item-Radius"/>
+			<gavp name="Header-Item"/>
+		</grouped>
+	</avp>
+
+	<avp name="Header-Insert-Install" code="131232" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Header-Insert-Definition"/>
+		</grouped>
+	</avp>
+
+	<avp name="Header-Insert-Remove" code="131233" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Header-Insert-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="User-Idle-Pod" code="131234" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="DISABLED" code="0"/>
+		<enum name="ENABLED" code="1"/>
+	</avp>
+
+	<avp name="Domain-Group-Clear" code="131235" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="DISABLED" code="0"/>
+		<enum name="ENABLED" code="1"/>
+	</avp>
+
+	<avp name="Cisco-QoS-Profile-Name" code="131236" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="Cisco-QoS-Profile" code="131237" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Cisco-QoS-Profile-Name"/>
+			<gavp name="QoS-Rate-Limit"/>
+		</grouped>
+	</avp>
+
+	<avp name="Cisco-QoS-Profile-Install" code="131238" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Cisco-QoS-Profile"/>
+		</grouped>
+	</avp>
+
+	<avp name="Cisco-QoS-Profile-Remove" code="131239" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Cisco-QoS-Profile"/>
+		</grouped>
+	</avp>
+
+	<avp name="Cisco-QoS-Profile-Uplink" code="131240" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Cisco-QoS-Profile-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="Cisco-QoS-Profile-Downlink" code="131241" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Cisco-QoS-Profile-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="Header-Item-Encryption" code="131242" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="UNENCRYPTED" code="0"/>
+		<enum name="ENCRYPTED" code="1"/>
+	</avp>
+
+	<avp name="Service-Group-Name" code="131243" vendor-id="Cisco" mandatory="mustnot" may-encrypt="yes" protected="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Service-Group-Definition" code="131244" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Service-Group-Name"/>
+			<gavp name="Cisco-Event-Trigger"/>
+			<!-- <gavp name="Cisco-QoS"/> -->
+			<gavp name="Cisco-Flow-Status"/>
+			<gavp name="Redirect-Server"/>
+		</grouped>
+	</avp>
+
+	<avp name="Service-Group-Install" code="131245" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Service-Group-Definition"/>
+		</grouped>
+	</avp>
+
+	<avp name="Service-Group-Remove" code="131246" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Service-Group-Name"/>
+		</grouped>
+	</avp>
+
+	<avp name="Service-Group-Event" code="131247" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Service-Group-Name"/>
+			<gavp name="Cisco-Event"/>
+		</grouped>
+	</avp>
+
+	<avp name="Cisco-Report-Usage" code="131248" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Event-Trigger"/>
+		</grouped>
+	</avp>
+
+	<avp name="Accel" code="131249" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="DISABLE" code="0"/>
+		<enum name="ENABLE" code="1"/>
+	</avp>
+
+
+	<!--********************** START Cisco GX R6 AVPS *****************-->
+	<avp name="Cisco-Answer-User-Usage" code="131250" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Cisco-Request-Usage-Type"/>
+			<gavp name="Volume-Usage"/>
+			<gavp name="Cisco-Time-Usage"/>
+		</grouped>
+	</avp>
+
+	<avp name="Cisco-Request-Usage-Type" code="131251" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="NO_USAGE" code="0"/>
+		<enum name="VOL_USAGE" code="1"/>
+		<enum name="TIME_USAGE" code="2"/>
+	</avp>
+
+	<avp name="Cisco-Request-Charging-Rule-Usage" code="131252" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Charging-Rule-Name"/>
+			<gavp name="Cisco-Request-Usage-Type"/>
+		</grouped>
+	</avp>
+
+	<avp name="Cisco-Request-Service-Group-Usage" code="131253" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Service-Group-Name"/>
+			<gavp name="Cisco-Request-Usage-Type"/>
+		</grouped>
+	</avp>
+
+	<avp name="Cisco-Answer-Charging-Rule-Usage" code="131254" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Charging-Rule-Name"/>
+			<gavp name="Cisco-Request-Usage-Type"/>
+			<gavp name="Volume-Usage"/>
+			<gavp name="Cisco-Time-Usage"/>
+		</grouped>
+	</avp>
+	<avp name="Cisco-Answer-Service-Group-Usage" code="131255" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Service-Group-Name"/>
+			<gavp name="Cisco-Request-Usage-Type"/>
+			<gavp name="Volume-Usage"/>
+			<gavp name="Cisco-Time-Usage"/>
+		</grouped>
+	</avp>
+
+	<avp name="User-Agent" code="131256" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Service-Life-Time" code="131257" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Volume-Threshold-64" code="131258" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned64"/>
+	</avp>
+
+	<avp name="Delegated-IP-Install" code="131259" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Delegated-IPv4-Definition"/>
+			<gavp name="Delegated-IPv6-Definition"/>
+		</grouped>
+	</avp>
+
+	<avp name="Delegated-IPv4-Definition" code="131260" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Framed-IP-Address"/>
+			<gavp name="Framed-IP-Netmask"/>
+			<gavp name="Aggr-Prefix-Len"/>
+		</grouped>
+	</avp>
+
+	<avp name="Delegated-IPv6-Definition" code="131261" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Delegated-IPv6-Prefix"/>
+			<gavp name="Aggr-Prefix-Len"/>
+		</grouped>
+	</avp>
+
+	<avp name="Aggr-Prefix-Len" code="131262" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Service-Identifier-Lo" code="131263" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Service-Identifier-Hi" code="131264" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Service-Identifier-Range" code="131265" vendor-id="Cisco" mandatory="mustnot" protected="mustnot" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Service-Identifier-Lo"/>
+			<gavp name="Service-Identifier-Hi"/>
+		</grouped>
+	</avp>
+	<!-- ********************** END Cisco AVPS ***************** -->
+
+</vendor>

--- a/codec-diameter-codegen/src/main/resources/diameter/CiscoSystems.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/CiscoSystems.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Ref:
+http://www.cisco.com/c/dam/en/us/td/docs/wireless/asr_5000/20/AAA/20-AAA-Reference.pdf
+-->
+
+<vendor vendor-id="CiscoSystems" code="9" name="Cisco">
+  <avp name="DSCP" vendor-id="CiscoSystems" code="131178" >
+    <type type-name="Unsigned32" />
+  </avp>
+
+  <avp name="Rate-Limit-Action" code="131177" vendor-id="CiscoSystems" >
+    <type type-name="Unsigned32"/>
+    <enum name="FORWARD" code="0"></enum>
+    <enum name="DROP" code="1"></enum>
+    <enum name="MARK_DSCP" code="2"></enum>
+  </avp>
+
+  <avp name="QoS-Group-Rule-Install" vendor-id="CiscoSystems" code="132001" >
+    <grouped>
+      <gavp name="QoS-Group-Rule-Definition" />
+    </grouped>
+  </avp>
+
+
+  <avp name="QoS-Group-Rule-Definition" code="132003" vendor-id="CiscoSystems">
+    <grouped>
+      <gavp name="QoS-Group-Rule-Name" />
+      <gavp name="Flow-Status" />
+      <gavp name="QoS-Information" />
+      <gavp name="Redirect-Server" />
+      <gavp name="Monitoring-Key" />
+      <gavp name="Precedence" />
+    </grouped>
+  </avp>
+
+  <avp name="QoS-Group-Rule-Name" vendor-id="CiscoSystems" code="132004" >
+    <type type-name="OctetString" />
+  </avp>
+
+  <avp name="MBR-Limit-Exceed-Action-UL" vendor-id="CiscoSystems" code="132006" >
+    <grouped>
+      <gavp name="Rate-Limit-Action" />
+      <gavp name="DSCP" />
+    </grouped>
+  </avp>
+
+  <avp name="MBR-Limit-Exceed-Action-DL" vendor-id="CiscoSystems" code="132008" >
+    <grouped>
+      <gavp name="Rate-Limit-Action" />
+      <gavp name="DSCP" />
+    </grouped>
+  </avp>
+
+  <avp name="MBR-Burst-Size-UL" vendor-id="CiscoSystems" code="132009" >
+    <type type-name="Unsigned32" />
+  </avp>
+
+  <avp name="MBR-Burst-Size-DL" vendor-id="CiscoSystems" code="132010" >
+    <type type-name="Unsigned32" />
+  </avp>
+
+  <avp name="QoS-Level" code="132011" vendor-id="CiscoSystems" >
+    <type type-name="Unsigned32" />
+    <enum name="SUBSCRIBER_LEVEL" code="1"></enum>
+  </avp>
+
+  <avp name="Override-Control" code="132017" vendor-id="CiscoSystems">
+    <grouped>
+      <gavp name="Override-Control-Name" />
+      <gavp name="Override-Rule-Name" />
+      <gavp name="Override-Charging-Action-Parameters" />
+    </grouped>
+  </avp>
+
+  <avp name="Override-Rule-Name" code="132018" vendor-id="CiscoSystems" >
+    <type type-name="OctetString"/>
+  </avp>
+
+  <avp name="Override-Charging-Action-Parameters" code="132019" vendor-id="CiscoSystems">
+    <grouped>
+      <gavp name="Execution-Time" />
+      <gavp name="Override-Control-Pending-Queue-Action" />
+      <gavp name="Override-Charging-Action-Name" />
+      <gavp name="Override-Charging-Action-Exclude-Rule" />
+      <gavp name="Override-Charging-Parameters" />
+      <!-- Need definition of this before we can include it -->
+      <!--gavp name="Override-Policy-Parameters" /-->
+    </grouped>
+  </avp>
+
+  <avp name="Override-Charging-Action-Name" code="132020" vendor-id="CiscoSystems" >
+    <type type-name="OctetString"/>
+  </avp>
+
+  <avp name="Override-Charging-Action-Exclude-Rule" code="132021" vendor-id="CiscoSystems" >
+    <type type-name="UTF8String"/>
+  </avp>
+
+   <avp name="Override-Charging-Parameters" code="132022" vendor-id="CiscoSystems">
+    <grouped>
+      <gavp name="Override-Service-Identifier" />
+      <gavp name="Override-Rating-Group" />
+      <gavp name="Override-Online" />
+      <gavp name="Override-Offline" />
+    </grouped>
+  </avp>
+
+  <avp name="Override-Service-Identifier" code="132023" vendor-id="CiscoSystems" >
+    <type type-name="Unsigned32"/>
+  </avp>
+
+  <avp name="Override-Rating-Group" code="132024" vendor-id="CiscoSystems" >
+    <type type-name="Unsigned32"/>
+  </avp>
+
+  <avp name="CiscoSystems-Execution-Time" code="132025" vendor-id="CiscoSystems" >
+    <type type-name="OctetString"></type>
+  </avp>
+
+  <avp name="Override-Online" code="132026" vendor-id="CiscoSystems" >
+  <type type-name="Enumerated"/>
+    <enum name="Disable-Online" code="0"/>
+    <enum name="Enable-Online" code="1"/>
+  </avp>
+
+  <avp name="Override-Offline" code="132027" vendor-id="CiscoSystems" >
+  <type type-name="Enumerated"/>
+    <enum name="Disable-Offline" code="0"/>
+    <enum name="Enable-Offline" code="1"/>
+  </avp>
+
+  <avp name="Override-Control-Name" code="132052" vendor-id="CiscoSystems" >
+    <type type-name="OctetString" />
+  </avp>
+
+  <avp name="Override-Control-Pending-Queue-Action" code="132078" vendor-id="CiscoSystems" >
+  <type type-name="Enumerated"/>
+    <enum name="Flush" code="0"/>
+    <enum name="Retain" code="1"/>
+  </avp>
+
+</vendor>

--- a/codec-diameter-codegen/src/main/resources/diameter/Custom.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/Custom.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+    <!-- Any files added here need to be added to Custom.make and
+	 packaging/nsis/custom_diameter_xmls.txt if you want them to be distributed
+    -->
+
+    <!-- create entities like this:
+	<!ENTITY myEntity		SYSTEM "myFile.xml">
+    -->
+
+    <!-- and then add the entity here:
+	&myEntity;
+    -->

--- a/codec-diameter-codegen/src/main/resources/diameter/Ericsson.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/Ericsson.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<application id="16777227"	name="Ericsson MSI"			uri="none"/>
+<application id="16777228"	name="Ericsson Zx"			uri="none"/>
+<application id="16777232"	name="Ericsson Charging-CIP"		uri="none"/>
+<application id="16777233"	name="Ericsson Mm"			uri="none"/>
+<application id="16777269"	name="Ericsson HSI"			uri="none"/>
+<application id="16777301"	name="Ericsson Charging-DCIP"		uri="none"/>
+<application id="16777304"	name="Ericsson Sy"			uri="none"/>
+<application id="16777315"	name="Ericsson Diameter Signalling Controller Application (DSC)" uri="none"/>
+<application id="16777327"	name="Ericsson Sx"			uri="none"/>
+
+<vendor vendor-id="Ericsson" code="193" name="Ericsson">
+<!-- *********** Last updated 2007-04-12 ************ -->
+	<avp name="Acc-Service-Type" code="261" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+	   <type type-name="Enumerated"/>
+		<enum name="Audio Conference" code="0"/>
+		<enum name="Video Conference" code="1"/>
+	</avp>
+	<avp name="Rule-Space-Suggestion" code="290" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Rule-Space-Decision" code="291" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Bearer-Control-Options" code="292" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<!-- ************************** SCAP AVPS, see 155 19-FAY 112 51/2 rev B ********************* -->
+	<avp name="SCAP-Currency-Code" code="544" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+	    <type type-name="Unsigned32"/>
+	</avp>
+	<avp name="SCAP-Subscription-Id" code="553" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<grouped>
+			<gavp name="SCAP-Subscription-Id-Data"/>
+			<gavp name="SCAP-Subscription-Id-Type"/>
+		</grouped>
+	</avp>
+	<avp name="SCAP-Subscription-Id-Data" code="554" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="SCAP-Subscription-Id-Type" code="555" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="End User MSISDN" code="0"/>
+		<enum name="End User IMSI" code="1"/>
+		<enum name="End User SIP URL" code="2"/>
+		<enum name="End User NAI" code="3"/>
+		<enum name="End User PRIVATE (operator defined)" code="4"/>
+	</avp>
+	<avp name="Original-Subscription-Id" code="559" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<grouped>
+			<gavp name="SCAP-Subscription-Id-Data"/>
+			<gavp name="SCAP-Subscription-Id-Type"/>
+		</grouped>
+	</avp>
+
+	<avp name="Abnormal-Termination-Reason" code="600" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="Service Element Termination" code="0"/>
+		<enum name="Connection to User Broken" code="1"/>
+	</avp>
+	<avp name="SCAP-Final-Unit-Indication" code="601" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="SCAP-Granted-Service-Unit" code="602" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<grouped>
+			<gavp name="SCAP-Unit-Type"/>
+			<gavp name="SCAP-Unit-Value"/>
+			<gavp name="SCAP-Currency-Code"/>
+		</grouped>
+	</avp>
+	<avp name="Cost" code="603" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<type type-name="Float64"/>
+	</avp>
+	<avp name="SCAP-Cost-Information" code="604" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<grouped>
+			<gavp name="Cost"/>
+			<gavp name="SCAP-Currency-Code"/>
+		</grouped>
+	</avp>
+	<avp name="Accounting-Correlation-Id" code="605" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SCAP-Requested-Service-Unit" code="606" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<grouped>
+			<gavp name="SCAP-Unit-Type"/>
+			<gavp name="SCAP-Unit-Value"/>
+			<gavp name="SCAP-Currency-Code"/>
+		</grouped>
+	</avp>
+	<avp name="SCAP-Service-Parameter-Info" code="607" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<grouped>
+			<gavp name="SCAP-Service-Parameter-Type"/>
+			<gavp name="SCAP-Service-Parameter-Value"/>
+		</grouped>
+	</avp>
+	<avp name="SCAP-Service-Parameter-Type" code="608" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<!-- CCN Specific Interpretation, see 1553-HSD 108 06/1 rev A -->
+		<enum name="Service Provider Id (CCN)" code="0"/>
+		<enum name="Extension Number 1 (CCN)" code="1"/>
+		<enum name="Extension Number 2 (CCN)" code="2"/>
+		<enum name="Extension Number 3 (CCN)" code="3"/>
+		<enum name="Extension Number 4 (CCN)" code="4"/>
+		<enum name="Extension Text (CCN)" code="5"/>
+		<enum name="GPRS Quality of Service (CCN)" code="6"/>
+		<enum name="Redirecting Party Number (CCN)" code="7"/>
+		<enum name="Originating Location Information (CCN)" code="8"/>
+		<enum name="Terminating Location Information (CCN)" code="9"/>
+		<enum name="Region Charging Origin (CCN)" code="10"/>
+		<enum name="Subscription Type (CCN)" code="11"/>
+		<enum name="SMS Delivery Status (CCN)" code="12"/>
+		<enum name="Time Zone (CCN)" code="13"/>
+		<enum name="Traffic Case (CCN)" code="14"/>
+		<enum name="Dedicated Account Id (CCN)" code="15"/>
+		<enum name="Calling Party Number (CCN)" code="16"/>
+		<enum name="Called Party Number (CCN)" code="17"/>
+		<enum name="Tele Service Code (CCN)" code="18"/>
+		<enum name="Service Key (CCN)" code="19"/>
+	</avp>
+	<avp name="SCAP-Service-Parameter-Value" code="609" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="SCAP-Event-Timestamp" code="610" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<type type-name="Time"/>
+	</avp>
+	<avp name="SCAP-Unit-Type" code="611" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="Service Credit Time (seconds)" code="0"/>
+		<enum name="Service Credit Volume (bytes)" code="1"/>
+		<enum name="Service Credit Events (number of events)" code="2"/>
+		<enum name="Serivce Credit Money (monetary value)" code="3"/>
+	</avp>
+	<avp name="SCAP-Unit-Value" code="612" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<grouped>
+			<gavp name="SCAP-Value-Digits"/>
+			<gavp name="SCAP-Exponent"/>
+		</grouped>
+	</avp>
+	<avp name="SCAP-Used-Service-Unit" code="613" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<grouped>
+			<gavp name="SCAP-Unit-Type"/>
+			<gavp name="SCAP-Unit-Value"/>
+			<gavp name="SCAP-Currency-Code"/>
+		</grouped>
+	</avp>
+	<avp name="SCAP-Check-Balance-Result" code="614" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="Enough Credit" code="0"/>
+		<enum name="No Credit" code="1"/>
+	</avp>
+	<avp name="SCAP-Requested-Action" code="615" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="Direct Debiting" code="0"/>
+		<enum name="Refund Account" code="1"/>
+		<enum name="Check Balance" code="2"/>
+		<enum name="Price Enquiry" code="3"/>
+	</avp>
+	<avp name="SCAP-Exponent" code="616" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<type type-name="Integer32"/>
+	</avp>
+	<avp name="SCAP-Value-Digits" code="617" mandatory="must" vendor-bit="must" vendor-id="Ericsson" protected="may" may-encrypt="yes">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<!-- ************************ END SCAP AVPS ******************* -->
+
+
+	<avp name="Charging-Rule-Authorization" code="1055" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<grouped>
+			<gavp name="Authorization-State"/>
+			<gavp name="Authorization-State-Change-Time"/>
+			<gavp name="Next-Authorization-State"/>
+		</grouped>
+	</avp>
+	<avp name="Authorization-State" code="1056" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="Authorized" code="0"/>
+		<enum name="Unauthorized due to calendar time" code="1"/>
+		<enum name="Unauthorized due to roaming" code="2"/>
+		<enum name="Unauthorized due to QoS" code="3"/>
+		<enum name="Unauthorized due to blacklisting" code="4"/>
+		<enum name="Unauthorized due to terminal limitations" code="5"/>
+		<enum name="Unauthorized due to user defined reason 1" code="6"/>
+		<enum name="Unauthorized due to user defined reason 2" code="7"/>
+		<enum name="Unauthorized due to user defined reason 3" code="8"/>
+		<enum name="Unauthorized due to user defined reason 4" code="9"/>
+		<enum name="Unauthorized due to user defined reason 5" code="10"/>
+		<enum name="Unauthorized due to unknown reason" code="11"/>
+		<enum name="Unauthorized due to Usage Reporting over Gx" code="12"/>
+	</avp>
+	<avp name="Authorization-State-Change-Time" code="1057" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Next-Authorization-State" code="1059" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="Authorized" code="0"/>
+		<enum name="Unauthorized due to calendar time" code="1"/>
+	</avp>
+	<avp name="Gx-Capability-List" code="1060" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Result-Code-Extension" code="1067" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Subscription-Id-Location" code="1074" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Other-Party-Id" code="1075" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<grouped>
+			<gavp name="Other-Party-Id-Nature"/>
+			<gavp name="Other-Party-Id-Data"/>
+			<gavp name="Other-Party-Id-Type"/>
+		</grouped>
+	</avp>
+	<avp name="Other-Party-Id-Nature" code="1076" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="UNKNOWN" code="0"/>
+		<enum name="INTERNATIONAL" code="1"/>
+		<enum name="NATIONAL" code="2"/>
+	</avp>
+	<avp name="Other-Party-Id-Data" code="1077" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Other-Party-Id-Type" code="1078" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="END_USER_MSISDN" code="0"/>
+		<enum name="END_USER_IMSI" code="1"/>
+		<enum name="END_USER_SIP_URL" code="2"/>
+		<enum name="END_USER_NAI" code="3"/>
+		<enum name="END_USER_PRIVATE" code="4"/>
+	</avp>
+	<avp name="Ericsson-Customer-Id" code="1146" mandatory="must" vendor-bit="must" vendor-id="Ericsson" may-encrypt="no" protected="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+</vendor>

--- a/codec-diameter-codegen/src/main/resources/diameter/HP.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/HP.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vendor vendor-id="HP"				code="11"	name="Hewlett Packard"/>
+
+<application id="16777305" name="HP Diameter Topology Discovery" uri="none">
+	<command name="Peer Information"	code="100" vendor-id="HP"/>
+	<command name="Fetch Peers"		code="101" vendor-id="HP"/>
+	<command name="Subscribe Change"	code="102" vendor-id="HP"/>
+	<command name="Notify Change"		code="103" vendor-id="HP"/>
+
+	<avp name="Peer-State" code="200"  vendor-id="HP" mandatory="must" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="Down" code="0"/>
+		<enum name="Up" code="1"/>
+	</avp>
+	<avp name="Peer-Name" code="201"  vendor-id="HP" mandatory="must" vendor-bit="must">
+		<type type-name="DiameterIdentity"/>
+	</avp>
+
+	<avp name="Peer-Identity" code="202"  vendor-id="HP" mandatory="must" vendor-bit="must">
+		<type type-name="DiameterIdentity"/>
+	</avp>
+	<avp name="Peer-State-Change" code="203" vendor-id="HP" mandatory="must" vendor-bit="must">
+		<grouped>
+			<gavp name="Peer-Name"/>
+			<gavp name="Peer-Identity"/>
+			<gavp name="Peer-State"/>
+		</grouped>
+	</avp>
+	<avp name="More-Peers" code="204" vendor-id="HP" mandatory="must" vendor-bit="must">
+		<grouped>
+			<gavp name="Peer-Name"/>
+			<gavp name="Peer-Identity"/>
+			<gavp name="Peer-State"/>
+			<gavp name="Peer-State-Change"/>
+		</grouped>
+	</avp>
+	<avp name="Peer-Type" code="205"  vendor-id="HP" mandatory="must" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="Client" code="0"/>
+		<enum name="Server" code="1"/>
+		<enum name="ClientAndServer" code="2"/>
+		<enum name="Proxy" code="3"/>
+	</avp>
+</application>

--- a/codec-diameter-codegen/src/main/resources/diameter/Huawei.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/Huawei.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vendor vendor-id="Huawei"                    code="2011"      name="Huawei">
+  <avp name="P2PSMS-Information" code="20400" mandatory="mustnot" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="Huawei">
+    <grouped>
+      <gavp name="SMSC-Address-Huawei"/>
+      <gavp name="SM-Id"/>
+      <gavp name="SM-Length"/>
+    </grouped>
+  </avp>
+  <avp name="SMSC-Address-Huawei" code="20401" mandatory="mustnot" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="Huawei">
+    <type type-name="UTF8String"/>
+  </avp>
+  <avp name="SM-Id" code="20402" mandatory="mustnot" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="Huawei">
+    <type type-name="UTF8String"/>
+  </avp>
+  <avp name="SM-Length" code="20403" mandatory="mustnot" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="Huawei">
+    <type type-name="Unsigned32"/>
+  </avp>
+  <avp name="MO-MSC-Address" code="20404" mandatory="mustnot" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="Huawei">
+    <type type-name="UTF8String"/>
+  </avp>
+  <avp name="MT-MSC-Address" code="20405" mandatory="mustnot" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="Huawei">
+    <type type-name="UTF8String"/>
+  </avp>
+  <avp name="Source-Addr" code="20406" mandatory="mustnot" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="Huawei">
+    <type type-name="UTF8String"/>
+  </avp>
+  <avp name="Dest-Addr" code="20407" mandatory="mustnot" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="Huawei">
+    <type type-name="UTF8String"/>
+  </avp>
+  <avp name="Fee-Flag" code="20409" mandatory="mustnot" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="Huawei">
+    <type type-name="Enumerated"/>
+    <enum name="Charge in the original mode" code="0"/>
+    <enum name="Charge the calling number" code="1"/>
+    <enum name="Charge the called number" code="2"/>
+    <enum name="Charge the charging number" code="3"/>
+  </avp>
+  <avp name="Fee-Type" code="20410" mandatory="mustnot" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="Huawei">
+    <type type-name="Enumerated"/>
+    <enum name="Charge by default mode" code="0"/>
+    <enum name="Charge by item" code="1"/>
+    <enum name="Charge by month (with authentication and fee deduction)" code="2"/>
+    <enum name="Charge by month (with authentication but no fee deduction)" code="3"/>
+    <enum name="Charge upper limit amount by the number of SMs" code="4"/>
+    <enum name="Charge by month with limited number of SMs (with authentication and fee deduction)" code="5"/>
+    <enum name="Charge by month with limited number of SMs (with authentication but no fee deduction)" code="6"/>
+  </avp>
+  <avp name="Status-Report-Requested" code="20415" mandatory="mustnot" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="Huawei">
+    <type type-name="Enumerated"/>
+    <enum name="No" code="0"/>
+    <enum name="Yes" code="1"/>
+    <enum name="Refund on Failure" code="2"/>
+  </avp>
+  <avp name="Send-Result" code="20418" mandatory="mustnot" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="Huawei">
+    <type type-name="Enumerated"/>
+    <enum name="Delivered" code="0"/>
+  </avp>
+</vendor>

--- a/codec-diameter-codegen/src/main/resources/diameter/Inovar.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/Inovar.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vendor vendor-id="Inovar"			code="41897"	name="Inovar">
+	<avp name="Inovar-Forward-To-Party" code="4001" mandatory="must" vendor-bit="must" vendor-id="Inovar">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Inovar-App-Code" code="4002" mandatory="must" vendor-bit="must" vendor-id="Inovar">
+		<type type-name="Enumerated"/>
+		<enum name="=MY5"					code="1"/>
+		<enum name="=Virtual Caller ID (VCID)"			code="2"/>
+	</avp>
+	<avp name="Inovar-Service-Code" code="4003" mandatory="must" vendor-bit="must" vendor-id="Inovar">
+		<type type-name="Enumerated"/>
+		<enum name="=UE Registration Notification/Buddy List Lookup"	code="1"/>
+		<enum name="=Unsuccessful Call Setup Notification"		code="2"/>
+	</avp>
+	<avp name="Inovar-Service-ID" code="4004" mandatory="must" vendor-bit="must" vendor-id="Inovar">
+		<grouped>
+			<gavp name="Inovar-App-Code"/>
+			<gavp name="Inovar-Service-Code"/>
+		</grouped>
+	</avp>
+	<avp name="Inovar-Unsuccessful-Call-Reason" code="4005" mandatory="must" vendor-bit="must" vendor-id="Inovar">
+		<grouped>
+			<gavp name="Inovar-SIP-Response-Code"/>
+			<gavp name="Inovar-ISUP-Cause"/>
+			<gavp name="Inovar-Supplementary-Service-Id"/>
+		</grouped>
+	</avp>
+	<avp name="Inovar-SIP-Response-Code" code="4006" mandatory="must" vendor-bit="must" vendor-id="Inovar">
+		<type type-name="Integer32"/>
+	</avp>
+	<avp name="Inovar-ISUP-Cause" code="4007" mandatory="must" vendor-bit="must" vendor-id="Inovar">
+		<type type-name="Integer32"/>
+	</avp>
+	<avp name="Inovar-Supplementary-Service-Id" code="4008" mandatory="must" vendor-bit="must" vendor-id="Inovar">
+		<type type-name="Integer32"/>
+	</avp>
+	<avp name="Inovar-PS-Registration-Status" code="4009" mandatory="must" vendor-bit="must" vendor-id="Inovar">
+		<type type-name="Enumerated"/>
+		<enum name="=Subscriber is Not Registered in PS Domain"		code="0"/>
+		<enum name="=Subscriber is Registered in PS Domain"		code="1"/>
+	</avp>
+	<avp name="Inovar-Service-Result" code="4010" mandatory="must" vendor-bit="must" vendor-id="Inovar">
+		<type type-name="Enumerated"/>
+		<enum name="=MY5 Buddy List match found"      								code="1001"/>
+		<enum name="=MY5 internal failure"        								code="1002"/>
+		<enum name="=MY5 Subs not found"        								code="1003"/>
+		<enum name="=MY5 Subs Buddy List not configured"        						code="1004"/>
+		<enum name="=MY5 Subs Buddy List cfg not enabled"        						code="1005"/>
+		<enum name="=MY5 Subs Buddy List cfg enabled, but no match found 4 the Other Party Number"        	code="1006"/>
+		<enum name="=VCID success"        									code="2001"/>
+		<enum name="=VCID internal failure"        								code="2002"/>
+		<enum name="=VCID Subscriber not found"        								code="2003"/>
+	</avp>
+	<avp name="Inovar-Calling-Party-Info" code="4011" mandatory="must" vendor-bit="must" vendor-id="Inovar">
+		<grouped>
+			<gavp name="Calling-Party-Address"/>
+			<!--
+			Missing information from vendor how to present this AVP
+			<gavp name="Calling-Party-Address-Presentation-Status"/>
+			-->
+		</grouped>
+	</avp>
+</vendor>

--- a/codec-diameter-codegen/src/main/resources/diameter/Juniper.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/Juniper.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vendor vendor-id="Juniper"                    code="2636"      name="Juniper">
+<!-- *********** Last updated 2016-04-14 ************ -->
+	<avp name="TDF-Application-Instance-Identifier-Base" code="1100" vendor-bit="must" vendor-id="Juniper">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Service-Chaining-Information" code="1101" vendor-bit="must" vendor-id="Juniper">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="LRF-Profile-Name" code="1102" vendor-bit="must" vendor-id="Juniper">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="HCM-Profile-Name" code="1103" vendor-bit="must" vendor-id="Juniper">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Forwarding-Class-Name" code="1104" vendor-bit="must" vendor-id="Juniper">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Redirect-VRF" code="1105" vendor-bit="must" vendor-id="Juniper">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Requested-Burstsize-UL" code="1106" vendor-bit="must" vendor-id="Juniper">
+		<type type-name="Integer32"/>
+	</avp>
+	<avp name="Requested-Burstsize-DL" code="1107" vendor-bit="must" vendor-id="Juniper">
+		<type type-name="Integer32"/>
+	</avp>
+	<avp name="Steering-Information" code="1108" vendor-bit="must" vendor-id="Juniper">
+		<grouped>
+			<gavp name="Steering-Uplink-VRF"/>
+			<gavp name="Steering-Downlink-VRF"/>
+			<gavp name="Steering-IP-Address"/>
+		</grouped>
+	</avp>
+	<avp name="Steering-Uplink-VRF" code="1109" vendor-bit="must" vendor-id="Juniper">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Steering-Downlink-VRF" code="1110" vendor-bit="must" vendor-id="Juniper">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Steering-IP-Address" code="1111" vendor-bit="must" vendor-id="Juniper">
+		<type type-name="IPAddress"/>
+	</avp>
+</vendor>

--- a/codec-diameter-codegen/src/main/resources/diameter/Nokia.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/Nokia.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Nokia vendor-specific AVPs. Simple encoding, by old (oleksandr.darchuk[AT]gmail.com). 02.03.2009 -->
+
+<application id="16777328"	name="Nokia Service Extension, NSE"	uri="none"/>
+<application id="16777341"	name="Nokia Sdr"			uri="none"/>
+
+<vendor vendor-id="Nokia"			code="94"	name="Nokia">
+
+	<avp name="Nokia-IMS-Media-Component-Id" code="5101" vendor-id="Nokia">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Nokia-Time-Of-First-Usage" code="5103" vendor-id="Nokia">
+		<type type-name="Time"/>
+	</avp>
+
+	<avp name="Nokia-Time-Of-Last-Usage" code="5104" vendor-id="Nokia">
+		<type type-name="Time"/>
+	</avp>
+
+	<avp name="Nokia-Session-Start-Indicator" code="5105" vendor-id="Nokia">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Nokia-Rulebase-Id" code="5106" vendor-id="Nokia">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="Nokia-Quota-Consumption-Time" code="5109" vendor-id="Nokia">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Nokia-Quota-Holding-Time" code="5110" vendor-id="Nokia">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Default-Quota" code="5111" vendor-id="Nokia">
+		<grouped>
+			<gavp name="CC-Time"/>
+			<gavp name="CC-Total-Octets"/>
+			<gavp name="CC-Input-Octets"/>
+			<gavp name="CC-Output-Octets"/>
+			<gavp name="CC-Service-Specific-Units"/>
+		</grouped>
+	</avp>
+
+	<avp name="Nokia-URI" code="5112" vendor-id="Nokia">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="NSN-Token-Value" code="5113" vendor-id="Nokia">
+		<type type-name="OctetString"/>
+	</avp>
+
+</vendor>

--- a/codec-diameter-codegen/src/main/resources/diameter/NokiaSolutionsAndNetworks.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/NokiaSolutionsAndNetworks.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- Nokia Solutions and Networks vendor-specific AVPs.  -->
+
+<application id="16777317" name="Nokia Solutions and Networks (NSN) Hd Application" uri="none">
+
+  <avp name="User-Agent-Type" code="2016" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="NokiaSolutionsAndNetworks">
+    <type type-name="Enumerated"/>
+    <enum name="NON_MOBILE_BROWSER" code="0"/>
+    <enum name="MOBILE_BROWSER"     code="1"/>
+  </avp>
+</application>
+
+<application id="16777246"	name="NSN Unified Charging Trigger Function (UCTF)" uri="none"/>
+
+<vendor vendor-id="NokiaSolutionsAndNetworks"	code="28458"	name="Nokia Solutions and Networks">
+
+  <avp name="NSN-IN-Information" code="100" mandatory="must" vendor-bit="must" vendor-id="NokiaSolutionsAndNetworks">
+    <grouped>
+      <!-- <gavp name="NSN-Calling-Partys-Category"/> -->
+      <!-- <gavp name="NSN-High-Layer-Compatibility"/> -->
+      <!-- <gavp name="NSN-VLR-Number"/> -->
+      <!-- <gavp name="NSN-Answer-Time-Stamp"/> -->
+      <!-- <gavp name="NSN-Time-Zone"/> -->
+      <!-- <gavp name="NSN-Redirecting-Party-Id"/> -->
+      <!-- <gavp name="NSN-Generic-Service-Data"/> -->
+      <!-- <gavp name="NSN-Roaming-Indication"/> -->
+      <!-- <gavp name="NSN-IN-Bearer-Service"/> -->
+      <!-- <gavp name="NSN-NP-Information"/> -->
+      <!-- <gavp name="NSN-Connection-Type"/> -->
+      <!-- <gavp name="NSN-A-Party-Member-Type"/> -->
+      <!-- <gavp name="NSN-B-Party-Member-Type"/> -->
+      <!-- <gavp name="NSN-Access-Type"/> -->
+      <!-- <gavp name="NSN-AoC-Tariff"/> -->
+      <!-- <gavp name="NSN-Account-Information"/> -->
+      <!-- <gavp name="NSN-Subscriber-Status"/> -->
+      <!-- <gavp name="NSN-Message-Warning-Time"/> -->
+      <!-- <gavp name="NSN-Language-ID"/> -->
+      <gavp name="Currency-Code"/>
+      <!-- <gavp name="NSN-Customer-Group-ID"/> -->
+      <!-- <gavp name="NSN-GSM-Charge-Advice-Information"/> -->
+      <!-- <gavp name="NSN-Method-Name"/> -->
+      <!-- <gavp name="NSN-Reference-Number"/> -->
+      <!-- <gavp name="NSN-Inband-Announcement"/> -->
+      <!-- <gavp name="NSN-Outband-Information"/> -->
+      <gavp name="NSN-Account-Location-Id"/>
+    </grouped>
+  </avp>
+
+  <avp name="NSN-Account-Location-Id" code="223" mandatory="must" vendor-bit="must" vendor-id="NokiaSolutionsAndNetworks">
+    <type type-name="UTF8String"/>
+  </avp>
+
+  <avp name="Account-State" code="60528" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="NokiaSolutionsAndNetworks">
+        <type type-name="UTF8String" />
+    </avp>
+
+    <avp name="Subscriber-Specific-Info" code="60530" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="NokiaSolutionsAndNetworks">
+        <grouped>
+            <gavp name="Account-State" />
+            <gavp name="Active-Product-Offer" />
+            <gavp name="Billing-Account" />
+        </grouped>
+    </avp>
+
+    <avp name="Offer-Name" code="60551" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="NokiaSolutionsAndNetworks">
+        <type type-name="UTF8String" />
+    </avp>
+
+    <avp name="Version" code="60552" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="NokiaSolutionsAndNetworks">
+        <type type-name="UTF8String" />
+    </avp>
+
+    <avp name="Active-Product-Offer" code="60553" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="NokiaSolutionsAndNetworks">
+        <grouped>
+            <gavp name="Offer-Name" />
+            <gavp name="Version" />
+            <gavp name="Expiry-Date" />
+        </grouped>
+    </avp>
+
+    <avp name="Expiry-Date" code="60554" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="NokiaSolutionsAndNetworks">
+        <type type-name="Time" />
+    </avp>
+
+    <avp name="Billing-Account" code="60557" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="NokiaSolutionsAndNetworks">
+        <grouped>
+            <gavp name="Billing-Account-Number" />
+            <gavp name="Account-Type" />
+            <gavp name="Account-Subtype" />
+        </grouped>
+    </avp>
+
+    <avp name="Billing-Account-Number" code="60558" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="NokiaSolutionsAndNetworks">
+        <type type-name="Integer32" />
+    </avp>
+
+    <avp name="Account-Type" code="60559" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="NokiaSolutionsAndNetworks">
+        <type type-name="UTF8String" />
+    </avp>
+
+    <avp name="Account-Subtype" code="60560" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="NokiaSolutionsAndNetworks">
+        <type type-name="UTF8String" />
+    </avp>
+
+</vendor>

--- a/codec-diameter-codegen/src/main/resources/diameter/Oracle.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/Oracle.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vendor vendor-id="OracleTekelec" code="323" name="Oracle Tekelec">
+	<avp name="DSR-ApplicationInvoked" code="2468" vendor-bit="must" vendor-id="OracleTekelec">
+		<type type-name="Enumerated"/>
+		<enum name="RBAR ID"		code="3"/>
+		<enum name="FABR ID"		code="4"/>
+		<enum name="CPA ID"		code="5"/>
+		<enum name="Policy DRA ID"	code="6"/>
+	</avp>
+	<avp name="PDRA-Early-Binding" code="2500" vendor-bit="must" vendor-id="OracleTekelec">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Session-Release-Reason" code="2501" vendor-bit="must" vendor-id="OracleTekelec">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MsgCopyAnswer" code="2516" vendor-bit="must" vendor-id="OracleTekelec">
+		<grouped>
+			<gavp name="Session-Id"/>
+			<!-- This grouped AVP holds any AVP -->
+		</grouped>
+	</avp>
+</vendor>

--- a/codec-diameter-codegen/src/main/resources/diameter/README.md
+++ b/codec-diameter-codegen/src/main/resources/diameter/README.md
@@ -1,0 +1,1 @@
+The files within this directory are copies from Wireshark https://github.com/wireshark/wireshark/tree/master/diameter.

--- a/codec-diameter-codegen/src/main/resources/diameter/Starent.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/Starent.xml
@@ -1,0 +1,2225 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Cisco ASR 5x00 AAA Interface Administration and Reference, Version 14.0 -->
+
+<vendor vendor-id="Starent"			code="8164"	name="Starent">
+
+	<avp name="Access-Network-Charging-Physical-Access-Id" code="1472" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Access-Network-Charging-Physical-Access-Id-Value"/>
+			<gavp name="Access-Network-Charging-Physical-Access-Id-Realm"/>
+		</grouped>
+	</avp>
+
+	<avp name="Access-Network-Charging-Physical-Access-Id-Realm" code="1474" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Access-Network-Charging-Physical-Access-Id-Value" code="1473" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Customer-Id" code="1146" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Absolute-Validity-Time" code="505" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Time"/>
+	</avp>
+
+	<avp name="SN-Bandwidth-Control" code="512" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="HIGH" code="0"/>
+		<enum name="LOW" code="1"/>
+	</avp>
+
+	<avp name="SN-CF-Policy-ID" code="529" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Charging-Collection-Function-Name" code="530" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Charging-Id" code="525" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Fast-Reauth-Username-11010" code="11010" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Firewall-Policy-515" code="515" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Monitoring-Key" code="518" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Phase0-PSAPName" code="523" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Pseudonym-Username-11011" code="11011" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Remaining-Service-Unit" code="526" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Tariff-Change-Usage"/>
+			<gavp name="CC-Time"/>
+			<gavp name="CC-Total-Octets"/>
+			<gavp name="CC-Input-Octets"/>
+			<gavp name="CC-Output-Octets"/>
+			<gavp name="CC-Service-Specific-Units"/>
+			<gavp name="3GPP-Reporting-Reason"/>
+		</grouped>
+	</avp>
+
+	<avp name="SN-Rulebase-Id" code="528" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Service-Flow-Detection" code="520" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="ENABLE_DETECTION" code="0"/>
+	</avp>
+
+	<avp name="SN-Service-Start-Timestamp" code="527" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Time"/>
+	</avp>
+
+	<avp name="SN-Time-Quota-Threshold" code="503" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Total-Used-Service-Unit" code="504" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="Tariff-Change-Usage"/>
+			<gavp name="CC-Time"/>
+			<gavp name="CC-Total-Octets"/>
+			<gavp name="CC-Input-Octets"/>
+			<gavp name="CC-Output-Octets"/>
+			<gavp name="CC-Service-Specific-Units"/>
+			<gavp name="3GPP-Reporting-Reason"/>
+		</grouped>
+	</avp>
+
+	<avp name="SN-Traffic-Policy" code="514" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Transparent-Data" code="513" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Unit-Quota-Threshold" code="502" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Usage-Monitoring" code="521" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="USAGE_MONITORING_DISABLED" code="0"/>
+		<enum name="USAGE_MONITORING_ENABLED" code="1"/>
+	</avp>
+
+	<avp name="SN-Usage-Monitoring-Control" code="517" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<grouped>
+			<gavp name="SN-Monitoring-Key"/>
+			<gavp name="SN-Usage-Monitoring"/>
+			<gavp name="SN-Usage-Volume"/>
+		</grouped>
+	</avp>
+
+	<avp name="SN-Usage-Volume" code="519" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned64"/>
+	</avp>
+
+	<avp name="SN-Volume-Quota-Threshold" code="501" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Session-Start-Indicator" code="522" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Starent-Subscriber-Permission" code="20" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="None" code="0"/>
+		<enum name="Simple-IP" code="1"/>
+		<enum name="Mobile-IP" code="2"/>
+		<enum name="Simple-IP-Mobile-IP" code="3"/>
+		<enum name="HA-Mobile-IP" code="4"/>
+		<enum name="Simple-IP-HA-Mobile-IP" code="5"/>
+		<enum name="Mobile-IP-HA-Mobile-IP" code="6"/>
+		<enum name="SIP-MIP-HA-MIP" code="7"/>
+		<enum name="GGSN-PDP-TYPE-IP" code="8"/>
+		<enum name="GGSN-PDP-TYPE-PPP" code="16"/>
+		<enum name="Network-Mobility" code="32"/>
+		<enum name="FA-HA-NEMO" code="38"/>
+		<enum name="All" code="63"/>
+	</avp>
+
+	<avp name="Prohibit-Payload-Compression" code="237" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="Allowed" code="0"/>
+		<enum name="Prohibited" code="1"/>
+	</avp>
+
+	<avp name="SN-Access-link-IP-Frag" code="63" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="Normal" code="0"/>
+		<enum name="DF-Ignore" code="1"/>
+		<enum name="DF-Fragment-ICMP-Notify" code="2"/>
+	</avp>
+
+	<avp name="SN-Acct-Input-Giga-Dropped" code="230" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Acct-Input-Octets-Dropped" code="228" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Acct-Input-Packets-Dropped" code="226" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Acct-Output-Giga-Dropped" code="231" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Acct-Output-Octets-Dropped" code="229" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Acct-Output-Packets-Dropped" code="227" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Acs-Credit-Control-Group" code="301" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Admin-Expiry" code="204" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Integer32"/>
+	</avp>
+
+	<avp name="SN-Admin-Permission" code="21" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="None" code="0"/>
+		<enum name="CLI" code="1"/>
+		<enum name="FTP" code="2"/>
+		<enum name="CLI-FTP" code="3"/>
+		<enum name="Intercept" code="4"/>
+		<enum name="CLI-Intercept" code="5"/>
+		<enum name="CLI-Intercept-FTP" code="7"/>
+		<enum name="ECS" code="8"/>
+		<enum name="CLI-ECS" code="9"/>
+		<enum name="CLI-FTP-ECS" code="11"/>
+		<enum name="CLI-Intercept-ECS" code="13"/>
+		<enum name="CLI-Intercept-FTP-ECS" code="15"/>
+	</avp>
+
+	<avp name="SN-Assigned-VLAN-ID" code="152" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Authorised-Qos" code="266" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Bandwidth-Policy" code="300" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Call-Id" code="251" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Cause-Code" code="267" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="Normal_End_Of_Session" code="0"/>
+		<enum name="Successful_Transaction" code="1"/>
+		<enum name="End_Of_Subscriber_Dialog" code="2"/>
+		<enum name="3XX_Redirection" code="3"/>
+		<enum name="4XX_Request_Failure" code="4"/>
+		<enum name="5XX_Server_Failure" code="5"/>
+		<enum name="6XX_Global_Failure" code="6"/>
+		<enum name="Unspecified_Error" code="7"/>
+		<enum name="Unsuccessful_Session_Setup" code="8"/>
+		<enum name="Internal_Error" code="9"/>
+	</avp>
+
+	<avp name="SN-Cause-For-Rec-Closing" code="139" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-CBB-Policy" code="302" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-CF-Call-International" code="293" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="Disable" code="0"/>
+		<enum name="Enable" code="1"/>
+	</avp>
+
+	<avp name="SN-CF-Call-Local" code="291" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="Disable" code="0"/>
+		<enum name="Enable" code="1"/>
+	</avp>
+
+	<avp name="SN-CF-Call-LongDistance" code="292" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disable" code="0"/>
+	<enum name="Enable" code="1"/>
+	</avp>
+
+	<avp name="SN-CF-Call-Premium" code="294" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disable" code="0"/>
+	<enum name="Enable" code="1"/>
+	</avp>
+
+	<avp name="SN-CF-Call-RoamingInternatnl" code="298" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disable" code="0"/>
+	<enum name="Enable" code="1"/>
+	</avp>
+
+	<avp name="SN-CF-Call-Transfer" code="285" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disable" code="0"/>
+	<enum name="Enable" code="1"/>
+	</avp>
+
+	<avp name="SN-CF-Call-Waiting" code="284" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disable" code="0"/>
+	<enum name="Enable" code="1"/>
+	</avp>
+
+	<avp name="SN-CF-CId-Display" code="282" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disable" code="0"/>
+	<enum name="Enable" code="1"/>
+	</avp>
+
+	<avp name="SN-CF-CId-Display-Blocked" code="283" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disable" code="0"/>
+	<enum name="Enable" code="1"/>
+	</avp>
+
+	<avp name="SN-CF-Follow-Me" code="281" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-CF-Forward-Busy-Line" code="279" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-CF-Forward-No-Answer" code="278" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-CF-Forward-Not-Regd" code="280" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-CF-Forward-Unconditional" code="277" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-CFPolicy-ID" code="220" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Change-Condition" code="140" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="QOSCHANGE" code="0"/>
+	<enum name="TARIFFTIMECHANGE" code="1"/>
+	<enum name="SGSNCHANGE" code="500"/>
+	</avp>
+
+	<avp name="SN-Charging-VPN-Name" code="137" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Chrg-Char-Selection-Mode" code="138" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Content-Disposition" code="272" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Content-Length" code="271" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Content-Type" code="270" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-CR-International-Cid" code="295" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-CR-LongDistance-Cid" code="296" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-CSCF-App-Server-Info" code="275" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-CSCF-Rf-SDP-Media-Components" code="273" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Cscf-Subscriber-Ip-Address" code="287" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+			<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-Data-Tunnel-Ignore-DF-Bit" code="49" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-DHCP-Lease-Expiry-Policy" code="157" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="auto-renew" code="0"/>
+	<enum name="disconnect" code="1"/>
+	</avp>
+
+	<avp name="SN-DHCP-Options" code="309" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Direction" code="153" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Any" code="0"/>
+	<enum name="Uplink" code="1"/>
+	<enum name="Downlink" code="2"/>
+	</avp>
+
+	<avp name="SN-Disconnect-Reason" code="3" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Not-Defined" code="0"/>
+	<enum name="Admin-Disconnect" code="1"/>
+	<enum name="Remote-Disconnect" code="2"/>
+	<enum name="Local-Disconnect" code="3"/>
+	<enum name="Disc-No-Resource" code="4"/>
+	<enum name="Disc-Excd-Service-Limit" code="5"/>
+	<enum name="PPP-LCP-Neg-Failed" code="6"/>
+	<enum name="PPP-LCP-No-Response" code="7"/>
+	<enum name="PPP-LCP-Loopback" code="8"/>
+	<enum name="PPP-LCP-Max-Retry" code="9"/>
+	<enum name="PPP-Echo-Failed" code="10"/>
+	<enum name="PPP-Auth-Failed" code="11"/>
+	<enum name="PPP-Auth-Failed-No-AAA-Resp" code="12"/>
+	<enum name="PPP-Auth-No-Response" code="13"/>
+	<enum name="PPP-Auth-Max-Retry" code="14"/>
+	<enum name="Invalid-AAA-Attr" code="15"/>
+	<enum name="Failed-User-Filter" code="16"/>
+	<enum name="Failed-Provide-Service" code="17"/>
+	<enum name="Invalid-IP-Address-AAA" code="18"/>
+	<enum name="Invalid-IP-Pool-AAA" code="19"/>
+	<enum name="PPP-IPCP-Neg-Failed" code="20"/>
+	<enum name="PPP-IPCP-No-Response" code="21"/>
+	<enum name="PPP-IPCP-Max-Retry" code="22"/>
+	<enum name="PPP-No-Rem-IP-Address" code="23"/>
+	<enum name="Inactivity-Timeout" code="24"/>
+	<enum name="Session-Timeout" code="25"/>
+	<enum name="Max-Data-Excd" code="26"/>
+	<enum name="Invalid-IP-Source-Address" code="27"/>
+	<enum name="MSID-Auth-Failed" code="28"/>
+	<enum name="MSID-Auth-Failed-No-AAA-Resp" code="29"/>
+	<enum name="A11-Max-Retry" code="30"/>
+	<enum name="A11-Lifetime-Expired" code="31"/>
+	<enum name="A11-Message-Integrity-Failure" code="32"/>
+	<enum name="PPP-lcp-remote-disc" code="33"/>
+	<enum name="Session-setup-timeout" code="34"/>
+	<enum name="PPP-keepalive-failure" code="35"/>
+	<enum name="Flow-add-failed" code="36"/>
+	<enum name="Call-type-detection-failed" code="37"/>
+	<enum name="Wrong-ipcp-params" code="38"/>
+	<enum name="MIP-remote-dereg" code="39"/>
+	<enum name="MIP-lifetime-expiry" code="40"/>
+	<enum name="MIP-proto-error" code="41"/>
+	<enum name="MIP-auth-failure" code="42"/>
+	<enum name="MIP-reg-timeout" code="43"/>
+	<enum name="Invalid-dest-context" code="44"/>
+	<enum name="Source-context-removed" code="45"/>
+	<enum name="Destination-context-removed" code="46"/>
+	<enum name="Req-service-addr-unavailable" code="47"/>
+	<enum name="Demux-mgr-failed" code="48"/>
+	<enum name="Internal-error" code="49"/>
+	<enum name="AAA-context-removed" code="50"/>
+	<enum name="invalid-service-type" code="51"/>
+	<enum name="mip-relay-req-failed" code="52"/>
+	<enum name="mip-rcvd-relay-failure" code="53"/>
+	<enum name="ppp-restart-inter-pdsn-handoff" code="54"/>
+	<enum name="gre-key-mismatch" code="55"/>
+	<enum name="invalid_tunnel_context" code="56"/>
+	<enum name="no_peer_lns_address" code="57"/>
+	<enum name="failed_tunnel_connect" code="58"/>
+	<enum name="l2tp-tunnel-disconnect-remote" code="59"/>
+	<enum name="l2tp-tunnel-timeout" code="60"/>
+	<enum name="l2tp-protocol-error-remote" code="61"/>
+	<enum name="l2tp-protocol-error-local" code="62"/>
+	<enum name="l2tp-auth-failed-remote" code="63"/>
+	<enum name="l2tp-auth-failed-local" code="64"/>
+	<enum name="l2tp-try-another-lns-from-remote" code="65"/>
+	<enum name="l2tp-no-resource-local" code="66"/>
+	<enum name="l2tp-no-resource-remote" code="67"/>
+	<enum name="l2tp-tunnel-disconnect-local" code="68"/>
+	<enum name="l2tp-admin-disconnect_remote" code="69"/>
+	<enum name="l2tpmgr-reached-max-capacity" code="70"/>
+	<enum name="MIP-reg-revocation" code="71"/>
+	<enum name="path-failure" code="72"/>
+	<enum name="dhcp-relay-ip-validation-failed" code="73"/>
+	<enum name="gtp-unknown-pdp-addr-or-pdp-type" code="74"/>
+	<enum name="gtp-all-dynamic-pdp-addr-occupied" code="75"/>
+	<enum name="gtp-no-memory-is-available" code="76"/>
+	<enum name="dhcp-relay-static-ip-addr-not-allowed" code="77"/>
+	<enum name="dhcp-no-ip-addr-allocated" code="78"/>
+	<enum name="dhcp-ip-addr-allocation-tmr-exp" code="79"/>
+	<enum name="dhcp-ip-validation-failed" code="80"/>
+	<enum name="dhcp-static-addr-not-allowed" code="81"/>
+	<enum name="dhcp-ip-addr-not-available-at-present" code="82"/>
+	<enum name="dhcp-lease-expired" code="83"/>
+	<enum name="lpool-ip-validation-failed" code="84"/>
+	<enum name="lpool-static-ip-addr-not-allowed" code="85"/>
+	<enum name="static-ip-validation-failed" code="86"/>
+	<enum name="static-ip-addr-not-present" code="87"/>
+	<enum name="static-ip-addr-not-allowed" code="88"/>
+	<enum name="radius-ip-validation-failed" code="89"/>
+	<enum name="radius-ip-addr-not-provided" code="90"/>
+	<enum name="invalid-ip-addr-from-sgsn" code="91"/>
+	<enum name="no-more-sessions-in-aaa" code="92"/>
+	<enum name="ggsn-aaa-auth-req-failed" code="93"/>
+	<enum name="conflict-in-ip-addr-assignment" code="94"/>
+	<enum name="apn-removed" code="95"/>
+	<enum name="credits-used-bytes-in" code="96"/>
+	<enum name="credits-used-bytes-out" code="97"/>
+	<enum name="credits-used-bytes-total" code="98"/>
+	<enum name="prepaid-failed" code="99"/>
+	<enum name="l2tp-ipsec-tunnel-failure" code="100"/>
+	<enum name="l2tp-ipsec-tunnel-disconnected" code="101"/>
+	<enum name="mip-ipsec-sa-inactive" code="102"/>
+	<enum name="Long-Duration-Timeout" code="103"/>
+	<enum name="proxy-mip-registration-failure" code="104"/>
+	<enum name="proxy-mip-binding-update" code="105"/>
+	<enum name="proxy-mip-inter-pdsn-handoff-require-ip-address" code="106"/>
+	<enum name="proxy-mip-inter-pdsn-handoff-mismatched-address" code="107"/>
+	<enum name="Local-purge" code="108"/>
+	<enum name="failed-update-handoff" code="109"/>
+	<enum name="closed_rp-handoff-complete" code="110"/>
+	<enum name="closed_rp-duplicate-session" code="111"/>
+	<enum name="closed_rp-handoff-session-not-found" code="112"/>
+	<enum name="closed_rp-handoff-failed" code="113"/>
+	<enum name="pcf-monitor-keep-alive-failed" code="114"/>
+	<enum name="call-internal-reject" code="115"/>
+	<enum name="call-restarted" code="116"/>
+	<enum name="a11-mn-ha-auth-failure" code="117"/>
+	<enum name="a11-badly-formed" code="118"/>
+	<enum name="a11-t-bit-not-set" code="119"/>
+	<enum name="a11-unsupported-vendor-id" code="120"/>
+	<enum name="a11-mismatched-id" code="121"/>
+	<enum name="mipha-dup-home-addr-req" code="122"/>
+	<enum name="mipha-dup-imsi-session" code="123"/>
+	<enum name="ha-unreachable" code="124"/>
+	<enum name="IPSP-addr-in-use" code="125"/>
+	<enum name="mipfa-dup-home-addr-req" code="126"/>
+	<enum name="mipha-ip-pool-busyout" code="127"/>
+	<enum name="inter-pdsn-handoff" code="128"/>
+	<enum name="active-to-dormant" code="129"/>
+	<enum name="ppp-renegotiation" code="130"/>
+	<enum name="active-start-param-change" code="131"/>
+	<enum name="tarrif-boundary" code="132"/>
+	<enum name="a11-disconnect-no-active-stop" code="133"/>
+	<enum name="nw-reachability-failed-reject" code="134"/>
+	<enum name="nw-reachability-failed-redirect" code="135"/>
+	<enum name="container-max-exceeded" code="136"/>
+	<enum name="static-addr-not-allowed-in-apn" code="137"/>
+	<enum name="static-addr-required-by-radius" code="138"/>
+	<enum name="static-addr-not-allowed-by-radius" code="139"/>
+	<enum name="mip-registration-dropped" code="140"/>
+	<enum name="counter-rollover" code="141"/>
+	<enum name="constructed-nai-auth-fail" code="142"/>
+	<enum name="inter-pdsn-service-optimize-handoff-disabled" code="143"/>
+	<enum name="gre-key-collision" code="144"/>
+	<enum name="inter-pdsn-service-optimize-handoff-triggered" code="145"/>
+	<enum name="intra-pdsn-handoff-triggered" code="146"/>
+	<enum name="delayed-abort-timer-expired" code="147"/>
+	<enum name="Admin-AAA-disconnect" code="148"/>
+	<enum name="Admin-AAA-disconnect-handoff" code="149"/>
+	<enum name="PPP-IPV6CP-Neg-Failed" code="150"/>
+	<enum name="PPP-IPV6CP-No-Response" code="151"/>
+	<enum name="PPP-IPV6CP-Max-Retry" code="152"/>
+	<enum name="PPP-Restart-Invalid-source-IPV4-address" code="153"/>
+	<enum name="a11-disconnect-handoff-no-active-stop" code="154"/>
+	<enum name="call-restarted-inter-pdsn-handoff" code="155"/>
+	<enum name="call-restarted-ppp-termination" code="156"/>
+	<enum name="mipfa-resource-conflict" code="157"/>
+	<enum name="failed-auth-with-charging-svc" code="158"/>
+	<enum name="mipha-dup-imsi-session-purge" code="159"/>
+	<enum name="mipha-rev-pending-newcall" code="160"/>
+	<enum name="volume-quota-reached" code="161"/>
+	<enum name="duration-quota-reached" code="162"/>
+	<enum name="gtp-user-authentication-failed" code="163"/>
+	<enum name="MIP-reg-revocation-no-lcp-term" code="164"/>
+	<enum name="MIP-private-ip-no-rev-tunnel" code="165"/>
+	<enum name="Invalid-Prepaid-AAA-attr-in-auth-response" code="166"/>
+	<enum name="mipha-prepaid-reset-dynamic-newcall" code="167"/>
+	<enum name="gre-flow-control-timeout" code="168"/>
+	<enum name="mip-paaa-bc-query-not-found" code="169"/>
+	<enum name="mipha-dynamic-ip-addr-not-available" code="170"/>
+	<enum name="a11-mismatched-id-on-handoff" code="171"/>
+	<enum name="a11-badly-formed-on-handoff" code="172"/>
+	<enum name="a11-unsupported-vendor-id-on-handoff" code="173"/>
+	<enum name="a11-t-bit-not-set-on-handoff" code="174"/>
+	<enum name="MIP-reg-revocation-i-bit-on" code="175"/>
+	<enum name="A11-RRQ-Deny-Max-Count" code="176"/>
+	<enum name="Dormant-Transition-During-Session-Setup" code="177"/>
+	<enum name="PPP-Rem-Reneg-Disc-Always-Cfg" code="178"/>
+	<enum name="PPP-Rem-Reneg-Disc-NAI-MSID-Mismatch" code="179"/>
+	<enum name="mipha-subscriber-ipsec-tunnel-down" code="180"/>
+	<enum name="mipha-subscriber-ipsec-tunnel-failed" code="181"/>
+	<enum name="mipha-subscriber-ipsecmgr-death" code="182"/>
+	<enum name="flow-is-deactivated" code="183"/>
+	<enum name="ecsv2-license-exceeded" code="184"/>
+	<enum name="IPSG-Auth-Failed" code="185"/>
+	<enum name="driver-initiated" code="186"/>
+	<enum name="ims-authorization-failed" code="187"/>
+	<enum name="service-instance-released" code="188"/>
+	<enum name="flow-released" code="189"/>
+	<enum name="ppp-renego-no-ha-addr" code="190"/>
+	<enum name="intra-pdsn-handoff" code="191"/>
+	<enum name="overload-disconnect" code="192"/>
+	<enum name="css-service-not-found" code="193"/>
+	<enum name="Auth-Failed" code="194"/>
+	<enum name="dhcp-client-sent-release" code="195"/>
+	<enum name="dhcp-client-sent-nak" code="196"/>
+	<enum name="msid-dhcp-chaddr-mismatch" code="197"/>
+	<enum name="link-broken" code="198"/>
+	<enum name="prog-end-timeout" code="199"/>
+	<enum name="qos-update-wait-timeout" code="200"/>
+	<enum name="css-synch-cause" code="201"/>
+	<enum name="Gtp-context-replacement" code="202"/>
+	<enum name="PDIF-Auth-failed" code="203"/>
+	<enum name="l2tp-unknown-apn" code="204"/>
+	<enum name="ms-unexpected-network-reentry" code="205"/>
+	<enum name="r6-invalid-nai" code="206"/>
+	<enum name="eap-max-retry-reached" code="207"/>
+	<enum name="vbm-hoa-session-disconnected" code="208"/>
+	<enum name="vbm-voa-session-disconnected" code="209"/>
+	<enum name="in-acl-disconnect-on-violation" code="210"/>
+	<enum name="eap-msk-lifetime-expiry" code="211"/>
+	<enum name="eap-msk-lifetime-too-low" code="212"/>
+	<enum name="mipfa-inter-tech-handoff" code="213"/>
+	<enum name="r6-max-retry-reached" code="214"/>
+	<enum name="r6-nwexit-recd" code="215"/>
+	<enum name="r6-dereg-req-recd" code="216"/>
+	<enum name="r6-remote-failure" code="217"/>
+	<enum name="r6r4-protocol-errors" code="218"/>
+	<enum name="wimax-qos-invalid-aaa-attr" code="219"/>
+	<enum name="npu-gre-flows-not-available" code="220"/>
+	<enum name="r4-max-retry-reached" code="221"/>
+	<enum name="r4-nwexit-recd" code="222"/>
+	<enum name="r4-dereg-req-recd" code="223"/>
+	<enum name="r4-remote-failure" code="224"/>
+	<enum name="ims-authorization-revoked" code="225"/>
+	<enum name="ims-authorization-released" code="226"/>
+	<enum name="ims-auth-decision-invalid" code="227"/>
+	<enum name="mac-addr-validation-failed" code="228"/>
+	<enum name="excessive-wimax-pd-flows-cfgd" code="229"/>
+	<enum name="sgsn-canc-loc-sub" code="230"/>
+	<enum name="sgsn-canc-loc-upd" code="231"/>
+	<enum name="sgsn-mnr-exp" code="232"/>
+	<enum name="sgsn-ident-fail" code="233"/>
+	<enum name="sgsn-sec-fail" code="234"/>
+	<enum name="sgsn-auth-fail" code="235"/>
+	<enum name="sgsn-glu-fail" code="236"/>
+	<enum name="sgsn-imp-det" code="237"/>
+	<enum name="sgsn-smgr-purge" code="238"/>
+	<enum name="sgsn-subs-handed-to-peer" code="239"/>
+	<enum name="sgsn-dns-fail-inter-rau" code="240"/>
+	<enum name="sgsn-cont-rsp-fail" code="241"/>
+	<enum name="sgsn-hlr-not-found-for-imsi" code="242"/>
+	<enum name="sgsn-ms-init-det" code="243"/>
+	<enum name="sgsn-opr-policy-fail" code="244"/>
+	<enum name="sgsn-duplicate-context" code="245"/>
+	<enum name="hss-profile-update-failed" code="246"/>
+	<enum name="sgsn-no-pdp-activated" code="247"/>
+	<enum name="asnpc-idle-mode-timeout" code="248"/>
+	<enum name="asnpc-idle-mode-exit" code="249"/>
+	<enum name="asnpc-idle-mode-auth-failed" code="250"/>
+	<enum name="asngw-invalid-qos-configuration" code="251"/>
+	<enum name="sgsn-dsd-allgprswithdrawn" code="252"/>
+	<enum name="r6-pmk-key-change-failure" code="253"/>
+	<enum name="sgsn-illegal-me" code="254"/>
+	<enum name="sess-termination-timeout" code="255"/>
+	<enum name="sgsn-sai-fail" code="256"/>
+	<enum name="sgsn-rnc-removal" code="257"/>
+	<enum name="sgsn-rai-removal" code="258"/>
+	<enum name="sgsn-init-deact" code="259"/>
+	<enum name="ggsn-init-deact" code="260"/>
+	<enum name="hlr-init-deact" code="261"/>
+	<enum name="ms-init-deact" code="262"/>
+	<enum name="sgsn-detach-init-deact" code="263"/>
+	<enum name="sgsn-rab-rel-init-deact" code="264"/>
+	<enum name="sgsn-iu-rel-init-deact" code="265"/>
+	<enum name="sgsn-gtpu-path-failure" code="266"/>
+	<enum name="sgsn-gtpc-path-failure" code="267"/>
+	<enum name="sgsn-local-handoff-init-deact" code="268"/>
+	<enum name="sgsn-remote-handoff-init-deact" code="269"/>
+	<enum name="sgsn-gtp-no-resource" code="270"/>
+	<enum name="sgsn-rnc-no-resource" code="271"/>
+	<enum name="sgsn-odb-init-deact" code="272"/>
+	<enum name="sgsn-invalid-ti" code="273"/>
+	<enum name="sgsn-ggsn-ctxt-non-existent" code="274"/>
+	<enum name="sgsn-apn-restrict-vio" code="275"/>
+	<enum name="sgsn-regular-deact" code="276"/>
+	<enum name="sgsn-abnormal-deact" code="277"/>
+	<enum name="sgsn-actv-rejected-by-peer" code="278"/>
+	<enum name="sgsn-err-ind" code="279"/>
+	<enum name="asngw-non-anchor-prohibited" code="280"/>
+	<enum name="asngw-im-entry-prohibited" code="281"/>
+	<enum name="session-idle-mode-entry-timeout" code="282"/>
+	<enum name="session-idle-mode-exit-timeout" code="283"/>
+	<enum name="asnpc-ms-power-down-nwexit" code="284"/>
+	<enum name="asnpc-r4-nwexit-recd" code="285"/>
+	<enum name="sgsn-iu-rel-before-call-est" code="286"/>
+	<enum name="ikev2-subscriber-ipsecmgr-death" code="287"/>
+	<enum name="All-dynamic-pool-addr-occupied" code="288"/>
+	<enum name="mip6ha-ip-addr-not-available" code="289"/>
+	<enum name="bs-monitor-keep-alive-failed" code="290"/>
+	<enum name="sgsn-att-in-reg-state" code="291"/>
+	<enum name="sgsn-inbound-srns-in-reg-state" code="292"/>
+	<enum name="dt-ggsn-tun-reestablish-failed" code="293"/>
+	<enum name="sgsn-unknown-pdp" code="294"/>
+	<enum name="sgsn-pdp-auth-failure" code="295"/>
+	<enum name="sgsn-duplicate-pdp-context" code="296"/>
+	<enum name="sgsn-no-rsp-from-ggsn" code="297"/>
+	<enum name="sgsn-failure-rsp-from-ggsn" code="298"/>
+	<enum name="sgsn-apn-unknown" code="299"/>
+	<enum name="sgsn-serv-req-init-deact" code="300"/>
+	<enum name="sgsn-attach-on-attch-init-abort" code="301"/>
+	<enum name="sgsn-iu-rel-in-israu-init-abort" code="302"/>
+	<enum name="sgsn-smgr-init-abort" code="303"/>
+	<enum name="sgsn-mm-ctx-cleanup-init-abort" code="304"/>
+	<enum name="sgsn-unknown-abort" code="305"/>
+	<enum name="sgsn-guard-timeout-abort" code="306"/>
+	<enum name="vpn-bounce-dhcpip-validate-req" code="307"/>
+	<enum name="mipv6-id-mismatch" code="308"/>
+	<enum name="aaa-session-id-not-found" code="309"/>
+	<enum name="x1-max-retry-reached" code="310"/>
+	<enum name="x1-nwexit-recd" code="311"/>
+	<enum name="x1-dereg-req-recd" code="312"/>
+	<enum name="x1-remote-failure" code="313"/>
+	<enum name="x1x2-protocol-errors" code="314"/>
+	<enum name="x2-max-retry-reached" code="315"/>
+	<enum name="x2-nwexit-recd" code="316"/>
+	<enum name="x2-dereg-req-recd" code="317"/>
+	<enum name="x2-remote-failure" code="318"/>
+	<enum name="x1-pmk-key-change-failure" code="319"/>
+	<enum name="sa-rekeying-failure" code="320"/>
+	<enum name="sess-sleep-mode-entry-timeout" code="321"/>
+	<enum name="phsgw-non-anchor-prohibited" code="322"/>
+	<enum name="asnpc-pc-relocation-failed" code="323"/>
+	<enum name="asnpc-pc-relocation" code="324"/>
+	<enum name="auth_policy_mismatch" code="325"/>
+	<enum name="sa-lifetime-expiry" code="326"/>
+	<enum name="asnpc-del-ms-entry-recd" code="327"/>
+	<enum name="phspc-sleep-mode-timeout" code="328"/>
+	<enum name="phspc-sleep-mode-exit" code="329"/>
+	<enum name="phspc-sleep-mode-auth-failed" code="330"/>
+	<enum name="phspc-ms-power-down-nwexit" code="331"/>
+	<enum name="phspc-x2-nwexit-recd" code="332"/>
+	<enum name="invalid-nat-config" code="333"/>
+	<enum name="asngw-tid-entry-not-found" code="334"/>
+	<enum name="No-NAT-IP-Address" code="335"/>
+	<enum name="excessive-phs-pd-flows-cfgd" code="336"/>
+	<enum name="phsgw-invalid-qos-configuration" code="337"/>
+	<enum name="Interim-Update" code="338"/>
+	<enum name="sgsn-attach-abrt-rad-lost" code="339"/>
+	<enum name="sgsn-inbnd-irau-abrt-rad-lost" code="340"/>
+	<enum name="ike-keepalive-failed" code="341"/>
+	<enum name="sgsn-attach-abrt-ms-suspend" code="342"/>
+	<enum name="sgsn-inbnd-irau-abrt-ms-suspend" code="343"/>
+	<enum name="duplicate-session-detected" code="344"/>
+	<enum name="sgsn-xid-response-failure" code="345"/>
+	<enum name="sgsn-nse-cleanup" code="346"/>
+	<enum name="sgsn-gtp-req-failure" code="347"/>
+	<enum name="sgsn-imsi-mismatch" code="348"/>
+	<enum name="sgsn-bvc-blocked" code="349"/>
+	<enum name="sgsn-attach-on-inbound-irau" code="350"/>
+	<enum name="sgsn-attach-on-outbound-irau" code="351"/>
+	<enum name="sgsn-incorrect-state" code="352"/>
+	<enum name="sgsn-t3350-expiry" code="353"/>
+	<enum name="sgsn-page-timer-expiry" code="354"/>
+	<enum name="phsgw-tid-entry-not-found" code="355"/>
+	<enum name="phspc-del-ms-entry-recd" code="356"/>
+	<enum name="sgsn-pdp-local-purge" code="357"/>
+	<enum name="phs-invalid-nai" code="358"/>
+	<enum name="session-sleep-mode-exit-timeout" code="359"/>
+	<enum name="sgsn-offload-phase2" code="360"/>
+	<enum name="phs-thirdparty-auth-fail" code="361"/>
+	<enum name="remote-error-notify" code="362"/>
+	<enum name="no-response" code="363"/>
+	<enum name="PDG-Auth-failed" code="364"/>
+	<enum name="mme-s1AP-send-failed" code="365"/>
+	<enum name="mme-egtpc-connection-failed" code="366"/>
+	<enum name="mme-egtpc-create-session-failed" code="367"/>
+	<enum name="mme-authentication-failure" code="368"/>
+	<enum name="mme-ue-detach" code="369"/>
+	<enum name="mme-mme-detach" code="370"/>
+	<enum name="mme-hss-detach" code="371"/>
+	<enum name="mme-pgw-detach" code="372"/>
+	<enum name="mme-sub-validation-failure" code="373"/>
+	<enum name="mme-hss-connection-failure" code="374"/>
+	<enum name="mme-hss-user-unknown" code="375"/>
+	<enum name="dhcp-lease-mismatch-detected" code="376"/>
+	<enum name="nemo-link-layer-down" code="377"/>
+	<enum name="eapol-max-retry-reached" code="378"/>
+	<enum name="sgsn-offload-phase3" code="379"/>
+	<enum name="mbms-bearer-service-disconnect" code="380"/>
+	<enum name="disconnect-on-violation-odb" code="381"/>
+	<enum name="disconn-on-violation-focs-odb" code="382"/>
+	<enum name="CSCF-REG-Admin-disconnect" code="383"/>
+	<enum name="CSCF-REG-User-disconnect" code="384"/>
+	<enum name="CSCF-REG-Inactivity-timeout" code="385"/>
+	<enum name="CSCF-REG-Network-disconnect" code="386"/>
+	<enum name="CSCF-Call-Admin-disconnect" code="387"/>
+	<enum name="CSCF-CAll-User-disconnect" code="388"/>
+	<enum name="CSCF-CALL-Local-disconnect" code="389"/>
+	<enum name="CSCF-CALL-No-Resource" code="390"/>
+	<enum name="CSCF-CALL-No-Respone" code="391"/>
+	<enum name="CSCF-CALL-Inactivity-timeout" code="392"/>
+	<enum name="CSCF-CALL-Media-Auth-Failure" code="393"/>
+	<enum name="CSCF-REG-No-Resource" code="394"/>
+	<enum name="ms-unexpected-idle-mode-entry" code="395"/>
+	<enum name="re-auth-failed" code="396"/>
+	<enum name="sgsn-pdp-nse-cleanup" code="397"/>
+	<enum name="sgsn-mm-ctxt-gtp-no-resource" code="398"/>
+	<enum name="unknown-apn" code="399"/>
+	<enum name="gtpc-path-failure" code="400"/>
+	<enum name="gtpu-path-failure" code="401"/>
+	<enum name="actv-rejected-by-sgsn" code="402"/>
+	<enum name="sgsn-pdp-gprs-camel-release" code="403"/>
+	<enum name="sgsn-check-imei-failure" code="404"/>
+	<enum name="sgsn-sndcp-init-deact" code="405"/>
+	<enum name="sgsn-pdp-inactivity-timeout" code="406"/>
+	<enum name="fw-and-nat-policy-removed" code="407"/>
+	<enum name="FNG-Auth-failed" code="408"/>
+	<enum name="ha-stale-key-disconnect" code="409"/>
+	<enum name="No-IPV6-address-for-subscriber" code="410"/>
+	<enum name="prefix-registration-failure" code="411"/>
+	<enum name="disconnect-from-policy-server" code="412"/>
+	<enum name="s6b-auth-failed" code="413"/>
+	<enum name="gtpc-err-ind" code="414"/>
+	<enum name="gtpu-err-ind" code="415"/>
+	<enum name="invalid-pdn-type" code="416"/>
+	<enum name="aaa-auth-req-failed" code="417"/>
+	<enum name="apn-denied-no-subscription" code="418"/>
+	<enum name="Sgw-context-replacement" code="419"/>
+	<enum name="dup-static-ip-addr-req" code="420"/>
+	<enum name="apn-restrict-violation" code="421"/>
+	<enum name="invalid-wapn" code="422"/>
+	<enum name="ttg-nsapi-allocation-failed" code="423"/>
+	<enum name="mandatory-gtp-ie-missing" code="424"/>
+	<enum name="aaa-unreachable" code="425"/>
+	<enum name="asngw-service-flow-deletion" code="426"/>
+	<enum name="CT-PMIP-RRQ-NVSE-Value-Change" code="427"/>
+	<enum name="tcp-read-failed" code="428"/>
+	<enum name="tcp-write-failed" code="429"/>
+	<enum name="ssl-handshake-failed" code="430"/>
+	<enum name="ssl-renegotiate-failed" code="431"/>
+	<enum name="ssl-bad-message" code="432"/>
+	<enum name="ssl-alert-received" code="433"/>
+	<enum name="ssl-disconnect" code="434"/>
+	<enum name="ssl-migration" code="435"/>
+	<enum name="sgsn-ard-failure" code="436"/>
+	<enum name="sgsn-camel-release" code="437"/>
+	<enum name="Hotlining-Status-Change" code="447"/>
+	<enum name="ggsn-no-rsp-from-sgsn" code="448"/>
+	<enum name="diameter-protocol-error" code="449"/>
+	<enum name="diameter-request-timeout" code="450"/>
+	<enum name="operator-policy" code="451"/>
+	<enum name="spr-connection-timeout" code="452"/>
+	<enum name="mipha-dup-wimax-session" code="453"/>
+	<enum name="invalid-version-attr" code="454"/>
+	<enum name="sgsn-zone-code-failure" code="455"/>
+	<enum name="invalid-qci" code="456"/>
+	<enum name="no_rules" code="457"/>
+	<enum name="mme-init-ctxt-setup-failure" code="459"/>
+	<enum name="mme-driver-initiated" code="460"/>
+	<enum name="mme-s1ap-connection-down" code="461"/>
+	<enum name="mme-s1ap-reset-recd" code="462"/>
+	<enum name="mme-s6a-response-timeout" code="463"/>
+	<enum name="mme-s13-response-timeout" code="464"/>
+	<enum name="mme-Illegal-equipment" code="465"/>
+	<enum name="mme-unexpected-attach" code="466"/>
+	<enum name="mme-sgw-selection-failure" code="467"/>
+	<enum name="mme-pgw-selection-failure" code="468"/>
+	<enum name="mme-reselection-to-sgsn" code="469"/>
+	<enum name="mme-relocation-to-sgsn" code="470"/>
+	<enum name="mme-reselection-to-mme" code="471"/>
+	<enum name="mme-relocation-to-mme" code="472"/>
+	<enum name="mme-tau-attach-collision" code="473"/>
+	<enum name="mme-old-sgsn-resolution-failure" code="474"/>
+	<enum name="mme-old-mme-resolution-failure" code="475"/>
+	<enum name="mme-reloc-ho-notify-timeout" code="476"/>
+	<enum name="mme-reloc-ho-req-ack-timeout" code="477"/>
+	<enum name="mme-create-session-timeout" code="478"/>
+	<enum name="mme-create-session-failure" code="479"/>
+	<enum name="mme-s11-path-failure" code="480"/>
+	<enum name="mme-policy-no-ue-irat" code="481"/>
+	<enum name="mme-x2-handover-failed" code="482"/>
+	<enum name="mme-attach-restrict" code="483"/>
+	<enum name="mme-regional-zone-code" code="484"/>
+	<enum name="mme-no-response-from-ue" code="485"/>
+	<enum name="mme-sgw-relocation-failed" code="486"/>
+	<enum name="mme-implicit-detach" code="487"/>
+	<enum name="sgsn-detach-notify" code="488"/>
+	<enum name="emergency-inactivity-timeout" code="489"/>
+	<enum name="policy-initiated-release" code="490"/>
+	<enum name="gy-result-code-system-failure" code="491"/>
+	<enum name="mme-zone-code-validation-failed" code="492"/>
+	<enum name="sgsn-pgw-init-deact" code="493"/>
+	<enum name="s6b-ip-validation-failed" code="494"/>
+	<enum name="sgsn-failure-rsp-from-sgw" code="495"/>
+	<enum name="tcp-remote-close" code="496"/>
+	<enum name="tcp-reset-received" code="497"/>
+	<enum name="tcp-socket-error" code="498"/>
+	<enum name="ptmsi-signature-mismatch" code="499"/>
+	<enum name="camel-invalid-configuration" code="500"/>
+	<enum name="4Gto3G-context-replacement" code="501"/>
+	<enum name="mme-isr-sgsn-init-detach" code="502"/>
+	<enum name="sgsn-isr-addl-ptmsi-rai" code="503"/>
+	<enum name="sgsn-sgw-dbr-cause-isr-deact" code="504"/>
+	<enum name="sgsn-isr-mme-init-detach" code="505"/>
+	<enum name="mme-sgw-dbr-cause-isr-deact" code="506"/>
+	<enum name="sgsn-ptmsi-crunch" code="507"/>
+	<enum name="3Gto4G-context-replacement" code="508"/>
+	<enum name="mme-no-eps-bearers-activated" code="509"/>
+	<enum name="intra-ggsn-handoff" code="510"/>
+	<enum name="WSG-Auth-failed" code="511"/>
+	<enum name="Gtp-non-existent-pdp-context" code="512"/>
+	<enum name="sgsn-cancel-loc-inital-attach" code="513"/>
+	<enum name="Local-fallback-timeout" code="514"/>
+	<enum name="sgsn-nrspca-actv-rej-by-sgsn" code="515"/>
+	<enum name="sgsn-nrspca-actv-rej-by-ms" code="516"/>
+	<enum name="ims-authorization-config-delete" code="517"/>
+	<enum name="sgsn-no-ptmsi-signature" code="518"/>
+	<enum name="ePDG-dns-server-not-reachable" code="519"/>
+	<enum name="ePDG-dns-no-resource-records" code="520"/>
+	<enum name="ePDG-dns-no-service-params" code="521"/>
+	<enum name="ePDG-Auth-failed" code="522"/>
+	<enum name="ePDG-pgw-sel-failure-initial" code="523"/>
+	<enum name="ePDG-pgw-sel-failure-handoff" code="524"/>
+	<enum name="sgsn-ho-sgw-reloc-collision" code="525"/>
+	<enum name="ePDG-dbr-from-pgw" code="526"/>
+	<enum name="ePDG-gtpc-abort-session" code="527"/>
+	<enum name="ePDG-gtpu-abort-session" code="528"/>
+	<enum name="ePDG-gtpu-error-ind" code="529"/>
+	<enum name="ePDG-pgw-not-reachable" code="530"/>
+	<enum name="ePDG-reject-from-pgw" code="531"/>
+	<enum name="ipsg-session-replacement" code="532"/>
+	<enum name="ePDG-rel-due-to-handoff" code="533"/>
+	<enum name="mme-foreign-plmn-guti-rejected" code="534"/>
+	<enum name="sgsn-dsd-allepswithdrawn" code="535"/>
+	</avp>
+
+	<avp name="SN-DNS-Proxy-Intercept-List" code="214" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-DNS-Proxy-Use-Subscr-Addr" code="25" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disable" code="0"/>
+	<enum name="Enable" code="1"/>
+	</avp>
+
+	<avp name="SN-Dynamic-Addr-Alloc-Ind-Flag" code="141" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Ecs-Data-Volume" code="176" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Enable-QoS-Renegotiation" code="144" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="No" code="0"/>
+	<enum name="Yes" code="1"/>
+	</avp>
+
+	<avp name="SN-Event" code="255" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Ext-Inline-Srvr-Context" code="41" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Ext-Inline-Srvr-Down-Addr" code="56" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-Ext-Inline-Srvr-Down-VLAN" code="59" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Ext-Inline-Srvr-Preference" code="57" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Ext-Inline-Srvr-Up-Addr" code="55" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-Ext-Inline-Srvr-Up-VLAN" code="58" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-Fast-Reauth-Username-304" code="304" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Firewall-Enabled" code="198" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="False" code="0"/>
+	<enum name="True" code="1"/>
+	</avp>
+
+	<avp name="SN-Firewall-Policy-239" code="239" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-FMC-Location" code="171" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-GGSN-Address" code="264" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-GGSN-MIP-Required" code="68" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-Gratuitous-ARP-Aggressive" code="54" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-GTP-Version" code="62" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="GTP_VERSION_0" code="0"/>
+	<enum name="GTP_VERSION_1" code="1"/>
+	<enum name="GTP_VERSION_2" code="2"/>
+	</avp>
+
+	<avp name="SN-HA-Send-DNS-ADDRESS" code="47" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-Handoff-Indicator" code="310" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Active-Handoff" code="0"/>
+	<enum name="Location-Update" code="1"/>
+	</avp>
+
+	<avp name="SN-Home-Behavior" code="119" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Home-Profile" code="109" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Home-Sub-Use-GGSN" code="106" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Deny" code="0"/>
+	<enum name="Accept" code="1"/>
+	</avp>
+
+	<avp name="SN-IMS-AM-Address" code="167" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-IMS-AM-Domain-Name" code="168" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-IMS-Charging-Identifier" code="260" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-IMSI" code="252" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Inactivity-Time" code="232" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Integer32"/>
+	</avp>
+
+	<avp name="SN-Internal-SM-Index" code="122" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-IP-Alloc-Method" code="53" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Alloc_Local_Pool" code="0"/>
+	<enum name="Alloc_Dhcp_Client" code="1"/>
+	<enum name="Alloc_Radius" code="2"/>
+	<enum name="Alloc_No_Alloc" code="3"/>
+	<enum name="Alloc_Static_Alloc" code="4"/>
+	<enum name="Alloc_Dhcp_Relay" code="5"/>
+	</avp>
+
+	<avp name="SN-IPv6-Alloc-Method" code="314" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Alloc_Local_Pool" code="0"/>
+	<enum name="Alloc_Dhcp_Client" code="1"/>
+	<enum name="Alloc_No_Alloc" code="2"/>
+	<enum name="Alloc_Static_Alloc" code="3"/>
+	</avp>
+
+	<avp name="SN-IP-Filter-In" code="10" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-IP-Filter-Out" code="11" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-IP-Header-Compression" code="150" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="None" code="0"/>
+	<enum name="VJ" code="1"/>
+	<enum name="ROHC" code="2"/>
+	<enum name="VJ_ROHC" code="3"/>
+	</avp>
+
+	<avp name="SN-IP-Hide-Service-Address" code="60" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="No" code="0"/>
+	<enum name="Yes" code="1"/>
+	</avp>
+
+	<avp name="SN-IP-In-ACL" code="17" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-IP-In-Plcy-Grp" code="193" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-IP-Out-ACL" code="18" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-IP-Out-Plcy-Grp" code="194" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-IP-Pool-Name" code="8" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-IP-Source-Validation" code="14" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="No" code="0"/>
+	<enum name="Yes" code="1"/>
+	</avp>
+
+	<avp name="SN-IP-Source-Violate-No-Acct" code="196" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-IP-Src-Validation-Drop-Limit" code="110" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-IPv6-DNS-Proxy" code="126" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-IPv6-Egress-Filtering" code="103" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-IPv6-Min-Link-MTU" code="136" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-IPv6-num-rtr-advt" code="97" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-IPv6-Primary-DNS" code="101" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-IPv6-rtr-advt-interval" code="96" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-IPv6-Secondary-DNS" code="102" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-IPv6-Sec-Pool" code="124" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-IPv6-Sec-Prefix" code="125" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-ISC-Template-Name" code="276" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Is-Unregistered-Subscriber" code="269" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-L3-to-L2-Tun-Addr-Policy" code="43" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="no-local-alloc-validate" code="0"/>
+	<enum name="local-alloc" code="1"/>
+	<enum name="local-alloc-validate" code="2"/>
+	</avp>
+
+	<avp name="SN-LI-Dest-Address" code="240" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Local-IP-Address" code="13" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-Long-Duration-Action" code="45" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Detection" code="1"/>
+	<enum name="Disconnection" code="2"/>
+	<enum name="Dormant-Only-Disconnection" code="3"/>
+	<enum name="Dormant-Only-Detection" code="4"/>
+	</avp>
+
+	<avp name="SN-Long-Duration-Notification" code="253" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Suppress" code="0"/>
+	<enum name="Send" code="1"/>
+	</avp>
+
+	<avp name="SN-Long-Duration-Timeout" code="44" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Integer32"/>
+	</avp>
+
+	<avp name="SN-Max-Sec-Contexts-Per-Subs" code="290" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Mediation-Acct-Rsp-Action" code="105" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="None" code="0"/>
+	<enum name="No_Early_PDUs" code="1"/>
+	<enum name="Delay_GTP_Response" code="2"/>
+	</avp>
+
+	<avp name="SN-Mediation-Enabled" code="123" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-Mediation-No-Interims" code="146" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-Mediation-VPN-Name" code="104" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Min-Compress-Size" code="23" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-MIP-AAA-Assign-Addr" code="50" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-MIP-ANCID" code="166" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-MIP-Dual-Anchor" code="165" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-MIP-HA-Assignment-Table" code="154" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-MIP-Match-AAA-Assign-Addr" code="51" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-MIP-Reg-Lifetime-Realm" code="175" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-MIP-Send-Ancid" code="163" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-MIP-Send-Correlation-Info" code="188" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	<enum name="NVSE_CUstom1" code="2"/>
+	<enum name="NVSE_CUstom2" code="3"/>
+	</avp>
+
+	<avp name="SN-MIP-Send-Host-Config" code="311" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-MIP-Send-Imsi" code="164" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="NVSE_Starent" code="1"/>
+	<enum name="NVSE_Custom1" code="2"/>
+	</avp>
+
+	<avp name="SN-MIP-Send-Term-Verification" code="48" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="NVSE_Custom1" code="1"/>
+	<enum name="NVSE_Custom2" code="2"/>
+	<enum name="NVSE_Starent" code="3"/>
+	</avp>
+
+	<avp name="SN-MN-HA-Hash-Algorithm" code="99" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="MD5" code="1"/>
+	<enum name="MD5-RFC2002" code="2"/>
+	<enum name="HMAC-MD5" code="3"/>
+	</avp>
+
+	<avp name="SN-MN-HA-Timestamp-Tolerance" code="30" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Mode" code="151" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Reliable" code="0"/>
+	<enum name="Optimistic" code="1"/>
+	<enum name="Unidirectional" code="2"/>
+	</avp>
+
+	<avp name="SN-MS-ISDN" code="248" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-NAI-Construction-Domain" code="37" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-NAT-IP-Address" code="297" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-Node-Functionality" code="268" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="S-CSCF" code="0"/>
+	<enum name="P-CSCF" code="1"/>
+	<enum name="I-CSCF" code="2"/>
+	</avp>
+
+	<avp name="SN-NPU-Qos-Priority" code="98" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Best_Effort" code="0"/>
+	<enum name="Bronze" code="1"/>
+	<enum name="Silver" code="2"/>
+	<enum name="Gold" code="3"/>
+	<enum name="From_DSCP" code="4"/>
+	</avp>
+
+	<avp name="SN-Ntk-Initiated-Ctx-Ind-Flag" code="142" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Ntk-Session-Disconnect-Flag" code="143" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Session-Disconnect" code="0"/>
+	</avp>
+
+	<avp name="SN-Nw-Reachability-Server-Name" code="65" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Originating-IOI" code="261" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Overload-Disc-Connect-Time" code="233" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Overload-Disc-Inact-Time" code="234" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Overload-Disconnect" code="235" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-PDG-TTG-Required" code="299" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="No" code="0"/>
+	<enum name="Yes" code="1"/>
+	</avp>
+
+	<avp name="SN-PDIF-MIP-Release-TIA" code="172" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="No" code="0"/>
+	<enum name="Yes" code="1"/>
+	</avp>
+
+	<avp name="SN-PDIF-MIP-Required" code="170" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="No" code="0"/>
+	<enum name="Yes" code="1"/>
+	</avp>
+
+	<avp name="SN-PDIF-MIP-Simple-IP-Fallback" code="173" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="No" code="0"/>
+	<enum name="Yes" code="1"/>
+	</avp>
+
+	<avp name="SN-PDSN-Correlation-Id" code="8" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-PDSN-Handoff-Req-IP-Addr" code="46" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-PDSN-NAS-Id" code="190" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-PDSN-NAS-IP-Address" code="191" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+			<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-Permit-User-Mcast-PDUs" code="134" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-PPP-Accept-Peer-v6Ifid" code="95" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-PPP-Always-On-Vse" code="130" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-PPP-Data-Compression" code="9" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="None" code="0"/>
+	<enum name="Stac-LZS" code="1"/>
+	<enum name="MPPC" code="2"/>
+	<enum name="Deflate" code="3"/>
+	</avp>
+
+	<avp name="SN-PPP-Data-Compression-Mode" code="19" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Normal" code="0"/>
+	<enum name="Stateless" code="1"/>
+	</avp>
+
+	<avp name="SN-PPP-Keepalive" code="16" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-PPP-NW-Layer-IPv4" code="92" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	<enum name="Passive" code="2"/>
+	</avp>
+
+	<avp name="SN-PPP-NW-Layer-IPv6" code="93" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	<enum name="Passive" code="2"/>
+	</avp>
+
+	<avp name="SN-PPP-Outbound-Password" code="15" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-PPP-Outbound-Username" code="61" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-PPP-Progress-Code" code="4" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Not-Defined" code="0"/>
+	<enum name="Call-Lcp-Down" code="10"/>
+	<enum name="Call-Disconnecting" code="20"/>
+	<enum name="Call-Ppp-Renegotiating" code="30"/>
+	<enum name="Call-Arrived" code="40"/>
+	<enum name="Call-Pdg-Tcp-Connecting" code="45"/>
+	<enum name="Call-Pdg-Ssl-Connecting" code="46"/>
+	<enum name="Call-Lcp-Up" code="50"/>
+	<enum name="Call-Authenticating" code="60"/>
+	<enum name="Call-Bcmcs-Authenticating" code="70"/>
+	<enum name="Call-Authenticated" code="80"/>
+	<enum name="Call-Tunnel-Connecting" code="85"/>
+	<enum name="Call-Ipcp-Up" code="90"/>
+	<enum name="Call-Imsa-Authorizing" code="95"/>
+	<enum name="Call-Imsa-Authorized" code="97"/>
+	<enum name="Call-MBMS-UE-Authorizing" code="98"/>
+	<enum name="Call-MBMS-Bearer-Authorizing" code="99"/>
+	<enum name="Call-Simple-IP-Connected" code="100"/>
+	<enum name="Call-Mobile-IP-Connected" code="110"/>
+	<enum name="Call-Tunnel-Connected" code="115"/>
+	<enum name="Call-Pdp-Type-IP-Connected" code="120"/>
+	<enum name="Call-Pdp-Type-IPv6-Connected" code="125"/>
+	<enum name="Call-Pdp-Type-PPP-Connected" code="130"/>
+	<enum name="Call-Proxy-Mobile-IP-Connected" code="140"/>
+	<enum name="Call-Pdg-Connected" code="142"/>
+	<enum name="Call-Pdg-Ssl-Connected" code="141"/>
+	<enum name="Call-Pdg-Connected" code="142"/>
+	<enum name="Call-Pdg-Connected" code="142"/>
+	<enum name="Call-Ipsg-Connected" code="145"/>
+	<enum name="Call-Bcmcs-Connected" code="150"/>
+	<enum name="Call-MBMS-UE-Connected" code="155"/>
+	<enum name="Call-MBMS-Bearer-Connected" code="156"/>
+	<enum name="Call-Pending-Addr-From-DHCP" code="160"/>
+	<enum name="Call-Got-Addr-From-DHCP" code="170"/>
+	<enum name="Call-HA-IPSEC-Tunnel-Connecting" code="180"/>
+	<enum name="Call-HA-IPSEC-Connected" code="190"/>
+	<enum name="Call-ASN-Non-Anchor-Connected" code="200"/>
+	<enum name="Call-ASNPC-Connected" code="210"/>
+	<enum name="Call-Mobile-IPv6-Connected" code="220"/>
+	<enum name="Call-PMIPv6-Connected" code="221"/>
+	<enum name="Call-PHSPC-Connected" code="230"/>
+	<enum name="Call-GTP-IPv4-Connected" code="235"/>
+	<enum name="Call-GTP-IPv6-Connected" code="236"/>
+	<enum name="Call-GTP-IPv4-IPv6-Connected" code="237"/>
+	<enum name="Call-SGW-Connected" code="245"/>
+	<enum name="Call-MME-Attached" code="246"/>
+	<enum name="Call-Auth-Only-Connected" code="247"/>
+	</avp>
+
+	<avp name="SN-PPP-Reneg-Disc" code="187" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Never" code="0"/>
+	<enum name="Always" code="1"/>
+	<enum name="NAI_Prefix_MSID_Mismatch" code="2"/>
+	</avp>
+
+	<avp name="SN-Prepaid" code="128" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="no_prepaid" code="0"/>
+	<enum name="custom_prepaid" code="1"/>
+	<enum name="standard_prepaid" code="2"/>
+	<enum name="wimax_prepaid" code="4"/>
+	</avp>
+
+	<avp name="SN-Prepaid-Compressed-Count" code="31" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Uncompressed" code="0"/>
+	<enum name="Compressed" code="1"/>
+	</avp>
+
+	<avp name="SN-Prepaid-Final-Duration-Alg" code="135" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="current_time" code="0"/>
+	<enum name="last-user-layer3-activity-time" code="1"/>
+	<enum name="last-airlink-activity-time" code="2"/>
+	<enum name="last-airlink-activity-time-last-reported" code="3"/>
+	</avp>
+
+	<avp name="SN-Prepaid-Inbound-Octets" code="32" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Prepaid-Outbound-Octets" code="33" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Prepaid-Preference" code="129" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="prepaid_duration" code="0"/>
+	<enum name="prepaid_volume" code="1"/>
+	</avp>
+
+	<avp name="SN-Prepaid-Timeout" code="35" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Prepaid-Total-Octets" code="34" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Prepaid-Watermark" code="36" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Primary-DCCA-Peer" code="223" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Primary-DNS-Server" code="5" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-Primary-NBNS-Server" code="148" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-Proxy-MIP" code="52" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-Proxy-MIPV6" code="65530" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-Pseudonym-Username-305" code="305" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-QoS-Background-Class" code="91" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-QoS-Class-Background-PHB" code="113" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Best-Effort" code="0"/>
+	<enum name="Pass-Through" code="1"/>
+	<enum name="AF11" code="10"/>
+	<enum name="AF12" code="12"/>
+	<enum name="AF13" code="14"/>
+	<enum name="AF21" code="18"/>
+	<enum name="AF22" code="20"/>
+	<enum name="AF22" code="22"/>
+	<enum name="AF31" code="26"/>
+	<enum name="AF32" code="28"/>
+	<enum name="AF33" code="30"/>
+	<enum name="AF41" code="34"/>
+	<enum name="AF42" code="36"/>
+	<enum name="AF43" code="38"/>
+	<enum name="EF" code="46"/>
+	</avp>
+
+	<avp name="SN-QoS-Class-Conversational-PHB" code="111" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Best-Effort" code="0"/>
+	<enum name="Pass-Through" code="1"/>
+	<enum name="AF11" code="10"/>
+	<enum name="AF12" code="12"/>
+	<enum name="AF13" code="14"/>
+	<enum name="AF21" code="18"/>
+	<enum name="AF22" code="20"/>
+	<enum name="AF22" code="22"/>
+	<enum name="AF31" code="26"/>
+	<enum name="AF32" code="28"/>
+	<enum name="AF33" code="30"/>
+	<enum name="AF41" code="34"/>
+	<enum name="AF42" code="36"/>
+	<enum name="AF43" code="38"/>
+	<enum name="EF" code="46"/>
+	</avp>
+
+	<avp name="SN-QoS-Class-Interactive-1-PHB" code="114" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Best-Effort" code="0"/>
+	<enum name="Pass-Through" code="1"/>
+	<enum name="AF11" code="10"/>
+	<enum name="AF12" code="12"/>
+	<enum name="AF13" code="14"/>
+	<enum name="AF21" code="18"/>
+	<enum name="AF22" code="20"/>
+	<enum name="AF22" code="22"/>
+	<enum name="AF31" code="26"/>
+	<enum name="AF32" code="28"/>
+	<enum name="AF33" code="30"/>
+	<enum name="AF41" code="34"/>
+	<enum name="AF42" code="36"/>
+	<enum name="AF43" code="38"/>
+	<enum name="EF" code="46"/>
+	</avp>
+
+	<avp name="SN-QoS-Class-Interactive-2-PHB" code="115" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Best-Effort" code="0"/>
+	<enum name="Pass-Through" code="1"/>
+	<enum name="AF11" code="10"/>
+	<enum name="AF12" code="12"/>
+	<enum name="AF13" code="14"/>
+	<enum name="AF21" code="18"/>
+	<enum name="AF22" code="20"/>
+	<enum name="AF22" code="22"/>
+	<enum name="AF31" code="26"/>
+	<enum name="AF32" code="28"/>
+	<enum name="AF33" code="30"/>
+	<enum name="AF41" code="34"/>
+	<enum name="AF42" code="36"/>
+	<enum name="AF43" code="38"/>
+	<enum name="EF" code="46"/>
+	</avp>
+
+	<avp name="SN-QoS-Class-Interactive-3-PHB" code="116" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Best-Effort" code="0"/>
+	<enum name="Pass-Through" code="1"/>
+	<enum name="AF11" code="10"/>
+	<enum name="AF12" code="12"/>
+	<enum name="AF13" code="14"/>
+	<enum name="AF21" code="18"/>
+	<enum name="AF22" code="20"/>
+	<enum name="AF22" code="22"/>
+	<enum name="AF31" code="26"/>
+	<enum name="AF32" code="28"/>
+	<enum name="AF33" code="30"/>
+	<enum name="AF41" code="34"/>
+	<enum name="AF42" code="36"/>
+	<enum name="AF43" code="38"/>
+	<enum name="EF" code="46"/>
+	</avp>
+
+	<avp name="SN-QoS-Class-Streaming-PHB" code="112" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Best-Effort" code="0"/>
+	<enum name="Pass-Through" code="1"/>
+	<enum name="AF11" code="10"/>
+	<enum name="AF12" code="12"/>
+	<enum name="AF13" code="14"/>
+	<enum name="AF21" code="18"/>
+	<enum name="AF22" code="20"/>
+	<enum name="AF22" code="22"/>
+	<enum name="AF31" code="26"/>
+	<enum name="AF32" code="28"/>
+	<enum name="AF33" code="30"/>
+	<enum name="AF41" code="34"/>
+	<enum name="AF42" code="36"/>
+	<enum name="AF43" code="38"/>
+	<enum name="EF" code="46"/>
+	</avp>
+
+	<avp name="SN-QoS-Conversation-Class" code="86" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-QOS-HLR-Profile" code="303" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-QoS-Interactive1-Class" code="88" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-QoS-Interactive2-Class" code="89" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-QoS-Interactive3-Class" code="90" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-QoS-Negotiated" code="147" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-QoS-Renegotiation-Timeout" code="145" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-QoS-Streaming-Class" code="87" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-QoS-Tp-Dnlk" code="73" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Policing" code="1"/>
+	<enum name="Shaping" code="2"/>
+	</avp>
+
+	<avp name="SN-QoS-Tp-Uplk" code="79" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Policing" code="1"/>
+	<enum name="Shaping" code="2"/>
+	</avp>
+
+	<avp name="SN-QoS-Traffic-Policy" code="177" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Rad-APN-Name" code="162" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Radius-Returned-Username" code="236" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="No" code="0"/>
+	<enum name="Yes" code="1"/>
+	</avp>
+
+	<avp name="SN-Re-CHAP-Interval" code="7" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Roaming-Behavior" code="121" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Roaming-Profile" code="118" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Roaming-Sub-Use-GGSN" code="108" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Deny" code="0"/>
+	<enum name="Accept" code="1"/>
+	</avp>
+
+	<avp name="SN-ROHC-Flow-Marking-Mode" code="274" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="False" code="0"/>
+	<enum name="True" code="1"/>
+	</avp>
+
+	<avp name="SN-ROHC-Mode" code="151" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Reliable" code="0"/>
+	<enum name="Optimistic" code="1"/>
+	<enum name="Unidirectional" code="2"/>
+	</avp>
+
+	<avp name="SN-ROHC-Profile-Name" code="238" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Role-Of-Node" code="256" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="ORIGINATING_ROLE" code="0"/>
+	<enum name="TERMINATING_ROLE" code="1"/>
+	</avp>
+
+	<avp name="SN-Routing-Area-Id" code="249" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Rulebase" code="250" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-SDP-Session-Description" code="263" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Sec-IP-Pool-Name" code="265" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Secondary-DCCA-Peer" code="224" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Secondary-DNS-Server" code="6" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-Secondary-NBNS-Server" code="149" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-Service-Address" code="169" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-Service-Type" code="24" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="None" code="0"/>
+	<enum name="PDSN" code="1"/>
+	<enum name="Management" code="2"/>
+	<enum name="HA" code="3"/>
+	<enum name="GGSN" code="4"/>
+	<enum name="LNS" code="5"/>
+	<enum name="IPSG" code="6"/>
+	<enum name="CSCF" code="7"/>
+	<enum name="ASNGW" code="8"/>
+	<enum name="PDIF" code="9"/>
+	<enum name="STANDALONE_FA" code="10"/>
+	<enum name="SGSN" code="11"/>
+	<enum name="PHSGW" code="12"/>
+	<enum name="PDG" code="13"/>
+	<enum name="MIPV6HA" code="14"/>
+	<enum name="PGW" code="15"/>
+	<enum name="SGW" code="16"/>
+	<enum name="FNG" code="17"/>
+	<enum name="MSEG" code="18"/>
+	<enum name="HNBGW" code="19"/>
+	<enum name="BNG" code="20"/>
+	</avp>
+
+	<avp name="SN-Session-Id" code="257" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Simultaneous-SIP-MIP" code="22" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-SIP-Method" code="254" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-SIP-Request-Time-Stamp" code="258" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-SIP-Response-Time-Stamp" code="259" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Software-Version" code="288" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Subs-Acc-Flow-Traffic-Valid" code="225" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disable" code="0"/>
+	<enum name="Enable" code="1"/>
+	</avp>
+
+	<avp name="SN-Subscriber-Accounting" code="64" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="None" code="0"/>
+	<enum name="Radius" code="1"/>
+	<enum name="GTPP" code="2"/>
+	</avp>
+
+	<avp name="SN-Subscriber-Acct-Interim" code="70" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Normal" code="0"/>
+	<enum name="Suppress" code="1"/>
+	</avp>
+
+	<avp name="SN-Subscriber-Acct-Mode" code="192" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="flow-based-auxilliary" code="0"/>
+	<enum name="flow-based-all" code="1"/>
+	<enum name="flow-based-none" code="2"/>
+	<enum name="session-based" code="3"/>
+	<enum name="main-a10-only" code="4"/>
+	</avp>
+
+	<avp name="SN-Subscriber-Acct-Rsp-Action" code="100" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="None" code="0"/>
+	<enum name="No_Early_PDUs" code="1"/>
+	<enum name="Delay_GTP_Response" code="2"/>
+	</avp>
+
+	<avp name="SN-Subscriber-Acct-Start" code="69" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Normal" code="0"/>
+	<enum name="Suppress" code="1"/>
+	</avp>
+
+	<avp name="SN-Subscriber-Acct-Stop" code="71" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Normal" code="0"/>
+	<enum name="Suppress" code="1"/>
+	</avp>
+
+	<avp name="SN-Subscriber-Class" code="219" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Normal_Subscriber" code="0"/>
+	<enum name="Ting_100" code="1"/>
+	<enum name="Ting_500" code="2"/>
+	<enum name="Ting_Buddy" code="3"/>
+	<enum name="Ting_Star" code="4"/>
+	<enum name="Ting_Nolimit_SMS" code="5"/>
+	<enum name="Kids_Locator" code="6"/>
+	<enum name="Ting_2000" code="7"/>
+	<enum name="Handicapped_Welfare" code="8"/>
+	<enum name="Reserved" code="9"/>
+	</avp>
+
+	<avp name="SN-Subscriber-IP-Hdr-Neg-Mode" code="67" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Force" code="0"/>
+	<enum name="Detect" code="1"/>
+	</avp>
+
+	<avp name="SN-Subscriber-IP-TOS-Copy" code="85" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="None" code="0"/>
+	<enum name="Access-Tunnel" code="1"/>
+	<enum name="Data-Tunnel" code="2"/>
+	<enum name="Both" code="3"/>
+	</avp>
+
+	<avp name="SN-Subscriber-Nexthop-Address" code="127" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="SN-Subscriber-No-Interims" code="133" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-Subscriber-Permission" code="20" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="None" code="0"/>
+	<enum name="Simple-IP" code="1"/>
+	<enum name="Mobile-IP" code="2"/>
+	<enum name="Simple-IP-Mobile-IP" code="3"/>
+	<enum name="HA-Mobile-IP" code="4"/>
+	<enum name="Simple-IP-HA-Mobile-IP" code="5"/>
+	<enum name="Mobile-IP-HA-Mobile-IP" code="6"/>
+	<enum name="SIP-MIP-HA-MIP" code="7"/>
+	<enum name="GGSN-PDP-TYPE-IP" code="8"/>
+	<enum name="GGSN-PDP-TYPE-PPP" code="16"/>
+	<enum name="Network-Mobility" code="32"/>
+	<enum name="FA-HA-NEMO" code="38"/>
+	<enum name="All" code="63"/>
+	</avp>
+
+	<avp name="SN-Subscriber-Template-Name" code="158" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Subs-IMSA-Service-Name" code="159" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Subs-VJ-Slotid-Cmp-Neg-Mode" code="221" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="None" code="0"/>
+	<enum name="Receive" code="1"/>
+	<enum name="Transmit" code="2"/>
+	<enum name="Both" code="3"/>
+	</avp>
+
+	<avp name="SN-Tp-Dnlk-Burst-Size" code="76" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Tp-Dnlk-Committed-Data-Rate" code="74" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Tp-Dnlk-Exceed-Action" code="77" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Transmit" code="0"/>
+	<enum name="Drop" code="1"/>
+	<enum name="Lower-IP-Precedence" code="2"/>
+	<enum name="Buffer" code="3"/>
+	<enum name="Transmit-On-Buffer-Full" code="4"/>
+	</avp>
+
+	<avp name="SN-Tp-Dnlk-Peak-Data-Rate" code="75" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Tp-Dnlk-Violate-Action" code="78" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Transmit" code="0"/>
+	<enum name="Drop" code="1"/>
+	<enum name="Lower-IP-Precedence" code="2"/>
+	<enum name="Buffer" code="3"/>
+	<enum name="Transmit-On-Buffer-Full" code="4"/>
+	</avp>
+
+	<avp name="SN-Tp-Uplk-Burst-Size" code="82" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Tp-Uplk-Committed-Data-Rate" code="80" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Tp-Uplk-Exceed-Action" code="83" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Transmit" code="0"/>
+	<enum name="Drop" code="1"/>
+	<enum name="Lower-IP-Precedence" code="2"/>
+	<enum name="Buffer" code="3"/>
+	<enum name="Transmit-On-Buffer-Full" code="4"/>
+	</avp>
+
+	<avp name="SN-Tp-Uplk-Peak-Data-Rate" code="81" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Tp-Uplk-Violate-Action" code="84" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Transmit" code="0"/>
+	<enum name="Drop" code="1"/>
+	<enum name="Lower-IP-Precedence" code="2"/>
+	<enum name="Buffer" code="3"/>
+	<enum name="Transmit-On-Buffer-Full" code="4"/>
+	</avp>
+
+	<avp name="SN-TPO-Policy" code="308" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Traffic-Group" code="161" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-TrafficSelector-Class" code="307" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Tun-Addr-Policy" code="156" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="no-local-alloc-validate" code="0"/>
+	<enum name="local-alloc" code="1"/>
+	<enum name="local-alloc-validate" code="2"/>
+	</avp>
+
+	<avp name="SN-Tunnel-Gn" code="174" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-Tunnel-ISAKMP-Crypto-Map" code="38" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Tunnel-ISAKMP-Secret" code="39" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Tunnel-Load-Balancing" code="27" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="random" code="1"/>
+	<enum name="balanced" code="2"/>
+	<enum name="prioritized" code="3"/>
+	</avp>
+
+	<avp name="SN-Tunnel-Password" code="26" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-Unclassify-List-Name" code="132" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-User-Privilege" code="313" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Administrative" code="6"/>
+	<enum name="NAS_Prompt" code="7"/>
+	<enum name="Inspector" code="19650516"/>
+	<enum name="Security_Admin" code="19660618"/>
+	</avp>
+
+	<avp name="SN-Virtual-APN-Name" code="94" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-Visiting-Behavior" code="120" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Visiting-Profile" code="117" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-Visiting-Sub-Use-GGSN" code="107" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Deny" code="0"/>
+	<enum name="Accept" code="1"/>
+	</avp>
+
+	<avp name="SN-Voice-Push-List-Name" code="131" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-VPN-ID" code="1" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SN-VPN-Name" code="2" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="SN-WiMAX-Auth-Only" code="306" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="Unsigned32"/>
+	<enum name="Disabled" code="0"/>
+	<enum name="Enabled" code="1"/>
+	</avp>
+
+	<avp name="SN-WLAN-AP-Identifier" code="319" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="SN-WLAN-UE-Identifier" code="320" vendor-id="Starent" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+	<type type-name="OctetString"/>
+	</avp>
+
+</vendor>

--- a/codec-diameter-codegen/src/main/resources/diameter/TGPP.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/TGPP.xml
@@ -1,0 +1,1635 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<application id="16777223" name="3GPP Gmb" uri="http://www.3gpp.org/DynaReport/29061.htm">
+	<!--
+		This secion/application contains AVPs whose codes collide with other 3GPP AVPs.
+		The modern (non-conflicting) Gmb AVPs are in the SGmb application/section below.
+
+		If you want to use the Cx/Dx AVPs comment the below AVPs (1-27) out and uncomment
+		the Cx/Dx AVPs.
+	-->
+
+	<avp name="3GPP-IMSI" code="1" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="3GPP-Charging-Id" code="2" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-PDP-Type" code="3" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+		<enum name="IPv4" code="0"/>
+		<enum name="PPP" code="1"/>
+		<enum name="IPv6" code="2"/>
+		<enum name="IPv4v6" code="3"/>
+	</avp>
+	<avp name="3GPP-CG-Address" code="4" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="IPAddress"/>
+	</avp>
+	<avp name="3GPP-GPRS-Negotiated-QoS-Profile" code="5" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="3GPP-SGSN-Address" code="6" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="IPAddress"/>
+	</avp>
+	<avp name="3GPP-GGSN-Address" code="7" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="IPAddress"/>
+	</avp>
+	<avp name="3GPP-IMSI-MCC-MNC" code="8" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="3GPP-GGSN-MCC-MNC" code="9" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="3GPP-NSAPI" code="10" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="3GPP-Session-Stop-Indicator" code="11" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="3GPP-Selection-Mode" code="12" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="3GPP-Charging-Characteristics" code="13" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="3GPP-CG-IPv6-Address" code="14" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-SGSN-IPv6-Address" code="15" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-GGSN-IPv6-Address" code="16" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-IPv6-DNS-Server" code="17" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-SGSN-MCC-MNC" code="18" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="3GPP-Teardown-Indicator" code="19" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-IMEISV" code="20" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-RAT-Type" code="21" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-User-Location-Info" code="22" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-MS-TimeZone" code="23" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-CAMEL-Charging-Info" code="24" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-Packet-Filter" code="25" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-Negotiated-DSCP" code="26" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-Allocate-IP-Type" code="27" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<!-- Note: The AVP codes from 1 to 255 are reserved for backwards compatibility with 3GPP RADIUS Vendor Specific
+	     Attributes (See TS 29.061 [13]) -->
+	<!--
+	    <avp name="Reserved" code="28" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp> -->
+	    <avp name="3GPP-TWAN-Identifier" code="29" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	<!--
+	    <avp name="Reserved" code="30" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="31" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="32" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="33" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="34" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="35" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="36" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="37" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="38" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="39" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="40" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="41" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="42" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="43" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="44" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="45" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="46" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="47" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="48" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="49" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="50" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="51" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="52" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="53" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="54" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="55" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="56" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="57" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="58" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	    <avp name="Reserved" code="59" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		    <type type-name="OctetString"/>
+	    </avp>
+	-->
+
+	<!-- ************************** IMS Cx Dx AVPS ********************* -->
+<!--
+	These AVPs collide(share AVP code number) with other 3GPP AVPs (above).
+	Uncomment 1 - 28 here and comment out the ones above if you want to use these.
+	<avp name="Visited-Network-Identifier-OBSOLETE-CN25" code="1" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Public-Identity-OBSOLETE-CN25" code="2" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Server-Name-OBSOLETE-CN25" code="3" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Server-Capabilities-OBSOLETE-CN25" code="4" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Mandatory-Capability"/>
+			<gavp name="Optional-Capability"/>
+			<gavp name="Server-Name"/>
+		</grouped>
+	</avp>
+	<avp name="Mandatory-Capability-OBSOLETE-CN25" code="5" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Optional-Capability-OBSOLETE-CN25" code="6" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="User-Data-OBSOLETE-CN25" code="7" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="SIP-Number-Auth-Items-OBSOLETE-CN25" code="8" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="SIP-Authentication-Scheme-OBSOLETE-CN25" code="9" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="SIP-Authenticate-OBSOLETE-CN25" code="10" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="SIP-Authorization-OBSOLETE-CN25" code="11" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="SIP-Authentication-Context-OBSOLETE-CN25" code="12" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="SIP-Auth-Data-Item-OBSOLETE-CN25" code="13" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="SIP-Item-Number-OBSOLETE-CN25"/>
+			<gavp name="SIP-Authentication-Scheme-OBSOLETE-CN25"/>
+			<gavp name="SIP-Authenticate-OBSOLETE-CN25"/>
+			<gavp name="SIP-Authorization-OBSOLETE-CN25"/>
+			<gavp name="SIP-Authentication-Context-OBSOLETE-CN25"/>
+			<gavp name="Confidentiality-Key-OBSOLETE-CN25"/>
+			<gavp name="Integrity-Key-OBSOLETE-CN25"/>
+		</grouped>
+	</avp>
+	<avp name="SIP-Item-Number-OBSOLETE-CN25" code="14" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Server-Assignment-Type-OBSOLETE-CN25" code="15" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="No-Assignment" code="0"/>
+		<enum name="Registration" code="1"/>
+		<enum name="Re-Registration" code="2"/>
+		<enum name="Unregistered-User" code="3"/>
+		<enum name="Timeout-Deregistration" code="4"/>
+		<enum name="User-Deregistration" code="5"/>
+		<enum name="Timeout-Deregistration-Store-Server-Name" code="6"/>
+		<enum name="User-Deregistration-Store-Server-Name" code="7"/>
+		<enum name="Administrative-Deregistration" code="8"/>
+		<enum name="Authentication-Failure" code="9"/>
+		<enum name="Authentication-Timeout" code="10"/>
+		<enum name="Deregistration-Too-Much-Data" code="11"/>
+	</avp>
+	<avp name="Deregistration-Reason-OBSOLETE-CN25" code="16" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Reason-Code"/>
+			<gavp name="Reason-Info"/>
+		</grouped>
+	</avp>
+	<avp name="Reason-Code-OBSOLETE-CN25" code="17" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="Permanent-Termination" code="0"/>
+		<enum name="New-Server-Assigned" code="1"/>
+		<enum name="Server-Change" code="2"/>
+		<enum name="Remove-S-CSCF" code="3"/>
+	</avp>
+	<avp name="Reason-Info-OBSOLETE-CN25" code="18" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Charging-Information-OBSOLETE-CN25" code="19" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Primary-Event-Charging-Function-Name"/>
+			<gavp name="Secondary-Event-Charging-Function-Name"/>
+			<gavp name="Primary-Charging-Collection-Function-Name"/>
+			<gavp name="Secondary-Charging-Collection-Function-Name"/>
+		</grouped>
+	</avp>
+	<avp name="Primary-Event-Charging-Function-Name-OBSOLETE-CN25" code="20" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="DiameterURI"/>
+	</avp>
+	<avp name="Secondary-Event-Charging-Function-Name-OBSOLETE-CN25" code="21" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="DiameterURI"/>
+	</avp>
+	<avp name="Primary-Charging-Collection-Function-Name-OBSOLETE-CN25" code="22" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="DiameterURI"/>
+	</avp>
+	<avp name="Secondary-Charging-Collection-Function-Name-OBSOLETE-CN25" code="23" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="DiameterURI"/>
+	</avp>
+	<avp name="User-Authorization-Type-OBSOLETE-CN25" code="24" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="Registration" code="0"/>
+		<enum name="De-Registration" code="1"/>
+		<enum name="Registration-And-Capabilities" code="2"/>
+	</avp>
+	<avp name="User-Data-Request-Type-OBSOLETE-CN25" code="25" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="Complete-Profile" code="0"/>
+		<enum name="Registered-Profile" code="1"/>
+		<enum name="Unregistered-Profile" code="2"/>
+	</avp>
+	<avp name="User-Data-Already-Available-OBSOLETE-CN25" code="26" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="User-Data-Not-Available" code="0"/>
+		<enum name="User-Data-Already-Available" code="1"/>
+	</avp>
+	<avp name="Confidentiality-Key-OBSOLETE-CN25" code="27" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Integrity-Key-OBSOLETE-CN25" code="28" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+-->
+	<!-- ************************ END IMS Cx Dx AVPS ******************* -->
+</application>	<!-- 3GPP Gmb -->
+
+
+<!-- The AVP codes from 500 to 599 are reserved for TS 29.209, 29.211, and 29.229. -->
+<application id="16777222" name="3GPP Gq" uri="http://www.3gpp.org/DynaReport/29209.htm">
+	<!-- ETSI TS 129 209 V6.7.0 (2007-06) -->
+
+	<avp name="Abort-Cause" code="500" mandatory="must" vendor-bit="must" may-encrypt="yes" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+		<enum name="BEARER_RELEASED" code="0"/>
+		<enum name="INSUFFICIENT_SERVER_RESOURCES" code="1"/>
+		<enum name="INSUFFICIENT_BEARER_RESOURCES" code="2"/>
+		<enum name="PS_TO_CS_HANDOVER" code="3"/>
+		<enum name="SPONSORED_DATA_CONNECTIVITY_ DISALLOWED" code="4"/>
+	</avp>
+
+	<avp name="Access-Network-Charging-Address" code="501" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+		<type type-name="IPAddress"/>
+	</avp>
+
+	<avp name="Access-Network-Charging-Identifier" code="502" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Access-Network-Charging-Identifier-Value"/>
+			<gavp name="Flows"/>
+		</grouped>
+	</avp>
+
+	<avp name="Access-Network-Charging-Identifier-Value" code="503" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="AF-Application-Identifier" code="504" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="AF-Charging-Identifier" code="505" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Authorization-Token" code="506" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<avp name="Flow-Description" code="507" vendor-id="TGPP" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must">
+		<type type-name="IPFilterRule"/>
+	</avp>
+
+	<avp name="Flow-Grouping" code="508" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Flows"/>
+		</grouped>
+	</avp>
+
+	<avp name="Flow-Number" code="509" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Flows" code="510" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Media-Component-Number"/>
+			<gavp name="Flow-Number"/>
+			<gavp name="Final-Unit-Action"/>
+		</grouped>
+	</avp>
+
+	<avp name="Flow-Status" code="511" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="ENABLED-UPLINK" code="0"/>
+		<enum name="ENABLED-DOWNLINK" code="1"/>
+		<enum name="ENABLED" code="2"/>
+		<enum name="DISABLED" code="3"/>
+		<enum name="REMOVED" code="4"/>
+	</avp>
+
+	<avp name="Flow-Usage" code="512" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="NO_INFORMATION" code="0"/>
+		<enum name="RTCP" code="1"/>
+		<enum name="AF_SIGNALLING" code="2"/>
+	</avp>
+
+	<avp name="Specific-Action" code="513" mandatory="must" protected="may" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<!--ETSI TS 129 209 V6.7.0 (2007-06)-->
+		<enum name="SERVICE_INFORMATION_REQUEST (now void)" code="0"/>
+		<enum name="CHARGING_CORRELATION_EXCHANGE" code="1"/>
+		<enum name="INDICATION_OF_LOSS_OF_BEARER" code="2"/>
+		<enum name="INDICATION_OF_RECOVERY_OF_BEARER" code="3"/>
+		<enum name="INDICATION_OF_RELEASE_OF_BEARER" code="4"/>
+		<enum name="INDICATION_OF_ESTABLISHMENT_OF_BEARER (now void)" code="5"/>
+		<!-- ETSI ES 283 026 V2.4.1 (2008-11) defines these 2 events:
+		INDICATION_OF_SUBSCRIBER_DETACHMENT - 6
+		INDICATION_OF_RESERVATION_EXPIRATION - 7
+
+		But they are superceded by 3GPP 29.214 and ETSI 129 214 V10 with the
+		values below...
+		-->
+		<enum name="IP-CAN_CHANGE" code="6"/>
+		<enum name="INDICATION_OF_OUT_OF_CREDIT" code="7"/>
+		<!-- From 3GPP 29.214 v11.6.0: -->
+		<enum name="INDICATION_OF_SUCCESSFUL_RESOURCES_ALLOCATION" code="8"/>
+		<enum name="INDICATION_OF_FAILED_RESOURCES_ALLOCATION" code="9"/>
+		<enum name="INDICATION_OF_LIMITED_PCC_DEPLOYMENT" code="10"/>
+		<enum name="USAGE_REPORT" code="11"/>
+		<enum name="ACCESS_NETWORK_INFO_REPORT" code="12"/>
+		<enum name="INDICATION_OF_RECOVERY_FROM_LIMITED_PCC_DEPLOYMENT" code="13"/>
+		<enum name="INDICATION_OF_ACCESS_NETWORK_INFO_REPORTING_FAILURE" code="14"/>
+		<enum name="INDICATION_OF_TRANSFER_POLICY_EXPIRED" code="15"/>
+	</avp>
+
+	<avp name="Max-Requested-Bandwidth-DL" code="515" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Max-Requested-Bandwidth-UL" code="516" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Media-Component-Description" code="517" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Media-Component-Number"/>
+			<gavp name="Media-Sub-Component"/>
+			<gavp name="AF-Application-Identifier"/>
+			<gavp name="Media-Type"/>
+			<gavp name="Max-Requested-Bandwidth-UL"/>
+			<gavp name="Max-Requested-Bandwidth-DL"/>
+			<gavp name="Flow-Status"/>
+			<gavp name="RS-Bandwidth"/>
+			<gavp name="RR-Bandwidth"/>
+			<gavp name="Codec-Data"/>
+			<!-- ETSI ES 283 026 V1.6.0 (2008-02) -->
+			<gavp name="Reservation-Priority"/>
+			<gavp name="Reservation-Class"/>
+			<gavp name="Transport-Class"/>
+			<gavp name="Media-Authorization-Context-Id"/>
+		</grouped>
+	</avp>
+
+	<avp name="Media-Component-Number" code="518" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="Media-Sub-Component" code="519" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Flow-Number"/>
+			<gavp name="Flow-Description"/>
+			<gavp name="Flow-Status"/>
+			<gavp name="Flow-Usage"/>
+			<gavp name="Max-Requested-Bandwidth-UL"/>
+			<gavp name="Max-Requested-Bandwidth-DL"/>
+		</grouped>
+	</avp>
+
+	<avp name="Media-Type" code="520" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="AUDIO" code="0"/>
+		<enum name="VIDEO" code="1"/>
+		<enum name="DATA" code="2"/>
+		<enum name="APPLICATION" code="3"/>
+		<enum name="CONTROL" code="4"/>
+		<enum name="TEXT" code="5"/>
+		<enum name="MESSAGE" code="6"/>
+		<enum name="OTHER" code="4294967295"/>
+	</avp>
+
+	<avp name="RR-Bandwidth" code="521" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="RS-Bandwidth" code="522" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="SIP-Forking-Indication" code="523" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="SINGLE_DIALOGUE" code="0"/>
+		<enum name="SEVERAL_DIALOGUES" code="1"/>
+	</avp>
+</application>	<!-- 3GPP Gq -->
+
+
+<!-- The AVP codes from 500 to 599 are reserved for TS 29.209, 29.211, and 29.229. -->
+<application id="16777236" name="3GPP Rx" uri="http://www.3gpp.org/DynaReport/29214.htm">
+	<avp name="Codec-Data" code="524" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="UTF8String" />
+	</avp>
+
+	<avp name="Service-URN" code="525" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString" />
+	</avp>
+
+	<avp name="Acceptable-Service-Info" code="526" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Media-Component-Description"/>
+			<gavp name="Max-Requested-Bandwidth-UL"/>
+			<gavp name="Max-Requested-Bandwidth-DL"/>
+		</grouped>
+	</avp>
+
+	<avp name="Service-Info-Status" code="527" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated" />
+		<enum name="FINAL_SERVICE_INFORMATION" code="0"/>
+		<enum name="PRELIMINARY_SERVICE_INFORMATION" code="1"/>
+	</avp>
+	<avp name="MPS-Identifier" code="528" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString" />
+	</avp>
+	<avp name="AF-Signalling-Protocol" code="529" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated" />
+		<enum name="NO_INFORMATION" code="0" />
+		<enum name="SIP" code="1" />
+	</avp>
+	<avp name="Sponsored-Connectivity-Data" code="530" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Sponsor-Identity"/>
+			<gavp name="Application-Service-Provider-Identity"/>
+			<gavp name="Granted-Service-Unit"/>
+			<gavp name="Used-Service-Unit"/>
+		</grouped>
+	</avp>
+	<avp name="Sponsor-Identity" code="531" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="UTF8String" />
+	</avp>
+	<avp name="Application-Service-Provider-Identity" code="532" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="UTF8String" />
+	</avp>
+	<avp name="Rx-Request-Type" code="533" mandatory="may"  may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+		<enum name="INITIAL_REQUEST" code="0"/>
+		<enum name="UPDATE_REQUEST" code="1"/>
+		<enum name="PCSCF_RESTORATION" code="2"/>
+	</avp>
+	<avp name="Min-Requested-Bandwidth-DL" code="534" mandatory="may"  may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Min-Requested-Bandwidth-UL" code="535" mandatory="may" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Required-Access-Info" code="536" mandatory="may" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+		<enum name="USER_LOCATION" code="0"/>
+		<enum name="MS_TIME_ZONE" code="1"/>
+	</avp>
+	<avp name="IP-Domain-Id" code="537" mandatory="may" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="GCS-Identifier" code="538" mandatory="may"  may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Sharing-Key-DL" code="539" mandatory="may"  may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Sharing-Key-UL" code="540" mandatory="may"  may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Retry-Interval" code="541" mandatory="may"  may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="MCPTT-Identifier" code="547" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Content-Version" code="552" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="Extended-Max-Requested-BW-DL" code="554" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Extended-Max-Requested-BW-UL" code="555" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Extended-Max-Supported-BW-DL" code="556" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Extended-Max-Supported-BW-UL" code="557" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Extended-Min-Desired-BW-DL" code="558" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Extended-Min-Desired-BW-UL" code="559" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Extended-Min-Requested-BW-DL" code="560" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Extended-Min-Requested-BW-UL" code="561" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="MCVideo-Identifier" code="562" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+</application>	<!-- 3GPP Rx -->
+
+<!-- The AVP codes from 600 to 699 are reserved for TS 29.229. -->
+<application id="16777216" name="3GPP Cx" uri="http://www.3gpp.org/DynaReport/29229.htm">
+
+	<!-- IMS Cx Dx Application -->
+	<command name="User-Authorization"	code="300" vendor-id="TGPP"/>
+	<command name="Server-Assignment"	code="301" vendor-id="TGPP"/>
+	<command name="Location-Info"		code="302" vendor-id="TGPP"/>
+	<command name="Multimedia-Auth"		code="303" vendor-id="TGPP"/>
+	<command name="Registration-Termination" code="304" vendor-id="TGPP"/>
+	<command name="Push-Profile"		code="305" vendor-id="TGPP"/>
+
+	<!-- ************************** IMS Cx Dx AVPS 3GPP TS 29.229 version 6.7.0 Release 6 ********************* -->
+	<avp name="Visited-Network-Identifier" code="600" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Public-Identity" code="601" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Server-Name" code="602" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Server-Capabilities" code="603" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Mandatory-Capability"/>
+			<gavp name="Optional-Capability"/>
+			<gavp name="Server-Name"/>
+		</grouped>
+	</avp>
+	<avp name="Mandatory-Capability" code="604" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Optional-Capability" code="605" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Cx-User-Data" code="606" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-SIP-Number-Auth-Items" code="607" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="3GPP-SIP-Authentication-Scheme" code="608" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="3GPP-SIP-Authenticate" code="609" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-SIP-Authorization" code="610" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="SIP-Authentication-Context" code="611" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="3GPP-SIP-Auth-Data-Item" code="612" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="SIP-Item-Number"/>
+			<gavp name="3GPP-SIP-Authentication-Scheme"/>
+			<gavp name="3GPP-SIP-Authenticate"/>
+			<gavp name="3GPP-SIP-Authorization"/>
+			<gavp name="SIP-Authentication-Context"/>
+			<gavp name="Confidentiality-Key"/>
+			<gavp name="Integrity-Key"/>
+			<gavp name="SIP-Digest-Authenticate"/>
+			<gavp name="Framed-IP-Address"/>
+			<gavp name="Framed-IPv6-Prefix"/>
+			<gavp name="Framed-Interface-Id"/>
+			<gavp name="Line-Identifier"/>
+			<gavp name="Authentication-Method"/>
+			<gavp name="Authentication-Information-SIM"/>
+			<gavp name="Authorization-Information-SIM"/>
+		</grouped>
+	</avp>
+	<avp name="3GPP-SIP-Item-Number" code="613" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Server-Assignment-Type" code="614" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="NO_ASSIGNMENT" code="0"/>
+		<enum name="REGISTRATION" code="1"/>
+		<enum name="RE_REGISTRATION" code="2"/>
+		<enum name="UNREGISTERED_USER" code="3"/>
+		<enum name="TIMEOUT_DEREGISTRATION" code="4"/>
+		<enum name="USER_DEREGISTRATION" code="5"/>
+		<enum name="TIMEOUT_DEREGISTRATION_STORE_SERVER_NAME" code="6"/>
+		<enum name="USER_DEREGISTRATION_STORE_SERVER_NAME" code="7"/>
+		<enum name="ADMINISTRATIVE_DEREGISTRATION" code="8"/>
+		<enum name="AUTHENTICATION_FAILURE" code="9"/>
+		<enum name="AUTHENTICATION_TIMEOUT" code="10"/>
+		<enum name="DEREGISTRATION_TOO_MUCH_DATA" code="11"/>
+		<enum name="AAA_USER_DATA_REQUEST" code="12"/>
+		<enum name="PGW_UPDATE" code="13"/>
+		<enum name="RESTORATION" code="14"/>
+	</avp>
+	<avp name="Deregistration-Reason" code="615" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Reason-Code"/>
+			<gavp name="Reason-Info"/>
+		</grouped>
+	</avp>
+	<avp name="Reason-Code" code="616" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="PERMANENT_TERMINATION" code="0"/>
+		<enum name="NEW_SERVER_ASSIGNED" code="1"/>
+		<enum name="SERVER_CHANGE" code="2"/>
+		<enum name="REMOVE_S-CSCF" code="3"/>
+	</avp>
+	<avp name="Reason-Info" code="617" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Charging-Information" code="618" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Primary-Event-Charging-Function-Name"/>
+			<gavp name="Secondary-Event-Charging-Function-Name"/>
+			<gavp name="Primary-Charging-Collection-Function-Name"/>
+			<gavp name="Secondary-Charging-Collection-Function-Name"/>
+		</grouped>
+	</avp>
+	<avp name="Primary-Event-Charging-Function-Name" code="619" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="DiameterURI"/>
+	</avp>
+	<avp name="Secondary-Event-Charging-Function-Name" code="620" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="DiameterURI"/>
+	</avp>
+	<avp name="Primary-Charging-Collection-Function-Name" code="621" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="DiameterURI"/>
+	</avp>
+	<avp name="Secondary-Charging-Collection-Function-Name" code="622" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="DiameterURI"/>
+	</avp>
+	<avp name="User-Authorization-Type" code="623" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="REGISTRATION" code="0"/>
+		<enum name="DE_REGISTRATION" code="1"/>
+		<enum name="REGISTRATION_AND_CAPABILITIES" code="2"/>
+	</avp>
+	<avp name="User-Data-Already-Available" code="624" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="USER_DATA_NOT_AVAILABLE" code="0"/>
+		<enum name="USER_DATA_ALREADY_AVAILABLE" code="1"/>
+	</avp>
+	<avp name="Confidentiality-Key" code="625" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Integrity-Key" code="626" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="User-Data-Request-Type-OBSOLETE" code="627" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="Complete-Profile" code="0"/>
+		<enum name="Registered-Profile" code="1"/>
+		<enum name="Unregistered-Profile" code="2"/>
+	</avp>
+	<avp name="Supported-Features" code="628" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<grouped>
+			<gavp name="Vendor-Id"/>
+			<gavp name="Feature-List-ID"/>
+			<gavp name="Feature-List"/>
+		</grouped>
+	</avp>
+	<avp name="Feature-List-ID" code="629" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Feature-List" code="630" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Supported-Applications" code="631" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<grouped>
+			<gavp name="Auth-Application-Id"/>
+			<gavp name="Acct-Application-Id"/>
+			<gavp name="Vendor-Specific-Application-Id"/>
+		</grouped>
+	</avp>
+	<avp name="Associated-Identities" code="632" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<grouped>
+			<gavp name="User-Name"/>
+		</grouped>
+	</avp>
+	<avp name="Originating-Request" code="633" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="ORIGINATING" code="0"/>
+	</avp>
+	<avp name="Wildcarded-PSI" code="634" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="SIP-Digest-Authenticate" code="635" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<grouped>
+			<gavp name="Digest-Realm"/>
+			<gavp name="Digest-Algorithm"/>
+			<gavp name="Digest-Qop"/>
+			<gavp name="Digest-HA1"/>
+		</grouped>
+	</avp>
+	<avp name="Wildcarded-IMPU" code="636" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="UAR-Flags" code="637" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Loose-Route-Indication" code="638" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="LOOSE_ROUTE_NOT_REQUIRED" code="0"/>
+		<enum name="LOOSE_ROUTE_REQUIRED" code="1"/>
+	</avp>
+	<avp name="SCSCF-Restoration-Info" code="639" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<grouped>
+			<gavp name="User-Name"/>
+			<gavp name="Restoration-Info"/>
+		</grouped>
+	</avp>
+	<avp name="Path" code="640" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Contact" code="641" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Subscription-Info" code="642" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<grouped>
+			<gavp name="Call-ID-SIP-Header"/>
+			<gavp name="From-SIP-Header"/>
+			<gavp name="To-SIP-Header"/>
+			<gavp name="Record-Route"/>
+			<gavp name="Contact"/>
+		</grouped>
+	</avp>
+	<avp name="Call-ID-SIP-Header" code="643" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="From-SIP-Header" code="644" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="To-SIP-Header" code="645" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Record-Route" code="646" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Associated-Registered-Identities" code="647" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<grouped>
+			<gavp name="User-Name"/>
+		</grouped>
+	</avp>
+	<avp name="Multiple-Registration-Indication" code="648" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="NOT_MULTIPLE_REGISTRATION" code="0"/>
+		<enum name="MULTIPLE_REGISTRATION" code="1"/>
+	</avp>
+	<avp name="Restoration-Info" code="649" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<grouped>
+			<gavp name="Path"/>
+			<gavp name="Contact"/>
+			<gavp name="Subscription-Info"/>
+		</grouped>
+	</avp>
+	<avp name="Session-Priority" code="650" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="PRIORITY-0" code="0"/>
+		<enum name="PRIORITY-1" code="1"/>
+		<enum name="PRIORITY-2" code="2"/>
+		<enum name="PRIORITY-3" code="3"/>
+		<enum name="PRIORITY-4" code="4"/>
+	</avp>
+	<avp name="Identity-with-Emergency-Registration" code="651" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<grouped>
+			<gavp name="User-Name"/>
+			<gavp name="Public-Identity"/>
+			<gavp name="Restoration-Info"/>
+		</grouped>
+	</avp>
+  <avp name="Priviledged-Sender-Indication" code="652" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+    <type type-name="Enumerated"/>
+    <enum name="NOT_PRIVILEDGED_SENDER" code="0"/>
+    <enum name="PRIVILEDGED_SENDER" code="1"/>
+  </avp>
+  <avp name="LIA-Flags" code="653" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+    <type type-name="Unsigned32"/>
+  </avp>
+  <avp name="Initial-CSeq-Sequence-Number" code="654" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+    <type type-name="Unsigned32"/>
+  </avp>
+  <avp name="SAR-Flags" code="655" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+    <type type-name="Unsigned32"/>
+  </avp>
+  <avp name="Allowed-WAF-WWSF-Identities" code="656" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+    <grouped>
+      <gavp name="WebRTC-Authentication-Function-Name"/>
+      <gavp name="WebRTC-Web-Server-Function-Name"/>
+    </grouped>
+  </avp>
+  <avp name="WebRTC-Authentication-Function-Name" code="657" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+    <type type-name="UTF8String"/>
+  </avp>
+  <avp name="WebRTC-Web-Server-Function-Name" code="658" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+    <type type-name="UTF8String"/>
+  </avp>
+</application>
+
+
+<!-- The AVP codes from 700 to 799 are reserved for TS 29.329. -->
+<application id="16777217" name="3GPP Sh" uri="http://www.3gpp.org/DynaReport/29329.htm">
+	<!-- 3GPP TS 29.329 version 11.6.0 Release 11, ETSI TS 129 329 V11.6.0 (2013-04)-->
+
+	<!-- 3GPP Sh Application -->
+	<command name="User-Data"			code="306" vendor-id="TGPP"/>
+	<command name="Profile-Update"			code="307" vendor-id="TGPP"/>
+	<command name="Subscribe-Notifications"		code="308" vendor-id="TGPP"/>
+	<command name="Push-Notification"		code="309" vendor-id="TGPP"/>
+
+	<avp name="User-Identity" code="700" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<grouped>
+			<gavp name="Public-Identity"/>
+			<gavp name="MSISDN"/>
+		</grouped>
+	</avp>
+	<avp name="MSISDN" code="701" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Sh-User-Data" code="702" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Data-Reference" code="703" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="RepositoryData" code="0"/>
+		<enum name="Undefined" code="1"/>
+		<enum name="Undefined" code="2"/>
+		<enum name="Undefined" code="3"/>
+		<enum name="Undefined" code="4"/>
+		<enum name="Undefined" code="5"/>
+		<enum name="Undefined" code="6"/>
+		<enum name="Undefined" code="7"/>
+		<enum name="Undefined" code="8"/>
+		<enum name="Undefined" code="9"/>
+		<enum name="IMSPublicIdentity" code="10"/>
+		<enum name="IMSUserState" code="11"/>
+		<enum name="S-CSCFName" code="12"/>
+		<enum name="InitialFilterCriteria" code="13"/>
+		<enum name="LocationInformation" code="14"/>
+		<enum name="UserState" code="15"/>
+		<enum name="ChargingInformation" code="16"/>
+		<enum name="MSISDN" code="17"/>
+		<enum name="PSIActivation" code="18"/>
+		<enum name="DSAI" code="19"/>
+		<enum name="Reserved" code="20"/>
+		<enum name="ServiceLevelTraceInfo" code="21"/>
+		<enum name="IPAddressSecureBindingInformation" code="22"/>
+		<enum name="ServicePriorityLevel" code="23"/>
+		<enum name="SMSRegistrationInfo" code="24"/>
+		<enum name="UEReachabilityForIP" code="25"/>
+		<enum name="TADSinformation" code="26"/>
+		<enum name="STN-SR" code="27"/>
+		<enum name="UE-SRVCC-Capability" code="28"/>
+		<enum name="ExtendedPriority" code="29"/>
+		<enum name="CSRN" code="30"/>
+		<enum name="ReferenceLocationInformation" code="31"/>
+	</avp>
+	<avp name="Service-Indication" code="704" mandatory="must" vendor-bit="mustnot" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Subs-Req-Type" code="705" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="Subscribe" code="0"/>
+		<enum name="Unsubscribe" code="1"/>
+	</avp>
+	<avp name="Requested-Domain" code="706" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="CS-Domain" code="0"/>
+		<enum name="PS-Domain" code="1"/>
+	</avp>
+	<avp name="Current-Location" code="707" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="DoNotNeedInitiateActiveLocationRetrieval" code="0"/>
+		<enum name="InitiateActiveLocationRetrieval" code="1"/>
+	</avp>
+	<avp name="Identity-Set" code="708" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="ALL_IDENTITIES" code="0"/>
+		<enum name="REGISTERED_IDENTITIES" code="1"/>
+		<enum name="IMPLICIT_IDENTITIES" code="2"/>
+		<enum name="ALIAS_IDENTITIES" code="3"/>
+	</avp>
+	<avp name="Expiry-Time" code="709" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Time"/>
+	</avp>
+	<avp name="Send-Data-Indication" code="710" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="USER_DATA_NOT_REQUESTED" code="0"/>
+		<enum name="USER_DATA_REQUESTED" code="1"/>
+	</avp>
+	<avp name="DSAI-Tag" code="711" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="One-Time-Notification" code="712" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+		<enum name="ONE_TIME_NOTIFICATION_REQUESTED" code="0"/>
+	</avp>
+	<avp name="Requested-Nodes" code="713" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="MME" code="1"/>
+		<enum name="SGSN" code="2"/>
+		<enum name="MME,SGSN" code="3"/>
+	</avp>
+	<avp name="Serving-Node-Indication" code="714" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="ONLY_SERVING_NODES_REQUIRED" code="0"/>
+	</avp>
+	<avp name="Repository-Data-ID" code="715" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<grouped>
+		<gavp name="Service-Indication"/>
+		<gavp name="Sequence-Number"/>
+		</grouped>
+	</avp>
+	<avp name="Sequence-Number" code="716" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Pre-paging-Supported" code="717" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="PREPAGING_NOT_SUPPORTED" code="0"/>
+		<enum name="PREPAGING_SUPPORTED" code="1"/>
+	</avp>
+	<avp name="Local-Time-Zone-Indication" code="718" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="ONLY_LOCAL_TIME_ZONE_REQUESTED" code="0"/>
+		<enum name="LOCAL_TIME_ZONE_WITH_LOCATION_INFO_REQUESTED" code="1"/>
+	</avp>
+	<avp name="UDR-Flags" code="719" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="no">
+		<type type-name="Enumerated"/>
+		<enum name="Location-Information-EPS-Supported" code="1"/>
+		<enum name="RAT-Type-Requested" code="2"/>
+		<!-- <enum name="Location-Information-EPS-Supported,RAT-Type-Requested" code="3"/> -->
+	</avp>
+	<!--
+	720 Call-Reference-Info Grouped
+	721 Call-Reference-Number OctetString
+	722 AS-Number OctetString
+	-->
+</application>	<!-- 3GPP Sh -->
+
+<!-- Note: This section has both SGmb and Gmb AVPs -->
+<!-- The AVP codes from 900 to 999 are reserved for TS 29.061. -->
+<application id="16777292" name="3GPP SGmb" uri="http://www.3gpp.org/DynaReport/29061.htm">
+	<avp name="TMGI" code="900" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Required-MBMS-Bearer-Capabilities" code="901" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="MBMS-StartStop-Indication" code="902" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+		<enum name="START" code="0"/>
+		<enum name="STOP" code="1"/>
+		<enum name="UPDATE" code="2"/>
+	</avp>
+	<avp name="MBMS-Service-Area" code="903" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MBMS-Session-Duration" code="904" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Alternative-APN" code="905" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="MBMS-Service-Type" code="906" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+		<enum name="MULTICAST" code="0"/>
+		<enum name="BROADCAST" code="1"/>
+	</avp>
+	<avp name="MBMS-2G-3G-Indicator" code="907" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+		<enum name="2G" code="0"/>
+		<enum name="3G" code="1"/>
+		<enum name="2G-AND-3G" code="2"/>
+	</avp>
+	<avp name="MBMS-Session-Identity" code="908" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="RAI" code="909" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Additional-MBMS-Trace-Info" code="910" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MBMS-Time-To-Data-Transfer" code="911" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MBMS-Session-Repetition-Number" code="912" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MBMS-Required-QoS" code="913" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="MBMS-Counting-Information" code="914" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+		<enum name="COUNTING-NOT-APPLICABLE" code="0"/>
+		<enum name="COUNTING-APPLICABLE" code="1"/>
+	</avp>
+	<avp name="MBMS-User-Data-Mode-Indication" code="915" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+		<enum name="Unicast" code="0"/>
+		<enum name="Multicast and Unicast" code="1"/>
+	</avp>
+	<avp name="MBMS-GGSN-Address" code="916" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MBMS-GGSN-IPv6-Address" code="917" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MBMS-BMSC-SSM-IP-Address" code="918" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MBMS-BMSC-SSM-IPv6-Address" code="919" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MBMS-Flow-Identifier" code="920" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="CN-IP-Multicast-Distribution" code="921" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+		<enum name="NO-IP-MULTICAST" code="0"/>
+		<enum name="IP-MULTICAST" code="1"/>
+	</avp>
+	<avp name="MBMS-HC-Indicator" code="922" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+		<enum name="uncompressed-header" code="0"/>
+		<enum name="compressed-header" code="1"/>
+	</avp>
+	<avp name="MBMS-Access-Indicator" code="923" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+		<enum name="UTRAN" code="0"/>
+		<enum name="E-UTRAN" code="1"/>
+		<enum name="UTRAN-AND-E-UTRAN" code="2"/>
+	</avp>
+	<avp name="MBMS-GW-SSM-IP-Address" code="924" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="IPAddress"/>
+	</avp>
+	<avp name="MBMS-GW-SSM-IPv6-Address" code="925" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MBMS-BMSC-SSM-UDP-Port" code="926" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MBMS-GW-UDP-Port" code="927" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MBMS-GW-UDP-Port-Indicator" code="928" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+		<enum name="UDP-PORT-REQUIRED" code="1"/>
+	</avp>
+	<avp name="MBMS-Data-Transfer-Start" code="929" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="MBMS-Data-Transfer-Stop" code="930" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<!--
+	Note: The AVP codes from 900 to 999 are reserved for TS 29.061
+	-->
+</application>	<!-- 3GPP SGmb -->
+
+<!-- The AVP codes from 2200 to 2299 are reserved for TS 29.061. -->
+<application id="16777267" name="3GPP S9" uri="http://www.3gpp.org/DynaReport/29061.htm">
+	<avp name="Subsession-Decision-Info" code="2200" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Subsession-Id"/>
+			<gavp name="AN-GW-Address"/>
+			<gavp name="Result-Code"/>
+			<gavp name="Experimental-Result-Code"/>
+			<gavp name="Charging-Rule-Remove"/>
+			<gavp name="Charging-Rule-Install"/>
+			<gavp name="QoS-Rule-Install"/>
+			<gavp name="QoS-Rule-Remove"/>
+			<gavp name="Default-EPS-Bearer-QoS"/>
+			<gavp name="Usage-Monitoring-Information"/>
+			<gavp name="Session-Release-Cause"/>
+			<gavp name="Bearer-Control-Mode"/>
+			<gavp name="Event-Trigger"/>
+			<gavp name="Online"/>
+			<gavp name="Offline"/>
+			<gavp name="QoS-Information"/>
+		</grouped>
+	</avp>
+	<avp name="Subsession-Enforcement-Info" code="2201" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Subsession-Id"/>
+			<gavp name="Subsession-Operation"/>
+			<gavp name="AN-GW-Address"/>
+			<gavp name="Bearer-Identifier"/>
+			<gavp name="Bearer-Operation"/>
+			<gavp name="Packet-Filter-Information"/>
+			<gavp name="Packet-Filter-Operation"/>
+			<gavp name="QoS-Information"/>
+			<gavp name="Framed-IP-Address"/>
+			<gavp name="Framed-IPv6-Prefix"/>
+			<gavp name="CoA-Information"/>
+			<gavp name="Called-Station-Id"/>
+			<gavp name="PDN-Connection-ID"/>
+			<gavp name="Bearer-Usage"/>
+			<gavp name="TFT-Packet-Filter-Information"/>
+			<gavp name="Online"/>
+			<gavp name="Offline"/>
+			<gavp name="Result-Code"/>
+			<gavp name="Experimental-Result-Code"/>
+			<gavp name="Charging-Rule-Report"/>
+			<gavp name="QoS-Rule-Report"/>
+			<gavp name="Default-EPS-Bearer-QoS"/>
+			<gavp name="Network-Request-Support"/>
+			<gavp name="Usage-Monitoring-Information"/>
+			<gavp name="Multiple-BBERF-Action"/>
+			<gavp name="Event-Trigger"/>
+			<gavp name="Access-Network-Charging-Address"/>
+			<gavp name="Access-Network-Charging-Identifier-Gx"/>
+			<gavp name="Session-Linking-Indicator"/>
+		</grouped>
+	</avp>
+	<avp name="Subsession-Id" code="2202" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Subsession-Operation" code="2203" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="TERMINATION" code="0"/>
+		<enum name="ESTABLISHMENT" code="1"/>
+		<enum name="MODIFICATION" code="2"/>
+	</avp>
+	<avp name="Multiple-BBERF-Action" code="2204" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="ESTABLISHMENT" code="0"/>
+		<enum name="TERMINATION"   code="1"/>
+	</avp>
+</application>	<!-- 3GPP S9 -->
+
+<!--
+		Note: The AVP codes from 3206 to 3308 are reserved for TS 29.338
+		-->
+
+<application id="16777312" name="3GPP S6c" uri="http://www.3gpp.org/ftp/Specs/html-info/29338.htm">
+	<avp name="SC-Address" code="3300" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="SM-RP-UI" code="3301" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="TFR-Flags" code="3302" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="SM-Delivery-Failure-Cause" code="3303" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SM-Enumerated-Delivery-Failure-Cause"/>
+				<gavp name="SM-Diagnostic-Info"/>
+			</grouped>
+		</avp>
+		<avp name="SM-Enumerated-Delivery-Failure-Cause" code="3304" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="MEMORY_CAPACITY_EXCEEDED" code="0"/>
+			<enum name="EQUIPMENT_PROTOCOL_ERROR" code="1"/>
+			<enum name="EQUIPMENT_NOT_SM-EQUIPPED" code="2"/>
+			<enum name="UNKNOWN_SERVICE_CENTRE " code="3"/>
+			<enum name="SC-CONGESTION" code="4"/>
+			<enum name="INVALID_SME-ADDRESS" code="5"/>
+			<enum name="USER_NOT_SC-USER" code="6"/>
+		</avp>
+		<avp name="SM-Diagnostic-Info" code="3305" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="SM-Delivery-Timer" code="3306" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="SM-Delivery-Start-Time" code="3307" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="SM-RP-MTI" code="3308" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SM_DELIVER" code="0"/>
+			<enum name="SM_STATUS_REPORT" code="1"/>
+		</avp>
+		<avp name="SM-RP-SMEA" code="3309" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="SRR-Flags" code="3310" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="SM-Delivery-Not-Intended" code="3311" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ONLY_IMSI_REQUESTED" code="0"/>
+			<enum name="ONLY_MCC_MNC_REQUESTED" code="1"/>
+		</avp>
+		<avp name="MWD-Status" code="3312" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="MME-Absent-User-Diagnostic-SM" code="3313" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="MSC-Absent-User-Diagnostic-SM" code="3314" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="SGSN-Absent-User-Diagnostic-SM" code="3315" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="SM-Delivery-Outcome" code="3316" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="MME-SM-Delivery-Outcome"/>
+				<gavp name="MSC-SM-Delivery-Outcome"/>
+				<gavp name="SGSN-SM-Delivery-Outcome"/>
+				<gavp name="IP-SM-GW-SM-Delivery-Outcome"/>
+			</grouped>
+		</avp>
+		<avp name="MME-SM-Delivery-Outcome" code="3317" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SM-Delivery-Cause"/>
+				<gavp name="Absent-User-Diagnostic-SM"/>
+			</grouped>
+		</avp>
+		<avp name="MSC-SM-Delivery-Outcome" code="3318" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SM-Delivery-Cause"/>
+				<gavp name="Absent-User-Diagnostic-SM"/>
+			</grouped>
+		</avp>
+		<avp name="SGSN-SM-Delivery-Outcome" code="3319" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SM-Delivery-Cause"/>
+				<gavp name="Absent-User-Diagnostic-SM"/>
+			</grouped>
+		</avp>
+		<avp name="IP-SM-GW-SM-Delivery-Outcome" code="3320" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SM-Delivery-Cause"/>
+				<gavp name="Absent-User-Diagnostic-SM"/>
+			</grouped>
+		</avp>
+		<avp name="SM-Delivery-Cause" code="3321" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SM-Delivery-Cause" code="0"/>
+			<enum name="ABSENT_USER" code="1"/>
+			<enum name="SUCCESSFUL_TRANSFER" code="2"/>
+		</avp>
+		<avp name="Absent-User-Diagnostic-SM" code="3322" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="RDR-Flags" code="3323" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+
+		<avp name="Maximum-UE-Availability-Time" code="3329" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Maximum-Retransmission-Time" code="3330" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Requested-Retransmission-Time" code="3331"  mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="SMS-GMSC-Address" code="3332"  mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="SMS-GMSC-Alert-Event" code="3333" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+</application> <!-- 3GPP S6c -->
+
+<application id="16777335" name="3GPP MB2c" uri="http://www.3gpp.org/DynaReport/29468.htm">
+
+	<command name="GCS-Action" code="8388662" vendor-id="TGPP"/>
+	<command name="GCS-Notification" code="8388663" vendor-id="TGPP"/>
+
+	<avp name="BMSC-Address" code="3500" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="IPAddress"/>
+	</avp>
+	<avp name="BMSC-Port" code="3501" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="MBMS-Bearer-Event" code="3502" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="MBMS-Bearer-Event-Notification" code="3503" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="TMGI"/>
+			<gavp name="MBMS-Flow-Identifier"/>
+			<gavp name="MBMS-Bearer-Event"/>
+		</grouped>
+	</avp>
+	<avp name="MBMS-Bearer-Request" code="3504" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="MBMS-StartStop-Indication"/>
+			<gavp name="TMGI"/>
+			<gavp name="MBMS-Flow-Identifier"/>
+			<gavp name="QoS-Information"/>
+			<gavp name="MBMS-Service-Area"/>
+			<gavp name="MBMS-Start-Time"/>
+			<gavp name="MB2U-Security"/>
+		</grouped>
+	</avp>
+	<avp name="MBMS-Bearer-Response" code="3505" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="TMGI"/>
+			<gavp name="MBMS-Flow-Identifier"/>
+			<gavp name="MBMS-Session-Duration"/>
+			<gavp name="MBMS-Bearer-Result"/>
+			<gavp name="BMSC-Address"/>
+			<gavp name="BMSC-Port"/>
+			<gavp name="MB2U-Security"/>
+			<gavp name="Radio-Frequency"/>
+		</grouped>
+	</avp>
+	<avp name="MBMS-Bearer-Result" code="3506" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="MBMS-Start-Time" code="3507" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Time"/>
+	</avp>
+	<avp name="Radio-Frequency" code="3508" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="TMGI-Allocation-Request" code="3509" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="TMGI-Number"/>
+			<gavp name="TMGI"/>
+		</grouped>
+	</avp>
+	<avp name="TMGI-Allocation-Response" code="3510" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="TMGI"/>
+			<gavp name="MBMS-Session-Duration"/>
+			<gavp name="TMGI-Allocation-Result"/>
+		</grouped>
+	</avp>
+	<avp name="TMGI-Allocation-Result" code="3511" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="TMGI-Deallocation-Request" code="3512" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="TMGI"/>
+		</grouped>
+	</avp>
+	<avp name="TMGI-Deallocation-Response" code="3513" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="TMGI"/>
+			<gavp name="TMGI-Deallocation-Result"/>
+		</grouped>
+	</avp>
+	<avp name="TMGI-Deallocation-Result" code="3514" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="TMGI-Expiry" code="3515" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="TMGI"/>
+		</grouped>
+	</avp>
+	<avp name="TMGI-Number" code="3516" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<avp name="MB2U-Security" code="3517" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+</application>	<!-- 3GPP MB2c -->
+
+<application id="16777336" name="3GPP PC4a" uri="http://www.3gpp.org/ftp/Specs/html-info/29344.htm">
+
+	<command name="ProSe-Subscriber-Information" code="8388664" vendor-id="TGPP"/>
+	<command name="Update-ProSe-Subscriber-Data" code="8388665" vendor-id="TGPP"/>
+	<command name="ProSe-Notify" code="8388666" vendor-id="TGPP"/>
+	<command name="Reset" code="8388667" vendor-id="TGPP"/>
+	<command name="ProSe-Initial-Location-Information" code="8388713" vendor-id="TGPP"/>
+
+	<avp name="ProSe-Subscription-Data" code="3701" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="ProSe-Permission"/>
+			<gavp name="ProSe-Allowed-PLMN"/>
+			<gavp name="3GPP-Charging-Characteristics"/>
+		</grouped>
+	</avp>
+	<avp name="ProSe-Permission" code="3702" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="ProSe-Allowed-PLMN" code="3703" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="Visited-PLMN-Id"/>
+			<gavp name="Authorized-Discovery-Range"/>
+			<gavp name="ProSe-Direct-Allowed"/>
+		</grouped>
+	</avp>
+	<avp name="ProSe-Direct-Allowed" code="3704" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="UPR-Flags" code="3705" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="PNR-Flags" code="3706" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="ProSe-Initial-Location-Information" code="3707" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<grouped>
+			<gavp name="MME-Name"/>
+			<gavp name="E-UTRAN-Cell-Global-Identity"/>
+			<gavp name="Tracking-Area-Identity"/>
+			<gavp name="Age-Of-Location-Information"/>
+		</grouped>
+	</avp>
+	<avp name="Authorized-Discovery-Range" code="3708" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+</application> <!-- 3GPP PC4a -->
+
+<application id="16777346" name="3GPP T6a/T6b" uri="http://www.3gpp.org/ftp/Specs/html-info/29128.htm">
+	<avp name="Communication-Failure-Information" code="4300" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+		<grouped>
+			<gavp name="Cause-Type"/>
+			<gavp name="S1AP-Cause"/>
+			<gavp name="RANAP-Cause"/>
+			<gavp name="BSSGP-Cause"/>
+			<gavp name="GMM-Cause"/>
+			<gavp name="SM-Cause"/>
+		</grouped>
+	</avp>
+	<avp name="Cause-Type" code="4301" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+ 		<enum name="RADIO_NETWORK_LAYER" code="0"/>
+ 		<enum name="TRANSPORT_LAYER" code="1"/>
+ 		<enum name="NAS" code="2"/>
+ 		<enum name="PROTOCOL" code="3"/>
+ 		<enum name="MISCELLANEOUS" code="4"/>
+	</avp>
+	<avp name="S1AP-Cause" code="4302" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="RANAP-Cause" code="4303" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="GMM-Cause" code="4304" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="SM-Cause" code="4305" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Number-Of-UE-Per-Location-Configuration" code="4306" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+		<grouped>
+			<gavp name="EPS-Location-Information"/>
+                        <gavp name="IMSI-Group-Id"/>
+		</grouped>
+	</avp>
+	<avp name="Number-Of-UE-Per-Location-Report" code="4307" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+		<grouped>
+			<gavp name="EPS-Location-Information"/>
+			<gavp name="UE-Count"/>
+                        <gavp name="IMSI-Group-Id"/>
+		</grouped>
+	</avp>
+	<avp name="UE-Count" code="4308" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="BSSGP-Cause" code="4309" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Serving-PLMN-Rate-Control" code="4310" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+		<grouped>
+			<gavp name="Uplink-Rate-Limit"/>
+			<gavp name="Downlink-Rate-Limit"/>
+		</grouped>
+	</avp>
+	<avp name="Uplink-Rate-Limit" code="4311" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Downlink-Rate-Limit" code="4312" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Extended-PCO" code="4313" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Connection-Action" code="4314" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+ 		<enum name="CONNECTION_ESTABLISHMENT" code="0"/>
+ 		<enum name="CONNECTION_RELEASE" code="1"/>
+ 		<enum name="CONNECTION_UPDATE" code="2"/>
+	</avp>
+	<avp name="Non-IP-Data" code="4315" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="SCEF-Wait-Time" code="4316" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+		<type type-name="Time"/>
+	</avp>
+	<avp name="CMR-Flags" code="4317" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="RRC-Cause-Counter" code="4318" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+		<grouped>
+			<gavp name="Counter-Value"/>
+			<gavp name="RRC-Counter-Timestamp"/>
+		</grouped>
+	</avp>
+	<avp name="Counter-Value" code="4319" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="RRC-Counter-Timestamp" code="4320" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+		<type type-name="Time"/>
+	</avp>
+	<avp name="Idle-Status-Indication" code="4322" mandatory="mustnot" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+		<grouped>
+			<gavp name="Idle-Status-Timestamp"/>
+			<gavp name="Active-Time"/>
+			<gavp name="Subscribed-Periodic-RAU-TAU-Timer"/>
+		</grouped>
+	</avp>
+	<avp name="Idle-Status-Timestamp" code="4323" mandatory="mustnot" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+		<type type-name="Time"/>
+	</avp>
+	<avp name="Active-Time" code="4324" mandatory="mustnot" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<!--
+	Note: The AVP codes from 4300 to 4399 are reserved for TS 29.128
+	-->
+</application>

--- a/codec-diameter-codegen/src/main/resources/diameter/TGPP2.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/TGPP2.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<vendor vendor-id="TGPP2"			code="5535"	name="3GPP2"/>
+
+<application id="16777323"	name="3GPP2 M1"	uri="http://www.3gpp2.org/Public_html/specs/X.S0068-0_v1.0_M2M_Enhancements_20140718.pdf"/>
+
+<application id="16777237"	name="3GPP2 Ty"	uri="http://www.3gpp2.org/public_html/specs/x.s0013-014-0_v1.0_080224.pdf">
+	<!--- TGPP2 AVPs X.S0013-013-0 (Tx):
+		http://www.3gpp2.org/Public_html/specs/X.S0013-013-0_v1.0_080224.pdf
+	-->
+	<avp name="Access-Network-Physical-Access-ID-Realm" code="898" vendor-bit="must" vendor-id="TGPP2">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Access-Network-Physical-Access-ID-Value" code="899" vendor-bit="must" vendor-id="TGPP2">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Access-Network-Physical-Access-ID" code="900" vendor-bit="must" vendor-id="TGPP2">
+		<grouped>
+			<gavp name="Access-Network-Physical-Access-ID-Value"/>
+			<gavp name="Access-Network-Physical-Access-ID-Realm"/>
+		</grouped>
+	</avp>
+
+
+	<!--- TGPP2 AVPs X.S0013-014-0 (Ty):
+		http://www.3gpp2.org/Public_html/specs/X.S0013-014-0_v1.0_080224.pdf
+	-->
+	<avp name="Flow-Operation" code="800" vendor-bit="must" vendor-id="TGPP2">
+		<type type-name="Enumerated"/>
+		<enum name="TERMINATION" code="0"/>
+		<enum name="ESTABLISHMENT" code="1"/>
+		<enum name="MODIFICATION" code="2"/>
+	</avp>
+	<avp name="3GPP2-Charging-Rule-Install" code="801" vendor-bit="must" vendor-id="TGPP2">
+		<grouped>
+			<gavp name="3GPP2-Charging-Rule-Definition"/>
+			<gavp name="Charging-Rule-Name"/>
+			<gavp name="Charging-Rule-Base-Name"/>
+		</grouped>
+	</avp>
+	<avp name="3GPP2-Charging-Rule-Definition" code="802" vendor-bit="must" vendor-id="TGPP2">
+		<grouped>
+			<gavp name="Charging-Rule-Name"/>
+			<gavp name="Service-Identifier"/>
+			<gavp name="Rating-Group"/>
+			<gavp name="Flow-Identifier"/>
+			<gavp name="Flow-Description"/>
+			<gavp name="Flow-Status"/>
+			<gavp name="3GPP2-QoS-Information"/>
+			<gavp name="Reporting-Level"/>
+			<gavp name="Online"/>
+			<gavp name="Offline"/>
+			<gavp name="Metering-Method"/>
+			<gavp name="Precedence"/>
+			<gavp name="AF-Charging-Identifier"/>
+			<gavp name="Flows"/>
+		</grouped>
+	</avp>
+	<avp name="3GPP2-Event-Trigger" code="803" vendor-bit="must" vendor-id="TGPP2">
+		<type type-name="Enumerated"/>
+		<enum name="PCF_CHANGE" code="0"/>
+		<enum name="QOS_CHANGE" code="1"/>
+		<enum name="RAT_CHANGE" code="2"/>
+		<enum name="TFT_CHANGE" code="3"/>
+		<enum name="PLMN_CHANGE" code="4"/>
+		<enum name="LOSS_OF_FLOW" code="5"/>
+		<enum name="RECOVERY_OF_FLOW" code="6"/>
+		<enum name="IP-CAN_CHANGE" code="7"/>
+		<enum name="PCC_RULE_FAILURE" code="8"/>
+		<enum name="ACCESS_NETWORK_PHYSICAL_ACCESS_ID_CHANGE" code="9"/>
+	</avp>
+	<avp name="3GPP2-QoS-Information" code="804" vendor-bit="must" vendor-id="TGPP2">
+		<grouped>
+			<gavp name="QoS-Class-Identifier"/>
+			<gavp name="Max-Requested-Bandwidth-UL"/>
+			<gavp name="Max-Requested-Bandwidth-DL"/>
+			<gavp name="Guaranteed-Bitrate-UL"/>
+			<gavp name="Guaranteed-Bitrate-DL"/>
+		</grouped>
+	</avp>
+	<avp name="3GPP2-Charging-Rule-Report" code="805" vendor-bit="must" vendor-id="TGPP2">
+		<grouped>
+			<gavp name="Charging-Rule-Name"/>
+			<gavp name="Charging-Rule-Base-Name"/>
+			<gavp name="PCC-Rule-Status"/>
+			<gavp name="Rule-Reason-Code"/>
+		</grouped>
+	</avp>
+	<avp name="AGW-IP-Address" code="806" vendor-bit="must" vendor-id="TGPP2">
+		<type type-name="IPAddress"/>
+	</avp>
+	<avp name="AGW-IPv6-Address" code="807" vendor-bit="must" vendor-id="TGPP2">
+		<type type-name="IPAddress"/>
+	</avp>
+	<avp name="3GPP2-RAT-Type" code="808" vendor-bit="must" vendor-id="TGPP2">
+		<type type-name="Enumerated"/>
+		<enum name="CDMA2000-1X" code="0"/>
+		<enum name="HRPD" code="1"/>
+		<enum name="WLAN" code="2"/>
+		<enum name="UMB" code="3"/>
+	</avp>
+	<avp name="Flow-Info" code="809" vendor-bit="must" vendor-id="TGPP2">
+		<grouped>
+			<gavp name="Flow-Identifier"/>
+			<gavp name="Flow-Description-Info"/>
+			<gavp name="Requested-QoS"/>
+			<gavp name="Granted-QoS"/>
+			<gavp name="Flow-Status"/>
+		</grouped>
+	</avp>
+	<avp name="Flow-Identifier" code="810" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP2">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Granted-QoS" code="811" vendor-bit="must" vendor-id="TGPP2">
+		<grouped>
+			<gavp name="QoS-Class-Identifier"/>
+			<gavp name="Guaranteed-Bitrate-UL"/>
+			<gavp name="Guaranteed-Bitrate-DL"/>
+		</grouped>
+	</avp>
+	<avp name="Requested-QoS" code="812" vendor-bit="must" vendor-id="TGPP2">
+		<grouped>
+			<gavp name="QoS-Class-Identifier"/>
+			<gavp name="Guaranteed-Bitrate-UL"/>
+			<gavp name="Guaranteed-Bitrate-DL"/>
+		</grouped>
+	</avp>
+	<avp name="Flow-Description-Info" code="813" vendor-bit="must" vendor-id="TGPP2">
+		<grouped>
+			<gavp name="Flow-Description"/>
+			<gavp name="Precedence"/>
+		</grouped>
+	</avp>
+	<avp name="Rule-Reason-Code" code="814" vendor-bit="must" vendor-id="TGPP2">
+		<type type-name="Enumerated"/>
+		<enum name="UNKNOWN_FLOW_IDENTIFIER" code="0"/>
+		<enum name="UNKNOWN_RULE_NAME" code="0"/>
+		<enum name="RATING_GROUP_ERROR" code="0"/>
+		<enum name="SERVICE_IDENTIFIER_ERROR" code="0"/>
+		<enum name="AGW_MALFUNCTION" code="0"/>
+		<enum name="RESOURCES_LIMITATION" code="0"/>
+	</avp>
+	<avp name="AGW-MCC-MNC" code="815" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP2">
+		<type type-name="UTF8String"/>
+	</avp>
+
+	<avp name="3GPP2-BSID" code="9010" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP2">
+		<type type-name="UTF8String"/>
+	</avp>
+</application>

--- a/codec-diameter-codegen/src/main/resources/diameter/VerizonWireless.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/VerizonWireless.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vendor vendor-id="VerizonWireless" code="12951" name="Verizon Wireless">
+
+  <avp name="Idle-To-Connected-Transition-Count" code="5001" vendor-id="VerizonWireless" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must">
+    <type type-name="Integer32"/>
+  </avp>
+
+  <avp name="Connected-Duration" code="5002" vendor-id="VerizonWireless" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="must" >
+    <type type-name="Unsigned32"/>
+  </avp>
+
+  <avp name="Charging-Gateway-Function-Host" vendor-id="VerizonWireless" code="6068" >
+    <type type-name="OctetString"/>
+  </avp>
+
+  <avp name="Charging-Group-ID" vendor-id="VerizonWireless" code="6069" >
+    <type type-name="OctetString"/>
+  </avp>
+
+  <avp name="Self-Activation-Status" code="6115" vendor-id="VerizonWireless" >
+    <type type-name="Enumerated"/>
+    <enum name="Continue" code="0"/>
+    <enum name="Reactivation-Disallowed-To-APN" code="1"/>
+  </avp>
+
+  <avp name="Origination-Timestamp" vendor-id="VerizonWireless" code="7102" >
+    <type type-name="Unsigned64"/>
+  </avp>
+
+  <avp name="Max-Wait-Time" code="7103" vendor-id="VerizonWireless" >
+    <type type-name="Unsigned32"/>
+  </avp>
+
+</vendor>
+

--- a/codec-diameter-codegen/src/main/resources/diameter/Vodafone.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/Vodafone.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<vendor vendor-id="Vodafone"			code="12645"	name="Vodafone"/>
+
+<application id="16777234" name="Vodafone Gx+" uri="none">
+
+	<avp name="Context-Type" code="256" vendor-id="Vodafone" mandatory="mustnot" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="PRIMARY" code="0"/>
+		<enum name="SECONDARY" code="1"/>
+	</avp>
+	<avp name="Vodafone-Quota-Consumption-Time" code="257" vendor-id="Vodafone" mandatory="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Vodafone-Quota-Holding-Time" code="258" vendor-id="Vodafone" mandatory="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Vodafone-Time-Quota-Threshold" code="259" vendor-id="Vodafone" mandatory="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Radio-Access-Technology" code="260" vendor-id="Vodafone" mandatory="mustnot" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="UTRAN" code="0"/>
+		<enum name="GERAN" code="1"/>
+		<enum name="WLAN" code="2"/>
+	</avp>
+	<avp name="Vodafone-Reporting-Reason" code="261" vendor-id="Vodafone" mandatory="mustnot" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="THRESHOLD" code="0"/>
+		<enum name="QHT" code="1"/>
+		<enum name="FINAL" code="2"/>
+		<enum name="QUOTA_EXHAUSTED" code="3"/>
+		<enum name="VALIDITY_TIME" code="4"/>
+		<enum name="OTHER_QUOTA_TYPE" code="5"/>
+		<enum name="RATING_CONDITION_CHANGE" code="6"/>
+		<enum name="FORCED_REAUTHORISATION " code="7"/>
+	</avp>
+	<avp name="Vodafone-Rulebase-Id" code="262" vendor-id="Vodafone" mandatory="mustnot" vendor-bit="must">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Vodafone-Time-Of-First-Usage" code="263" vendor-id="Vodafone" mandatory="mustnot" vendor-bit="must">
+		<type type-name="Time"/>
+	</avp>
+	<avp name="Vodafone-Time-Of-Last-Usage" code="264" vendor-id="Vodafone" mandatory="mustnot" vendor-bit="must">
+		<type type-name="Time"/>
+	</avp>
+	<avp name="Vodafone-Trigger" code="265" vendor-id="Vodafone" mandatory="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Vodafone-Trigger-Type"/>
+		</grouped>
+	</avp>
+	<avp name="Vodafone-Trigger-Type" code="266" vendor-id="Vodafone" mandatory="mustnot" vendor-bit="must">
+		<type type-name="Enumerated"/>
+		<enum name="CHANGE_IN_SGSN_IP_ADDRESS" code="1"/>
+		<enum name="CHANGEINQOS_ANY" code="2"/>
+		<enum name="CHANGEINLOCATION_ANY" code="3"/>
+		<enum name="CHANGEINRAT" code="4"/>
+		<enum name="CHANGEINQOS_TRAFFIC_CLASS" code="10"/>
+		<enum name="CHANGEINQOS_RELIABILITY_CLASS" code="11"/>
+		<enum name="CHANGEINQOS_DELAY_CLASS " code="12"/>
+		<enum name="CHANGEINQOS_PEAK_THROUGHPUT" code="13"/>
+		<enum name="CHANGEINQOS_PRECEDENCE_CLASS" code="14"/>
+		<enum name="CHANGEINQOS_MEAN_THROUGHPUT" code="15"/>
+		<enum name="CHANGEINQOS_MAXIMUM_BIT_RATE_FOR_UPLINK" code="16"/>
+		<enum name="CHANGEINQOS_MAXIMUM_BIT_RATE_FOR_DOWNLINK" code="17"/>
+		<enum name="CHANGEINQOS_RESIDUAL_BER" code="18"/>
+		<enum name="CHANGEINQOS_SDU_ERROR_RATIO" code="19"/>
+		<enum name="CHANGEINQOS_TRANSFER_DELAY" code="20"/>
+	</avp>
+	<avp name="User-Location-Information" code="267" vendor-id="Vodafone" mandatory="mustnot" vendor-bit="must">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Vodafone-Volume-Quota-Threshold" code="268" vendor-id="Vodafone" mandatory="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+</application>

--- a/codec-diameter-codegen/src/main/resources/diameter/chargecontrol.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/chargecontrol.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+
+<application id="4" name="Diameter Credit Control Application" uri="http://www.ietf.org/rfc/rfc4006.txt">
+
+	<command name="Credit-Control" code="272" vendor-id="None"/>
+
+	<!-- ************************* DCCA AVPs ************************ -->
+	<!-- This list is not complete yet -->
+	<avp name="CC-Correlation-Id" code="411" mandatory="may" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="CC-Input-Octets" code="412" mandatory="must">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="CC-Money" code="413" mandatory="must">
+		<grouped>
+			<gavp name="Unit-Value"/>
+			<gavp name="Currency-Code"/>
+		</grouped>
+	</avp>
+
+	<avp name="CC-Output-Octets" code="414" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="CC-Request-Number" code="415" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="CC-Request-Type" code="416" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="INITIAL_REQUEST"     code="1"/>
+		<enum name="UPDATE_REQUEST"      code="2"/>
+		<enum name="TERMINATION_REQUEST" code="3"/>
+		<enum name="EVENT_REQUEST"       code="4"/>
+	</avp>
+	<avp name="CC-Service-Specific-Units" code="417" mandatory="must">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="CC-Session-Failover" code="418" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="FAILOVER_NOT_SUPPORTED" code="0"/>
+		<enum name="FAILOVER_SUPPORTED" code="1"/>
+	</avp>
+	<avp name="CC-Sub-Session-Id" code="419" mandatory="must">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="CC-Time" code="420" mandatory="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="CC-Total-Octets" code="421" mandatory="must">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="Check-Balance-Result" code="422" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="ENOUGH_CREDIT" code="0"/>
+		<enum name="NO_CREDIT" code="1"/>
+	</avp>
+	<avp name="Cost-Information" code="423" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Unit-Value"/>
+			<gavp name="Currency-Code"/>
+			<gavp name="Cost-Unit"/>
+		</grouped>
+	</avp>
+	<avp name="Cost-Unit" code="424" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Currency-Code" code="425" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Credit-Control" code="426" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="CREDIT_AUTHORIZATION" code="0"/>
+		<enum name="RE_AUTHORIZATION" code="1"/>
+	</avp>
+	<avp name="Credit-Control-Failure-Handling" code="427" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="TERMINATE" code="0"/>
+		<enum name="CONTINUE" code="1"/>
+		<enum name="RETRY_AND_TERMINATE" code="2"/>
+	</avp>
+	<avp name="Direct-Debiting-Failure-Handling" code="428" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="CONTINUE" code="1"/>
+		<enum name="TERMINATE_OR_BUFFER" code="0"/>
+	</avp>
+	<avp name="Exponent" code="429" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Integer32"/>
+	</avp>
+	<avp name="Final-Unit-Indication" code="430" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Final-Unit-Action"/>
+			<gavp name="Restriction-Filter-Rule"/>
+			<gavp name="Filter-Id"/>
+			<gavp name="Redirect-Server"/>
+		</grouped>
+	</avp>
+	<avp name="Granted-Service-Unit" code="431" mandatory="must">
+		<grouped>
+			<gavp name="Tariff-Time-Change"/>
+			<gavp name="CC-Time"/>
+			<gavp name="CC-Money"/>
+			<gavp name="CC-Total-Octets"/>
+			<gavp name="CC-Input-Octets"/>
+			<gavp name="CC-Output-Octets"/>
+			<gavp name="CC-Service-Specific-Units"/>
+		</grouped>
+	</avp>
+	<avp name="Rating-Group" code="432" mandatory="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Redirect-Address-Type" code="433" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="IPV6_ADDRESS" code="1"/>
+		<enum name="SIP_URI" code="3"/>
+		<enum name="URL" code="2"/>
+		<enum name="IPV4_ADDRESS" code="0"/>
+	</avp>
+	<avp name="Redirect-Server" code="434" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Redirect-Address-Type"/>
+			<gavp name="Redirect-Server-Address"/>
+		</grouped>
+	</avp>
+	<avp name="Redirect-Server-Address" code="435" mandatory="must">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Requested-Action" code="436" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="DIRECT_DEBITING"  code="0"/>
+		<enum name="REFUND_ACCOUNT"   code="1"/>
+		<enum name="CHECK_BALANCE"    code="2"/>
+		<enum name="PRICE_ENQUIRY"    code="3"/>
+	</avp>
+	<avp name="Requested-Service-Unit" code="437" mandatory="must">
+		<grouped>
+			<gavp name="CC-Time"/>
+			<gavp name="CC-Money"/>
+			<gavp name="CC-Total-Octets"/>
+			<gavp name="CC-Input-Octets"/>
+			<gavp name="CC-Output-Octets"/>
+			<gavp name="CC-Service-Specific-Units"/>
+		</grouped>
+	</avp>
+	<avp name="Restriction-Filter-Rule" code="438" mandatory="must">
+		<type type-name="IPFilterRule"/>
+	</avp>
+	<avp name="Service-Identifier" code="439" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Service-Parameter-Info" code="440" mandatory="may" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Service-Parameter-Type"/>
+			<gavp name="Service-Parameter-Value"/>
+		</grouped>
+	</avp>
+	<avp name="Service-Parameter-Type" code="441" mandatory="may" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+		<!-- This field is vendor defined. -->
+	</avp>
+	<avp name="Service-Parameter-Value" code="442" mandatory="may" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Subscription-Id" code="443" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Subscription-Id-Data"/>
+			<gavp name="Subscription-Id-Type"/>
+		</grouped>
+	</avp>
+	<avp name="Subscription-Id-Data" code="444" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Unit-Value" code="445" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Value-Digits"/>
+			<gavp name="Exponent"/>
+		</grouped>
+	</avp>
+	<avp name="Used-Service-Unit" code="446" mandatory="must">
+		<grouped>
+			<gavp name="Tariff-Change-Usage"/>
+			<gavp name="CC-Time"/>
+			<gavp name="CC-Money"/>
+			<gavp name="CC-Total-Octets"/>
+			<gavp name="CC-Input-Octets"/>
+			<gavp name="CC-Output-Octets"/>
+			<gavp name="CC-Service-Specific-Units"/>
+		</grouped>
+	</avp>
+	<avp name="Value-Digits" code="447" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Integer64"/>
+	</avp>
+	<avp name="Validity-Time" code="448" mandatory="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Final-Unit-Action" code="449" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="TERMINATE" code="0"/>
+		<enum name="REDIRECT" code="1"/>
+		<enum name="RESTRICT_ACCESS" code="2"/>
+	</avp>
+	<avp name="Subscription-Id-Type" code="450" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="END_USER_E164"    code="0"/>
+		<enum name="END_USER_IMSI"    code="1"/>
+		<enum name="END_USER_SIP_URI" code="2"/>
+		<enum name="END_USER_NAI"     code="3"/>
+		<enum name="END_USER_PRIVATE" code="4"/>
+	</avp>
+	<avp name="Tariff-Time-Change" code="451" mandatory="must">
+		<type type-name="Time"/>
+	</avp>
+	<avp name="Tariff-Change-Usage" code="452" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="UNIT_AFTER_TARIFF_CHANGE" code="1"/>
+		<enum name="UNIT_INDETERMINATE" code="2"/>
+		<enum name="UNIT_BEFORE_TARIFF_CHANGE" code="0"/>
+	</avp>
+	<avp name="G-S-U-Pool-Identifier" code="453" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="CC-Unit-Type" code="454" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="TIME" code="0"/>
+		<enum name="MONEY" code="1"/>
+		<enum name="TOTAL-OCTETS" code="2"/>
+		<enum name="OUTPUT-OCTETS" code="4"/>
+		<enum name="INPUT-OCTETS" code="3"/>
+		<enum name="SERVICE-SPECIFIC-UNITS" code="5"/>
+	</avp>
+	<avp name="Multiple-Services-Indicator" code="455" mandatory="must">
+		<type type-name="Enumerated"/>
+		<enum name="MULTIPLE_SERVICES_NOT_SUPPORTED" code="0"/>
+		<enum name="MULTIPLE_SERVICES_SUPPORTED" code="1"/>
+	</avp>
+	<avp name="Multiple-Services-Credit-Control" code="456" mandatory="must">
+		<grouped>
+			<gavp name="Granted-Service-Unit"/>
+			<gavp name="Requested-Service-Unit"/>
+			<gavp name="Used-Service-Unit"/>
+			<gavp name="Tariff-Change-Usage"/>
+			<gavp name="Service-Identifier"/>
+			<gavp name="Rating-Group"/>
+			<gavp name="G-S-U-Pool-Reference"/>
+			<gavp name="Validity-Time"/>
+			<gavp name="Result-Code"/>
+			<gavp name="Final-Unit-Indication"/>
+		</grouped>
+	</avp>
+	<avp name="G-S-U-Pool-Reference" code="457" mandatory="must">
+		<grouped>
+			<gavp name="G-S-U-Pool-Identifier"/>
+			<gavp name="CC-Unit-Type"/>
+			<gavp name="Unit-Value"/>
+		</grouped>
+	</avp>
+	<avp name="User-Equipment-Info" code="458" mandatory="may">
+		<grouped>
+			<gavp name="User-Equipment-Info-Type"/>
+			<gavp name="User-Equipment-Info-Value"/>
+		</grouped>
+	</avp>
+	<avp name="User-Equipment-Info-Type" code="459" mandatory="may">
+		<type type-name="Enumerated"/>
+		<enum name="IMEISV" code="0"/>
+		<enum name="MAC" code="1"/>
+		<enum name="EUI64" code="2"/>
+		<enum name="MODIFIED_EUI64" code="3"/>
+	</avp>
+	<avp name="User-Equipment-Info-Value" code="460" mandatory="may">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Service-Context-Id" code="461" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+
+</application>

--- a/codec-diameter-codegen/src/main/resources/diameter/dictionary.dtd
+++ b/codec-diameter-codegen/src/main/resources/diameter/dictionary.dtd
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   $Log: dictionary.dtd,v $
+   Revision 1.1  2001/11/01 21:52:44  guy
+   From David Frascone: duUpdate to Diameter dissector to load the
+   dictionary as an XML file rather than building it in, and various
+   Diameter updates.
+
+   Revision 1.1  2001/08/24 18:04:44  chaos
+   Added per Mark's request
+
+   Revision 1.3  2001/07/31 17:43:36  chaos
+   Oops, forgot to turn on validity checking.  Fixed some errors found with validity checking turned on
+
+   Revision 1.2  2001/07/31 16:56:15  chaos
+   Lots of changes to support flags like in the draft, and to support commands
+
+-->
+<!ELEMENT dictionary (base, (application|vendor)*)>
+<!ELEMENT base (command*, typedefn+, avp+)>
+<!ATTLIST base
+	uri CDATA #IMPLIED
+>
+
+<!ELEMENT application (command*, typedefn*, avp*)>
+<!ATTLIST application
+	id CDATA #REQUIRED
+	name CDATA #IMPLIED
+	uri CDATA #IMPLIED
+>
+<!ELEMENT command (#PCDATA)>
+<!ATTLIST command
+	name CDATA #REQUIRED
+	code CDATA #REQUIRED
+	vendor-id IDREF #IMPLIED
+>
+<!ELEMENT vendor (avp*)>
+<!ATTLIST vendor
+	vendor-id ID #REQUIRED
+	code CDATA #REQUIRED
+	name CDATA #IMPLIED
+>
+<!ELEMENT typedefn EMPTY>
+<!ATTLIST typedefn
+	type-name ID #REQUIRED
+	type-parent IDREF #IMPLIED
+	description CDATA #IMPLIED
+>
+<!ELEMENT avp ((type | grouped), (enum*))>
+<!ATTLIST avp
+	name ID #REQUIRED
+	description CDATA #IMPLIED
+	code CDATA #REQUIRED
+	may-encrypt (yes | no) "yes"
+	mandatory (must | may | mustnot | shouldnot) "may"
+	protected (must | may | mustnot | shouldnot) "may"
+	vendor-bit (must | may | mustnot | shouldnot) "mustnot"
+	vendor-id IDREF #IMPLIED
+	constrained (true | false) "false"
+>
+<!ELEMENT type EMPTY>
+<!ATTLIST type
+	type-name IDREF #REQUIRED
+>
+<!ELEMENT grouped (gavp+)>
+<!ELEMENT gavp EMPTY>
+<!ATTLIST gavp
+	name IDREF #REQUIRED
+>
+<!ELEMENT enum EMPTY>
+<!ATTLIST enum
+	name CDATA #REQUIRED
+	code CDATA #REQUIRED
+>

--- a/codec-diameter-codegen/src/main/resources/diameter/dictionary.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/dictionary.xml
@@ -1,0 +1,8634 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?type-proto key="MIPRegistrationRequest" value="mip" ?>
+<?avp-proto key="Example-AVP" value="data" ?>
+
+<!DOCTYPE dictionary SYSTEM "dictionary.dtd" [
+	<!-- Any files added here need to be added packaging/nsis/wireshark.nsi -->
+
+	<!ENTITY nasreq			SYSTEM "nasreq.xml">
+	<!ENTITY eap			SYSTEM "eap.xml">
+	<!ENTITY mobileipv4		SYSTEM "mobileipv4.xml">
+	<!ENTITY chargecontrol		SYSTEM "chargecontrol.xml">
+	<!ENTITY sunping		SYSTEM "sunping.xml">
+	<!ENTITY TGPP			SYSTEM "TGPP.xml">
+	<!ENTITY TGPP2			SYSTEM "TGPP2.xml">
+	<!ENTITY sip			SYSTEM "sip.xml">
+	<!ENTITY etsie2e4		SYSTEM "etsie2e4.xml">
+	<!ENTITY Ericsson		SYSTEM "Ericsson.xml">
+	<!ENTITY mobileipv6		SYSTEM "mobileipv6.xml">
+	<!ENTITY Cisco			SYSTEM "Cisco.xml">
+	<!ENTITY Starent		SYSTEM "Starent.xml">
+	<!ENTITY Vodafone		SYSTEM "Vodafone.xml">
+	<!ENTITY AlcatelLucent		SYSTEM "AlcatelLucent.xml">
+	<!ENTITY Nokia			SYSTEM "Nokia.xml">
+	<!ENTITY NokiaSolutionsAndNetworks	SYSTEM "NokiaSolutionsAndNetworks.xml">
+	<!ENTITY HP			SYSTEM "HP.xml">
+	<!ENTITY CiscoSystems			SYSTEM "CiscoSystems.xml">
+	<!ENTITY Oracle			SYSTEM "Oracle.xml">
+	<!ENTITY Juniper		SYSTEM "Juniper.xml">
+	<!ENTITY Inovar			SYSTEM "Inovar.xml">
+	<!ENTITY Huawei			SYSTEM "Huawei.xml">
+	<!ENTITY VerizonWireless	SYSTEM "VerizonWireless.xml">
+	<!ENTITY Custom			SYSTEM "Custom.xml">
+]>
+<dictionary>
+	<base uri="http://www.ietf.org/rfc/rfc6733.txt">
+		<!-- ************************************************************** -->
+		<!-- *********************** Commands ***************************** -->
+		<!-- ************************************************************** -->
+
+		<!-- Diameter Base Protocol Command Codes -->
+		<!-- 0-255 RADIUS compatibility codes [http://www.iana.org/assignments/radius-types] -->
+		<!--256 Unassigned -->
+		<command name="Capabilities-Exchange"		code="257" vendor-id="None"/>
+		<command name="Re-Auth"				code="258" vendor-id="None"/>
+		<!-- 259 Unassigned
+		     260 AMR / AMA [RFC4004]     mobileipv4.xml
+		     261 Unassigned
+		     262 HAR / HAA [RFC4004]     mobileipv4.xml
+		     263-264 Unassigned
+		     265 AAR / AAA [RFC4005]     nasreq.xml
+		     266-267 Unassigned
+		     268 DER / DEA [RFC4072]     eap.xml
+		     269-270 Unassigned
+		-->
+		<command name="Accounting"			code="271" vendor-id="None"/>
+		<!-- 272 CCR / CCA [RFC4006]     chargecontrol.xml
+		     273 Unassigned
+		-->
+		<command name="Abort-Session"			code="274" vendor-id="None"/>
+		<command name="Session-Termination"		code="275" vendor-id="None"/>
+		<!--276-279 Unassigned -->
+		<command name="Device-Watchdog"			code="280" vendor-id="None"/>
+		<command name="Disconnect-Peer"			code="282" vendor-id="None"/>
+		<!--283 UAR / UAA [RFC4740]      sip.xml
+		    284 SAR / SAA [RFC4740]      sip.xml
+		    285 LIR / LIA [RFC4740]      sip.xml
+		    286 MAR / MAA [RFC4740]      sip.xml
+		    287 RTR / RTA [RFC4740]      sip.xml
+		    288 PPR / PPA [RFC4740]      sip.xml
+		    289-299 Unassigned
+		    300-313 Allocated for 3GPP [RFC3589]
+		    TGPP.xml ( 300 - 309 )
+		-->
+
+		<command name="Boostrapping-Info"	code="310" vendor-id="None"/>		<!-- BIR/BIA	29.109 [7] -->
+		<command name="Message-Process"		code="311" vendor-id="None"/>		<!-- MPR/MPA	29.140 [16] -->
+		<command name="GBAPush-Info"		code="312" vendor-id="None"/>		<!-- GPR/GPI	29.109 [7] -->
+		<!-- 313 (Not used yet) -->
+		<command name="Policy-Data"		code="314" vendor-id="None"/>		<!-- PDR / PDA [RFC5224] -->
+		<command name="Policy-Install"		code="315" vendor-id="None"/>		<!-- (PIA) [ITU-T Rec. Q.3303.3][RFC5431] -->
+
+		<!-- http://www.3gpp.org/ftp/Specs/html-info/29272.htm -->
+		<command name="3GPP-Update-Location"		code="316" vendor-id="None"/>
+		<command name="3GPP-Cancel-Location"		code="317" vendor-id="None"/>		<!--[3GPP TS 29.272][RFC5516] -->
+		<command name="3GPP-Authentication-Information"	code="318" vendor-id="None"/>		<!--[3GPP TS 29.272][RFC5516] -->
+		<command name="3GPP-Insert-Subscriber-Data"	code="319" vendor-id="None"/>		<!--[3GPP TS 29.272][RFC5516] -->
+		<command name="3GPP-Delete-Subscriber-Data"	code="320" vendor-id="None"/>		<!--[3GPP TS 29.272][RFC5516] -->
+		<command name="3GPP-Purge-UE"			code="321" vendor-id="None"/>		<!--[3GPP TS 29.272][RFC5516] -->
+		<command name="3GPP-Reset"			code="322" vendor-id="None"/>		<!--[3GPP TS 29.272][RFC5516] -->
+		<command name="3GPP-Notify"			code="323" vendor-id="None"/>		<!--[3GPP TS 29.272][RFC5516] -->
+		<command name="3GPP-ME-Identity-Check"		code="324" vendor-id="None"/>		<!--(ECR/ECA) [3GPP TS 29.272][RFC5516] -->
+		<command name="MIP6"				code="325" vendor-id="None"/>		<!--(MIR/MIA) [RFC5778] -->
+		<command name="QoS-Authorization"		code="326" vendor-id="None"/>		<!--(QAR/QAA) [RFC5866] -->
+		<command name="QoS-Install"			code="327" vendor-id="None"/>		<!--(QIR/QIA) [RFC5866] -->
+		<command name="Capabilities-Update"		code="328" vendor-id="None"/>		<!--[RFC6737] -->
+		<command name="IKEv2-SK"			code="329" vendor-id="None"/>		<!--[RFC6738] -->
+		<command name="NAT-Control"			code="330" vendor-id="None"/>   <!--[RFC6736] -->
+		<!--
+			331-8388607 Unassigned
+			8388608 WIMAX-HRPD-SFF Request/Answer [http://www.3gpp2.org/Public_html/specs/tsgx.cfm][3GPP2 X.S0058-0 v1.0][Avi_Lior]
+			8388609 WiMAX-Diameter-EAP-Request/Answer (WDER/WDEA) WDE [http://www.wimaxforum.org/resources/documents/technical/T33][WiMAX Release 1.5][Avi_Lior]
+			8388610 WiMAX-Change-of-Authorization-Request/Answer (WCAR/WCAA) WCA [http://www.wimaxforum.org/resources/documents/technical/T33][WiMAX Release 1.5][Avi_Lior]
+			8388611 WiMAX-Reauthentication-Request/Answer (WRAR/WRAA) WRA [http://www.wimaxforum.org/resources/documents/technical/T33][WiMAX Release 1.5][Avi_Lior]
+			8388612 WiMAX-Session-Termination-Request/Answer (WSTR/WSTA) WST [http://www.wimaxforum.org/resources/documents/technical/T33][WiMAX Release 1.5][Avi_Lior]
+			8388613 WiMAX-Abort-Session-Request/Answer (WASR/WASA) WAS [http://www.wimaxforum.org/resources/documents/technical/T33][WiMAX Release 1.5][Avi_Lior]
+			8388614 WiMAX-Home-Agent-IPv4-Request/Answer (WHA4R/WHA4A) WHA4 [http://www.wimaxforum.org/resources/documents/technical/T33][WiMAX Release 1.5][Avi_Lior]
+			8388615 WiMAX-Home-Agent-IPv6-Request/Answer (WHA6R/WHA6A) WHA6 [http://www.wimaxforum.org/resources/documents/technical/T33][WiMAX Release 1.5][Avi_Lior]
+			8388616 WiMAX-DHCP-Request/Answer (WDHCPR/WDHCPA) WDHCP [http://www.wimaxforum.org/resources/documents/technical/T33][WiMAX Release 1.5][Avi_Lior]
+			8388617 WiMAX-LAA-Request/Answer (WLAAR/WLAA) WLAA [http://www.wimaxforum.org/resources/documents/technical/T33][WiMAX Release 1.5][Avi_Lior]
+			8388618 WiMAX-Location-Accounting-Request/Answer (WLACR/WLACA) WLAC [http://www.wimaxforum.org/resources/documents/technical/T33][WiMAX Release 1.5][Avi_Lior]
+			8388619 WiMAX-Location-Measurement-Query-Request/Answer (WLMQR/WLMQA) WLMQ [http://www.wimaxforum.org/resources/documents/technical/T33][WiMAX Release 1.5][Avi_Lior]
+		-->
+		<command name="3GPP-Provide-Location"		code="8388620" vendor-id="None"/>	<!--(PLR/PLA) [http://www.3gpp.org/ftp/Specs/][3GPP TS 29.172 -->
+		<command name="3GPP-Location-Report"		code="8388621" vendor-id="None"/>	<!--(PLR/PLA) [http://www.3gpp.org/ftp/Specs/][3GPP TS 29.172 -->
+		<command name="3GPP-LCS-Routing-Info"		code="8388622" vendor-id="None"/>	<!--(PLR/PLA) [http://www.3gpp.org/ftp/Specs/][3GPP TS 29.172 -->
+
+		<!--
+			8388623 Notif-Request/Answer (NFR/NFA) [Tomas_Menzl]
+			8388624 Msg-Interface-Request/Answer (MIFR/MIFA) [Tomas_Menzl]
+			8388625 Mobile-Application-Request/Answer (MAPR/MAPA) [Tomas_Menzl]
+			8388626 Update Location Request/Answer (ULR / ULA) [3GPP2 publication X.S0057][Avi_Lior]
+			8388627 Cancel Location Request/Answer (CLR CLA) [3GPP2 publication X.S0057][Avi_Lior]
+			8388628 Juniper-Sync-Event (JSE) [Aleksey_Romanov]
+			8388629 Juniper-Session-Discovery (JSD) [Aleksey_Romanov]
+			8388630 Query Profile Request Answer (QPR/QPA) [3GPP2 publication X.S0057A E-UTRAN eHRPD7][Avi_Lior]
+		-->
+
+		<command name="Subscription Information Application" code="8388631" vendor-id="None"/>
+		<command name="Distributed Charging"		code="8388632" vendor-id="None"/>
+		<command name="Ericsson-SL"			code="8388633" vendor-id="None"/>	<!-- Ericsson Spending Limit -->
+		<command name="Ericsson-SN"			code="8388634" vendor-id="None"/>	<!-- Ericsson Spending Status Notification -->
+		<command name="Spending-Limit"			code="8388635" vendor-id="None"/>	<!-- TGPP 29.219/Sy -->
+		<command name="Spending-Status-Notification"	code="8388636" vendor-id="None"/>	<!-- TGPP 29.219/Sy -->
+		<command name="TDF-Session"	code="8388637" vendor-id="None"/>	<!-- [3GPP TS 29.212][Kimmo_Kymalainen] -->
+		<command name="3GPP-Update-VCSG-Location"	code="8388638" vendor-id="None"/>  <!-- [3GPP TS 29.272][Kimmo_Kymalainen] -->
+		<command name="3GPP-Device-Action"		code="8388639" vendor-id="None"/>     <!--[3GPP TS 29.368][RFC5719] -->
+		<command name="3GPP-Device-Notification"	code="8388640" vendor-id="None"/>    <!--[3GPP TS 29.368][RFC5719] -->
+		<command name="3GPP-Subscriber-Information"	code="8388641" vendor-id="None"/>     <!-- 3GPP TS 29.336 -->
+		<command name="Cancel-VCSG-Location"	code="8388642" vendor-id="None"/>
+		<command name="3GPP-Device-Trigger"		code="8388643" vendor-id="None"/>       <!-- 3GPP TS 29.337 -->
+		<command name="3GPP-Delivery-Report"		code="8388644" vendor-id="None"/>     <!-- 3GPP TS 29.337 -->
+		<command name="MO-Forward-Short-Message"	code="8388645" vendor-id="None"/>   <!-- 3GPP TS 29.338 -->
+		<command name="MT-Forward-Short-Message"	code="8388646" vendor-id="None"/>   <!-- 3GPP TS 29.338 -->
+		<command name="Send-Routing-Info-for-SM"	code="8388647" vendor-id="None"/>   <!-- 3GPP TS 29.338 -->
+		<command name="Alert-Service-Centre"	code="8388648" vendor-id="None"/>       <!-- 3GPP TS 29.338 -->
+		<command name="Report-SM-Delivery-Status"	code="8388649" vendor-id="None"/>   <!-- 3GPP TS 29.338 -->
+		<command name="NSN Cancel-LocationMS"		code="8388650" vendor-id="None"/>
+		<command name="NSN User-DataMS"		code="8388651" vendor-id="None"/>
+		<command name="NSN Profile-UpdateMS"		code="8388652" vendor-id="None"/>
+		<command name="NSN Subscribe-NotificationsMS"		code="8388653" vendor-id="None"/>
+		<command name="NSN Push-NotificationMS"		code="8388654" vendor-id="None"/>
+		<command name="Get Gateway"		code="8388655" vendor-id="None"/>
+		<command name="Trigger-Establishment"		code="8388656" vendor-id="None"/>
+		<command name="Ericsson Binding-Data"		code="8388657" vendor-id="None"/>
+		<!--
+			8388658 3GPP2 Subscriber-Information-Request/Answer (SIR/SIA) [3GPP2 X.S0068][Jun_Wang]
+			8388659 Verizon Session Data Recovery Request/Answer (SDR/SDA) [Niranjan_Avula]
+			8388660 Nokia Core Service Request/Answer (CSR/CSA) [Timo_Perala]
+			8388661 Nokia Extended Command Request/Answer (ECR/ECA) [Timo_Perala]
+			8388662 GCS-Action-Request/Answer (GAR/GAA) [3GPP TS 29.468][Kimmo_Kymalainen]
+			8388663 GCS-Notification-Request/Answer (GNR/GNA) [3GPP TS 29.468][Kimmo_Kymalainen]
+			8388664 ProSe-Subscriber-Information-Request/Answer (PIR/PIA) [3GPP TS 29.344][Kimmo_Kymalainen]  TGPP.xml
+			8388665 Update-ProSe-Subscriber-Data-Request/Answer (UPR/UPA) [3GPP TS 29.344][Kimmo_Kymalainen]  TGPP.xml
+			8388666 ProSe-Notify-Request/Answer (PNR/PNA) [3GPP TS 29.344][Kimmo_Kymalainen]                  TGPP.xml
+			8388667 Reset-Request/Answer (RSR/RSA) [3GPP TS 29.344][Kimmo_Kymalainen]                         TGPP.xml
+			8388668 ProSe-Authorization-Request/Answer (PAR/PAA) [3GPP TS 29.345][Kimmo_Kymalainen]
+			8388669 ProSe-Discovery-Request/Answer (PDR/PDA) [3GPP TS 29.345][Kimmo_Kymalainen]
+			8388670 ProSe-Match-Request/Answer (PMR/PMA) [3GPP TS 29.345][Kimmo_Kymalainen]
+			8388671 ProSe-Match-Report-Info-Request/Answer (PIR/PIA) [3GPP TS 29.345][Kimmo_Kymalainen]
+			8388672 ProSe-Proximity-Request/Answer (PRR/PRA) [3GPP TS 29.345][Kimmo_Kymalainen]
+			8388673 ProSe-Location-Update-Request (PLR/PLA) [3GPP TS 29.345][Kimmo_Kymalainen]
+			8388674 ProSe-Alert-Request/Answer (ALR/ALA) [3GPP TS 29.345][Kimmo_Kymalainen]
+			8388675 ProSe-Cancellation-Request/Answer (RPR/RPA) [3GPP TS 29.345][Kimmo_Kymalainen]
+			8388676 ProXimity-Action-Request/Answer (PXR/PXA) [3GPP TS 29.343][Kimmo_Kymalainen]
+			8388677 Rivada Xd DSC-Registration-Request/Answer (DDRR/DDRA) [Vincent_D_Onofrio]
+			8388678 Rivada Xd Heart-Beat-Request/Answer (DHBR/DHBA) [Vincent_D_Onofrio]
+			8388679 Rivada Xd Cell-Info-Transfer-Request/Answer (DCTR/DCTA) [Vincent_D_Onofrio]
+			8388680 Rivada Xd Cell-Info-Notification-Request/Answer (DCNR/DCNA) [Vincent_D_Onofrio]
+			8388681 Rivada Xd Cell-Info-Modification-Request/Answer (DIMR/DIMA) [Vincent_D_Onofrio]
+			8388682 Rivada Xd Cell-Info-Modification-Notification-Request/Answer (DINR/DINA) [Vincent_D_Onofrio]
+			8388683 Rivada Xd Resource-Allocation-Request/Answer (DRAR/DRAA) [Vincent_D_Onofrio]
+			8388684 Rivada Xd Resource-Allocation-Notification-Request/Answer (DANR/DANA) [Vincent_D_Onofrio]
+			8388685 Rivada Xd Resource-Modification-Request/Answer (DRMR/DRMA) [Vincent_D_Onofrio]
+			8388686 Rivada Xd Resource-Modification-Notification-Request/Answer (DMNR/DMNA) [Vincent_D_Onofrio]
+			8388687 Rivada Xd Resource-Hold-Request/Answer (DRHR/DRHA) [Vincent_D_Onofrio]
+			8388688 Rivada Xd Resource-Hold-Notification-Request/Answer (DHNR/DHNA) [Vincent_D_Onofrio]
+			8388689 Rivada Xd Resource-Resume-Request/Answer (DRSR/DRSA) [Vincent_D_Onofrio]
+			8388690 Rivada Xd Resource-Resume-Notification-Request/Answer (DSNR/DSNA) [Vincent_D_Onofrio]
+			8388691 Rivada Xd Resource-Usage-Update-Request/Answer (DRUR/DRUA) [Vincent_D_Onofrio]
+			8388692 Rivada Xd Resource-Usage-Notification-Request/Answer (DUNR/DUNA) [Vincent_D_Onofrio]
+			8388693 Rivada Xd Resource-Release-Request/Answer (DRRR/DRRA) [Vincent_D_Onofrio]
+			8388694 Rivada Xd Resource-Release-Notification-Request/Answer (DRNR/DRNA) [Vincent_D_Onofrio]
+			8388695 Rivada Xm Resource-Allocation-Request/Answer (MRAR/MRAA) [Vincent_D_Onofrio]
+			8388696 Rivada Xm Resource-Hold-Request/Answer (MRHR/MRHA) [Vincent_D_Onofrio]
+			8388697 Rivada Xm Resource-Release-Request/Answer (MRRR/MRRA) [Vincent_D_Onofrio]
+			8388698 Rivada Xm Resource-Modify-Request/Answer (MRMR/MRMA) [Vincent_D_Onofrio]
+			8388699 Rivada Xm Resource-Allocation-Notify-Request/Answer (MANR/MANA) [Vincent_D_Onofrio]
+			8388700 Rivada Xm Resource-Resume-Request/Answer (MRSR/MRSA) Vincent_D_Onofrio]
+			8388701 Rivada Xm Add-UE-Context-Request/Answer (MAUR/MAUA) [Vincent_D_Onofrio]
+			8388702 Rivada Xm Update-UE-Context-Request/Answer (MUUR/MUUA) [Vincent_D_Onofrio]
+			8388703 Rivada Xm Delete-UE-Context-Request/Answer (MDUR/MDUA) [Vincent_D_Onofrio]
+			8388704 Rivada Xm Detach-UE-Request/Answer (MDTR/MDTA) [Vincent_D_Onofrio]
+			8388705 Rivada Xm Page-UE-Request/Answer (MPUR/MPUA)[Vincent_D_Onofrio]
+			8388706 Rivada Xm Heart-Beat-Request/Answer (MHBR/MHBA) [Vincent_D_Onofrio]
+			8388707 Rivada Xa DPC-Registration-Request/Answer (ADRR/ADRA) [Vincent_D_Onofrio]
+			8388708 Rivada Xa Heart-Beat-Request/Answer (AHBR/AHBA) [Vincent_D_Onofrio]
+			8388709 Rivada Xa Resource-Allocation-Request/Answer (ARAR/ARAA) [Vincent_D_Onofrio]
+			8388710 Rivada Xa Resource-Release-Request/Answer (ARRR/ARRA) [Vincent_D_Onofrio]
+			8388711 Rivada Xa Resource-Release-Notification-Request/Answer (ARNR/ARNA) [Vincent_D_Onofrio]
+			8388712 Rivada Xh User-Data-Request/Answer (HUDR/HUDA) [Vincent_D_Onofrio]
+			8388713 ProSe-Initial-Location-Information-Request/Answer (PSR/PSA) [3GPP TS 29.344][Kimmo_Kymalainen] TGPP.xml
+			8388714 Nokia Session-Sync-Request/Answer (SSR/SSA) [Timo_Perala]
+			8388715 Nokia Session-Mass-Sync-Request/Answer (SMR/SMA) [Timo_Perala]
+			8388716 Nokia Fetch-Session-Request/Answer (FSR/FSA) [Timo_Perala]
+		-->
+		<command name="Ericsson Trace-Report"		code="8388717" vendor-id="None"/>
+		<command name="Configuration-Information"		code="8388718" vendor-id="None"/>
+		<command name="Reporting-Information"		code="8388719" vendor-id="None"/>
+		<command name="Non-Aggregated-RUCI-Report"		code="8388720" vendor-id="None"/>
+		<command name="Aggregated-RUCI-Report"		code="8388721" vendor-id="None"/>
+		<command name="Modify-Uecontext"		code="8388722" vendor-id="None"/>
+		<!--
+			8388723 Background-Data-Transfer-Request/Answer (BTR/BTA) [3GPP TS 29.154][Kimmo_Kymalainen]
+			8388724 Network-Status-Request/Answer (NSR/NSA) [3GPP TS 29.153][Kimmo_Kymalainen]
+			8388725 Network-Status-Continuous-Report-Request/Answer (NCR/NCA) [3GPP TS 29.153][Kimmo_Kymalainen]
+		-->
+		<command name="NIDD-Information"		code="8388726" vendor-id="None"/>	<!-- 3GPP TS 29.336 -->
+		<!--
+			8388727 ProXimity-Application-Request/Answer (XAR/XAA) [3GPP TS 29.343][Kimmo_Kymalainen]
+			8388728 Data-Pull-Request/Answer (DPR/DPA) [3GPP TS 29.283][Kimmo_Kymalainen]
+			8388729 Data-Update-Request/Answer (DMR/DMA) [3GPP TS 29.283][Kimmo_Kymalainen]
+			8388730 Notification-Data-Request/Answer (NDR/NDA) [3GPP TS 29.283][Kimmo_Kymalainen]
+			8388731 TSSF-Notification-Request/Answer (TNR/TNA) [3GPP TS 29.212][Kimmo_Kymalainen]
+		-->
+		<command name="Connection-Management"		code="8388732" vendor-id="None"/>    <!-- 3GPP TS 29.128 -->
+		<command name="MO-Data"		code="8388733" vendor-id="None"/>     <!-- 3GPP TS 29.128 -->
+		<command name="MT-Data"		code="8388734" vendor-id="None"/>     <!-- 3GPP TS 29.128 -->
+		<!--
+			8388658-16777213 Unassigned
+			16777214 Experimental code [RFC3588]
+			16777215 Experimental code [RFC3588]
+		-->
+
+		<!-- ************************************************************** -->
+		<!-- ********************** End Commands ************************** -->
+		<!-- ************************************************************** -->
+
+
+		<!-- ************************************************************** -->
+		<!-- ************************ typedefn's ************************** -->
+		<!-- ************************************************************** -->
+		<typedefn type-name="OctetString"/>
+		<!--
+			The data contains arbitrary data of variable length. Unless
+			otherwise noted, the AVP Length field MUST be set to at least 9
+			(13 if the 'V' bit is enabled).  Data used to transmit (human
+			readable) character string data uses the UTF-8 [24] character
+			set and is NOT NULL-terminated. The minimum Length field MUST
+			be 9, but can be set to any value up to 65504 bytes. AVP Values
+			of this type that do not align on a 32-bit boundary MUST have
+			the necessary padding.
+		-->
+		<typedefn type-name="UTF8String" type-parent="OctetString"/>
+		<!--
+			The UTF8String format is derived from the OctetString AVP Base
+			Format. This is a human readable string represented using the
+			ISO/IEC IS 10646-1 character set, encoded as an OctetString
+			using the UTF-8 [29] transformation format described in RFC
+			2279.
+
+			Since additional code points are added by amendments to the
+			10646 standard from time to time, implementations MUST be
+			prepared to encounter any code point from 0x00000001 to
+			0x7fffffff. Byte sequences that do not correspond to the valid
+			UTF-8 encoding of a code point or are outside this range are
+			prohibited. Note that since a code point of 0x00000000 is
+			prohibited, no octet will contain a value of 0x00.
+
+			The use of control codes SHOULD be avoided. When it is
+			necessary to represent a newline, the control code sequence CR
+			LF SHOULD be used.
+
+			The use of leading or trailing white space SHOULD be avoided.
+
+			For code points not directly supported by user interface
+			hardware or software, an alternative means of entry and
+			display, such as hexadecimal, MAY be provided.
+
+			For information encoded in 7-bit US-ASCII, the UTF-8 encoding
+			is identical to the US-ASCII encoding.
+
+			UTF-8 may require multiple bytes to represent a single
+			character / code point; thus the length of a UTF8String in
+			octets may be different from the number of characters encoded.
+
+			Note that the size of an UTF8String is measured in octets, not
+			characters.
+
+			The UTF8String MUST not contain any octets with a value of
+			zero.
+		-->
+		<typedefn type-name="IPAddress" type-parent="OctetString"/>
+		<!--
+			The IPAddress format is derived from the OctetString AVP Base
+			Format. It represents 32 bit (IPv4) [17] or 128 bit (IPv6) [16]
+			address, most significant octet first. The format of the
+			address (IPv4 or IPv6) is determined by the length. If the
+			attribute value is an IPv4 address, the AVP Length field MUST
+			be 12 (16 if 'V' bit is enabled), otherwise the AVP Length
+			field MUST be set to 24 (28 if the 'V' bit is enabled) for IPv6
+			addresses.
+		-->
+		<typedefn type-name="DiameterIdentity" type-parent="OctetString"/>
+		<!--
+			The DiameterIdentity format is derived from the OctetString AVP
+			Base Format.  It uses the UTF-8 encoding and has the same
+			requirements as the UTF8String.  In addition, it must follow
+			the Uniform Resource Identifiers (URI) syntax [29] rules
+			specified below:
+
+			   Diameter-Identity  = fqdn [ port ] [ transport ]
+						[ protocol ]
+
+			   aaa-protocol       = ( "diameter" | "radius" | "tacacs+" )
+
+			   protocol           = ";protocol=" aaa-protocol
+						; If absent, the default AAA protocol
+						; is diameter.
+
+			   fqdn               = Fully Qualified Host Name
+
+			   port               = ":" 1*DIGIT
+						; One of the ports used to listen for
+						; incoming connections. ; If absent,
+						; the default Diameter port (TBD) is
+						; assumed.
+
+			   transport-protocol = ( "tcp" | "sctp" | "udp" )
+
+			   transport          = ";transport=" transport-protocol
+
+						; One of the transports used to listen
+						; for incoming connections. If absent,
+						; the default SCTP [26] protocol is
+						; assumed. UDP MUST NOT be used when
+						; the aaa-protocol field is set to
+						; diameter.
+
+			   The following are examples of valid Diameter host
+			   identities:
+
+			      host.abc.com;transport=tcp
+			      host.abc.com:6666;transport=tcp
+			      aaa://host.abc.com;protocol=diameter
+			      aaa://host.abc.com:6666;protocol=diameter
+			      aaa://host.abc.com:6666;transport=tcp;protocol=diameter
+			      aaa://host.abc.com:1813;transport=udp;protocol=radius
+
+			Since multiple Diameter processes on a single host cannot
+			listen for incoming connections on the same port on a given
+			protocol, the DiameterIdentity is guaranteed to be unique per
+			host.
+
+			A Diameter node MAY advertise different identities on each
+			connection, via the CER and CEA's Origin-Host AVP, but the same
+			identity MUST be used throughout the duration of a connection.
+
+			When comparing AVPs of this format, it is necessary to add any
+			absent fields with the default values prior to the comparison.
+			For example, diameter-host.abc.com would be expanded to
+			aaa://diameter/diameter-host.abc.com:TBD;protocol=sctp.
+		-->
+		<typedefn type-name="IPFilterRule" type-parent="OctetString"/>
+		<!--
+			The IPFilterRule format is derived from the OctetString AVP
+			Base Format.  It uses the UTF-8 encoding and has the same
+			requirements as the UTF8String. Packets may be filtered based
+			on the following information that is associated with it:
+
+			   Direction                          (in or out)
+			   Source and destination IP address  (possibly masked)
+			   Protocol
+			   Source and destination port        (lists or ranges)
+			   TCP flags
+			   IP fragment flag
+			   IP options
+			   ICMP types
+
+			Rules for the appropriate direction are evaluated in order,
+			with the first matched rule terminating the evaluation.  Each
+			packet is evaluated once. If no rule matches, the packet is
+			dropped if the last rule evaluated was a permit, and passed if
+			the last rule was a deny.
+
+			IPFilterRule filters MUST follow the format:
+
+			   action dir proto from src to dst [options]
+
+			   action       permit - Allow packets that match the rule.
+					deny   - Drop packets that match the rule.
+
+			   dir          "in" is from the terminal, "out" is to the
+					terminal.
+
+			   proto        An IP protocol specified by number.  The "ip"
+					keyword means any protocol will match.
+
+			   src and dst  <address/mask> [ports]
+
+					The <address/mask> may be specified as:
+					ipno       An IPv4 or IPv6 number in dotted-
+						   quad or canonical IPv6 form. Only
+						   this exact IP number will match the
+						   rule.
+					ipno/bits  An IP number as above with a mask
+						   width of the form 1.2.3.4/24.  In
+						   this case all IP numbers from
+						   1.2.3.0 to 1.2.3.255 will match.
+						   The bit width MUST be valid for the
+						   IP version and the IP number MUST
+						   NOT have bits set beyond the mask.
+
+					The sense of the match can be inverted by
+					preceding an address with the not modifier,
+					causing all other addresses to be matched
+					instead.  This does not affect the selection of
+					port numbers.
+
+					   The keyword "any" is 0.0.0.0/0 or the IPv6
+					   equivalent.  The keyword "assigned" is the
+					   address or set of addresses assigned to the
+					   terminal.  The first rule SHOULD be "deny in
+					   ip !assigned".
+
+					With the TCP, UDP and SCTP protocols, optional
+					ports may be specified as:
+
+					   {port|port-port}[,port[,...]]
+
+					The `-' notation specifies a range of ports
+					(including boundaries).
+
+					Fragmented packets which have a non-zero offset
+					(i.e. not the first fragment) will never match
+					a rule which has one or more port
+					specifications.  See the frag option for
+					details on matching fragmented packets.
+
+			   options:
+			      frag    Match if the packet is a fragment and this is not
+				      the first fragment of the datagram.  frag may not
+				      be used in conjunction with either tcpflags or
+				      TCP/UDP port specifications.
+
+			      ipoptions spec
+				      Match if the IP header contains the comma
+				      separated list of options specified in spec. The
+				      supported IP options are:
+
+				      ssrr (strict source route), lsrr (loose source
+				      route), rr (record packet route) and ts
+				      (timestamp). The absence of a particular option
+				      may be denoted with a `!'.
+
+			      tcpoptions spec
+				      Match if the TCP header contains the comma
+				      separated list of options specified in spec. The
+				      supported TCP options are:
+
+				      mss (maximum segment size), window (tcp window
+				      advertisement), sack (selective ack), ts (rfc1323
+				      timestamp) and cc (rfc1644 t/tcp connection
+				      count).  The absence of a particular option may
+				      be denoted with a `!'.
+
+			      established
+				      TCP packets only. Match packets that have the RST
+				      or ACK bits set.
+
+			      setup   TCP packets only. Match packets that have the SYN
+				      bit set but no ACK bit.
+
+			      tcpflags spec
+				      TCP packets only. Match if the TCP header
+				      contains the comma separated list of flags
+				      specified in spec. The supported TCP flags are:
+
+				      fin, syn, rst, psh, ack and urg. The absence of a
+				      particular flag may be denoted with a `!'. A rule
+				      which contains a tcpflags specification can never
+				      match a fragmented packet which has a non-zero
+				      offset.  See the frag option for details on
+				      matching fragmented packets.
+
+			      icmptypes types
+				      ICMP packets only.  Match if the ICMP type is in
+				      the list types. The list may be specified as any
+				      combination of ranges or individual types
+				      separated by commas.  The supported ICMP types
+				      are:
+
+				      echo reply (0), destination unreachable (3),
+				      source quench (4), redirect (5), echo request
+				      (8), router advertisement (9), router
+				      solicitation (10), time-to-live exceeded (11), IP
+				      header bad (12), timestamp request (13),
+				      timestamp reply (14), information request (15),
+				      information reply (16), address mask request (17)
+				      and address mask reply (18).
+
+			There is one kind of packet that the access device MUST always
+			discard, that is an IP fragment with a fragment offset of one.
+			This is a valid packet, but it only has one use, to try to
+			circumvent firewalls.
+
+			   An access device that is unable to interpret or apply a deny
+			   rule MUST terminate the session.  An access device that is
+			   unable to interpret or apply a permit rule MAY apply a more
+			   restrictive rule.  An access device MAY apply deny rules of
+			   its own before the supplied rules, for example to protect
+			   the access device owner's infrastructure.
+
+			The rule syntax is a modified subset of ipfw(8) from FreeBSD,
+			and the ipfw.c code may provide a useful base for
+			implementations.
+		-->
+		<typedefn type-name="QoSFilterRule" type-parent="OctetString"/>
+		<!--
+			The QosFilterRule format is derived from the OctetString AVP
+			Base Format.  It uses the UTF-8 encoding and has the same
+			requirements as the UTF8String. Packets may be marked or
+			metered based on the following information that is associated
+			with it:
+
+			   Direction                          (in or out)
+			   Source and destination IP address  (possibly masked)
+			   Protocol
+			   Source and destination port        (lists or ranges)
+			   DSCP values                        (no mask or range)
+
+			Rules for the appropriate direction are evaluated in order,
+			with the first matched rule terminating the evaluation.  Each
+			packet is evaluated once. If no rule matches, the packet is
+			treated as best effort.
+
+			QoSFilterRule filters MUST follow the format:
+
+			   action dir proto from src to dst [options]
+
+					tag    - Mark packet with a specific DSCP [49].
+						 The DSCP option MUST be included.
+
+					meter  - Meter traffic. The metering options
+						 MUST be included.
+
+			   dir          "in" is from the terminal, "out" is to the
+					terminal.
+
+			   proto        An IP protocol specified by number.  The "ip"
+					keyword means any protocol will match.
+
+			   src and dst  <address/mask> [ports]
+
+					The <address/mask> may be specified as:
+					ipno       An IPv4 or IPv6 number in dotted-
+						   quad or canonical IPv6 form. Only
+						   this exact IP number will match the
+						   rule.
+					ipno/bits  An IP number as above with a mask
+						   width of the form 1.2.3.4/24.  In
+						   this case all IP numbers from
+						   1.2.3.0 to 1.2.3.255 will match.
+						   The bit width MUST be valid for the
+						   IP version and the IP number MUST
+						   NOT have bits set beyond the mask.
+
+					The sense of the match can be inverted by
+					preceding an address with the not modifier,
+					causing all other addresses to be matched
+					instead.  This does not affect the selection of
+					port numbers.
+
+					   The keyword "any" is 0.0.0.0/0 or the IPv6
+					   equivalent.  The keyword "assigned" is the
+					   address or set of addresses assigned to the
+					   terminal.  The first rule SHOULD be "deny in
+					   ip !assigned".
+
+					With the TCP, UDP and SCTP protocols, optional
+					ports may be specified as:
+
+					   {port|port-port}[,port[,...]]
+
+					The `-' notation specifies a range of ports
+					(including boundaries).
+
+			   options:
+
+			      DSCP <color>
+				      color values as defined in [49]. Exact matching
+				      of DSCP values is required (no masks or ranges).
+				      the "deny" can replace the color_under or
+				      color_over values in the meter action for rate-
+				      dependent packet drop.
+
+			      metering <rate> <color_under> <color_over>
+				      The metering option provides Assured Forwarding,
+				      as defined in [50], and MUST be present if the
+				      action is set to meter. The rate option is the
+				      throughput, in bits per second, which is used by
+				      the access device to mark packets. Traffic above
+				      the rate is marked with the color_over codepoint,
+				      while traffic under the rate is marked with the
+				      color_under codepoint. The color_under and
+				      color_over options contain the drop preferences,
+				      and MUST conform to the recommended codepoint
+				      keywords described in [50] (e.g. AF13).
+
+				      The metering option also supports the strict
+				      limit on traffic required by Expedited
+				      Forwarding, as defined in [51]. The color_over
+				      option may contain the keyword "drop" to prevent
+				      forwarding of traffic that exceeds the rate
+				      parameter.
+
+			The rule syntax is a modified subset of ipfw(8) from FreeBSD,
+			and the ipfw.c code may provide a useful base for
+			implementations.
+		-->
+		<typedefn type-name="MIPRegistrationRequest" type-parent="OctetString"/>
+		<typedefn type-name="Integer32"/>
+		<!--
+			32 bit signed value, in network byte order. The AVP Length
+			field MUST be set to 12 (16 if the 'V' bit is enabled).
+		-->
+		<typedefn type-name="VendorId" type-parent="Unsigned32"/>
+		<typedefn type-name="AppId" type-parent="Unsigned32"/>
+		<typedefn type-name="Integer64"/>
+		<!--
+			64 bit signed value, in network byte order. The AVP Length
+			field MUST be set to 16 (20 if the 'V' bit is enabled).
+		-->
+		<typedefn type-name="Unsigned32"/>
+		<!--
+			32 bit unsigned value, in network byte order. The AVP Length
+			field MUST be set to 12 (16 if the 'V' bit is enabled).
+			Unsigned32 values used to transmit time data contains the four
+			most significant octets returned from NTP [18], in network byte
+			order.
+		-->
+		<typedefn type-name="Time"/>
+		<!--
+			The Time format is derived from the Unsigned32 AVP Base Format.
+			This is 32 bit unsigned value containing the four most
+			significant octets returned from NTP [18], in network byte
+			order.
+
+			This represent the number of seconds since 0h on 1 January 1900
+			with respect to the Coordinated Universal Time (UTC).
+
+			On 6h 28m 16s UTC, 7 February 2036 the time value will
+			overflow.  NTP [18] describes a procedure to extend the time to
+			2104.
+		-->
+		<typedefn type-name="Unsigned64"/>
+		<!--
+			64 bit unsigned value, in network byte order. The AVP Length
+			field MUST be set to 16 (20 if the 'V' bit is enabled).
+		-->
+		<typedefn type-name="Enumerated" type-parent="Integer32"/>
+		<typedefn type-name="DiameterURI" type-parent="UTF8String"/>
+		<typedefn type-name="Float32"/>
+		<!--
+			This represents floating point values of single precision as
+			described by [FLOATPOINT].  The 32-bit value is transmitted in
+			network byte order.  The AVP Length field MUST be set to 12 (16 if
+			the 'V' bit is enabled).
+		-->
+		<typedefn type-name="Float64"/>
+		<!--
+			This represents floating point values of double precision as
+			described by [FLOATPOINT].  The 64-bit value is transmitted in
+			network byte order.  The AVP Length field MUST be set to 16 (20 if
+			the 'V' bit is enabled).
+		-->
+
+		<!-- ************************************************************** -->
+		<!-- ************************* End Typedefns ************************ -->
+		<!-- ************************************************************** -->
+
+		<!-- ************************************************************** -->
+		<!-- ******************* RADIUS AVPS ************************ -->
+		<!-- ************************************************************** -->
+		<!-- http://www.iana.org/assignments/aaa-parameters -->
+		<!-- 1-255    Radius attributes                  [RAD-IANA] -->
+		<avp name="User-Name" code="1" mandatory="must">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="User-Password" code="2" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="CHAP-Password" code="3" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="NAS-IP-Address" code="4" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="NAS-Port" code="5" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Service-Type" code="6" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="Unknown" code="0"/>
+			<enum name="Login" code="1"/>
+			<enum name="Framed" code="2"/>
+			<enum name="Callback-Login" code="3"/>
+			<enum name="Callback-Framed" code="4"/>
+			<enum name="Outbound" code="5"/>
+			<enum name="Administrative" code="6"/>
+			<enum name="NAS-Prompt" code="7"/>
+			<enum name="Authenticate-Only" code="8"/>
+			<enum name="Callback-NAS-Prompt" code="9"/>
+			<enum name="Call Check" code="10"/>
+			<enum name="Callback Administrative" code="11"/>
+			<enum name="Voice" code="12"/>
+			<enum name="Fax" code="13"/>
+			<enum name="Modem Relay" code="14"/>
+			<enum name="IAPP-Register" code="15"/>
+			<enum name="IAPP-AP-Check" code="16"/>
+			<enum name="Authorize Only" code="17"/>
+			<enum name="Framed-Management" code="18"/>
+		</avp>
+		<avp name="Framed-Protocol" code="7" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="PPP" code="1"/>
+			<enum name="SLIP" code="2"/>
+			<enum name="ARAP" code="3"/>
+			<enum name="Gandalf" code="4"/>
+			<enum name="Xylogics" code="5"/>
+			<enum name="X.75" code="6"/>
+			<enum name="GPRS PDP Context" code="7"/>
+			<enum name="Ascend-ARA" code="255"/>
+			<enum name="MPP" code="256"/>
+			<enum name="EURAW" code="257"/>
+			<enum name="EUUI" code="258"/>
+			<enum name="X25" code="259"/>
+			<enum name="COMB" code="260"/>
+			<enum name="FR" code="261"/>
+		</avp>
+		<avp name="Framed-IP-Address" code="8" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Framed-IP-Netmask" code="9" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Framed-Routing" code="10" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="None" code="0"/>
+			<enum name="Send routing packets" code="1"/>
+			<enum name="Listen for routing packets" code="2"/>
+			<enum name="Send and Listen	" code="3"/>
+		</avp>
+		<avp name="Filter-Id" code="11" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Framed-MTU" code="12" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Framed-Compression" code="13" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="None" code="0"/>
+			<enum name="Van Jacobson TCP/IP header compression" code="1"/>
+			<enum name="IPX header compression" code="2"/>
+			<enum name="Stac-LZS compression" code="3"/>
+		</avp>
+		<avp name="Login-IP-Host" code="14" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Login-Service" code="15" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="Telnet" code="0"/>
+			<enum name="Rlogin" code="1"/>
+			<enum name="TCP-Clear" code="2"/>
+			<enum name="PortMaster" code="3"/>
+			<enum name="LAT" code="4"/>
+			<enum name="X25-PAD" code="5"/>
+			<enum name="X25-T3POS" code="6"/>
+			<enum name="Unassigned" code="7"/>
+			<enum name="TCP Clear Quiet (suppresses any NAS-generated connect string)" code="8"/>
+		</avp>
+		<avp name="Login-TCP-Port" code="16" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<!-- AVP 17 unassigned -->
+		<avp name="Reply-Message" code="18" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Callback-Number" code="19" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Callback-Id" code="20" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<!-- AVP 21 unassigned -->
+		<avp name="Framed-Route" code="22" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Framed-IPX-Network" code="23" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="State" code="24" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Class" code="25" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Vendor-Specific" code="26" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+			<!-- Should vendors be enum'ed? -->
+		</avp>
+		<avp name="Session-Timeout" code="27" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Idle-Timeout" code="28" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Termination-Action" code="29" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="Default" code="0"/>
+			<enum name="RADIUS-Request" code="1"/>
+		</avp>
+		<avp name="Called-Station-Id" code="30" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Calling-Station-Id" code="31" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="NAS-Identifier" code="32" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Proxy-State" code="33" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Login-LAT-Service" code="34" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Login-LAT-Node" code="35" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Login-LAT-Group" code="36" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Framed-AppleTalk-Link" code="37" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Framed-AppleTalk-Network" code="38" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Framed-AppleTalk-Zone" code="39" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Acct-Status-Type" code="40">
+			<type type-name="Enumerated"/>
+			<enum name="Start" code="1"/>
+			<enum name="Stop" code="2"/>
+			<enum name="Interim-Update" code="3"/>
+			<enum name="Modem-Start" code="4"/>
+			<enum name="Modem-Stop" code="5"/>
+			<enum name="Cancel" code="6"/>
+			<enum name="Accounting-On" code="7"/>
+			<enum name="Accounting-Off" code="8"/>
+			<!-- 9-14 Reserved for Tunnel Accounting -->
+			<enum name="Tunnel-Start" code="9"/>
+			<enum name="Tunnel-Stop" code="10"/>
+			<enum name="Tunnel-Reject" code="11"/>
+			<enum name="Tunnel-Link-Start" code="12"/>
+			<enum name="Tunnel-Link-Stop" code="13"/>
+			<enum name="Tunnel-Link-Rejectf" code="14"/>
+			<!-- 15 Reserved for Tunnel Failed -->
+			<enum name="Failed" code="15"/>
+		</avp>
+		<avp name="Acct-Delay-Time" code="41" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Acct-Input-Octets" code="42" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Acct-Output-Octets" code="43" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Acct-Session-Id" code="44" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+			<!-- See https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=5411 -->
+		</avp>
+		<avp name="Acct-Authentic" code="45" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="None" code="0"/>
+			<enum name="RADIUS" code="1"/>
+			<enum name="Local" code="2"/>
+			<enum name="Remote" code="3"/>
+			<enum name="Diameter" code="4"/>
+		</avp>
+		<avp name="Acct-Session-Time" code="46" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Acct-Input-Packets" code="47" mandatory="may">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Acct-Output-Packets" code="48" mandatory="may">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Acct-Terminate-Cause" code="49">
+			<type type-name="Enumerated"/>
+			<enum name="User-Request" code="1"/>
+			<enum name="Lost-Carrier" code="2"/>
+			<enum name="Lost-Service" code="3"/>
+			<enum name="Idle-Timeout" code="4"/>
+			<enum name="Session-Timeout" code="5"/>
+			<enum name="Admin-Reset" code="6"/>
+			<enum name="Admin-Reboot" code="7"/>
+			<enum name="Port-Error" code="8"/>
+			<enum name="NAS-Error" code="9"/>
+			<enum name="NAS-Request" code="10"/>
+			<enum name="NAS-Reboot" code="11"/>
+			<enum name="Port-Unneeded" code="12"/>
+			<enum name="Port-Preempted" code="13"/>
+			<enum name="Port-Suspended" code="14"/>
+			<enum name="Service-Unavailable" code="15"/>
+			<enum name="Callback" code="16"/>
+			<enum name="User-Error" code="17"/>
+			<enum name="Host-Request" code="18"/>
+			<enum name="Supplicant Restart" code="19"/>
+			<enum name="Reauthentication Failure" code="20"/>
+			<enum name="Port Reinitialized" code="21"/>
+			<enum name="Port Administratively Disabled" code="22"/>
+		</avp>
+		<avp name="Accounting-Multi-Session-Id" code="50" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Acct-Link-Count" code="51" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Acct-Input-Gigawords" code="52" mandatory="may">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Acct-Output-Gigawords" code="53" mandatory="may">
+			<type type-name="Integer32"/>
+		</avp>
+		<!-- AVP 54 unassigned -->
+		<avp name="Event-Timestamp" code="55" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Egress-VLANID" code="56" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Ingress-Filters" code="57" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="Enabled" code="1"/>
+			<enum name="Disabled" code="2"/>
+		</avp>
+		<avp name="Egress-VLAN-Name" code="58" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="User-Priority-Table" code="59" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="CHAP-Challenge" code="60" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="NAS-Port-Type" code="61" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="Async" code="0"/>
+			<enum name="Sync" code="1"/>
+			<enum name="ISDN-Sync" code="2"/>
+			<enum name="ISDN-Async-v120" code="3"/>
+			<enum name="ISDN-Async-v110" code="4"/>
+			<enum name="Virtual" code="5"/>
+			<enum name="PIAFS" code="6"/>
+			<enum name="HDLC-Clear-Channel" code="7"/>
+			<enum name="X25" code="8"/>
+			<enum name="X75" code="9"/>
+			<enum name="G.3 Fax" code="10"/>
+			<enum name="SDSL - Symmetric DSL" code="11"/>
+			<enum name="ADSL-CAP - Asymmetric DSL, Carrierless Amplitude Phase Modulation" code="12"/>
+			<enum name="ADSL-DMT - Asymmetric DSL, Discrete Multi-Tone" code="13"/>
+			<enum name="IDSL - ISDN Digital Subscriber Line" code="14"/>
+			<enum name="Ethernet" code="15"/>
+			<enum name="xDSL - Digital Subscriber Line of unknown type" code="16"/>
+			<enum name="Cable" code="17"/>
+			<enum name="Wireless - Other" code="18"/>
+			<enum name="Wireless - IEEE 802.11" code="19"/>
+			<enum name="Token-Ring" code="20"/>
+			<enum name="FDDI" code="21"/>
+			<enum name="Wireless - CDMA2000" code="22"/>
+			<enum name="Wireless - UMTS" code="23"/>
+			<enum name="Wireless - 1X-EV" code="24"/>
+			<enum name="IAPP" code="25"/>
+			<enum name="FTTP - Fiber to the Premises" code="26"/>
+			<enum name="Wireless - IEEE 802.16" code="27"/>
+			<enum name="Wireless - IEEE 802.20" code="28"/>
+			<enum name="Wireless - IEEE 802.22" code="29"/>
+			<enum name="PPPoA - PPP over ATM" code="30"/>
+			<enum name="PPPoEoA - PPP over Ethernet over ATM" code="31"/>
+			<enum name="PPPoEoE - PPP over Ethernet over Ethernet" code="32"/>
+			<enum name="PPPoEoVLAN - PPP over Ethernet over VLAN" code="33"/>
+			<enum name="PPPoEoQinQ - PPP over Ethernet over IEEE 802.1QinQ" code="34"/>
+			<enum name="xPON - Passive Optical Network" code="35"/>
+			<enum name="Wireless - XGP" code="36"/>
+		</avp>
+		<avp name="Port-Limit" code="62" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Login-LAT-Port" code="63" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Tunnel-Type" code="64" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="PPTP" code="1"/>
+			<enum name="L2F" code="2"/>
+			<enum name="L2TP" code="3"/>
+			<enum name="ATMP" code="4"/>
+			<enum name="VTP" code="5"/>
+			<enum name="AH" code="6"/>
+			<enum name="IP-IP-Encap" code="7"/>
+			<enum name="MIN-IP-IP" code="8"/>
+			<enum name="ESP" code="9"/>
+			<enum name="GRE" code="10"/>
+			<enum name="DVS" code="11"/>
+			<enum name="IP-in-IP Tunneling" code="12"/>
+			<enum name="VLAN" code="13"/>
+		</avp>
+		<avp name="Tunnel-Medium-Type" code="65" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="IPv4" code="1"/>
+			<enum name="IPv6" code="2"/>
+			<enum name="NSAP" code="3"/>
+			<enum name="HDLC" code="4"/>
+			<enum name="BBN" code="5"/>
+			<enum name="IEEE-802" code="6"/>
+			<enum name="E-163" code="7"/>
+			<enum name="E-164" code="8"/>
+			<enum name="F-69" code="9"/>
+			<enum name="X-121" code="10"/>
+			<enum name="IPX" code="11"/>
+			<enum name="Appletalk-802" code="12"/>
+			<enum name="Decnet4" code="13"/>
+			<enum name="Vines" code="14"/>
+			<enum name="E-164-NSAP" code="15"/>
+		</avp>
+		<avp name="Tunnel-Client-Endpoint" code="66" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Tunnel-Server-Endpoint" code="67" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Tunnel-Connection-ID" code="68" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Tunnel-Password" code="69" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="ARAP-Password" code="70" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="ARAP-Features" code="71" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="ARAP-Zone-Access" code="72" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="Only allow access to default zone" code="1"/>
+			<enum name="Use zone filter inclusively" code="2"/>
+			<enum name="Use zone filter exclusively" code="3"/>
+		</avp>
+		<avp name="ARAP-Security" code="73" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="ARAP-Security-Data" code="74" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Password-Retry" code="75" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Prompt" code="76" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="No Echo" code="0"/>
+			<enum name="Echo" code="1"/>
+		</avp>
+		<avp name="Connect-Info" code="77" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Configuration-Token" code="78" mandatory="must" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="EAP-Message" code="79" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Signature" code="80" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Tunnel-Private-Group-Id" code="81" mandatory="must" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Tunnel-Assignment-Id" code="82" mandatory="must" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Tunnel-Preference" code="83" mandatory="must" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="ARAP-Challenge-Response" code="84" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Acct-Interim-Interval" code="85" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Acct-Tunnel-Packets-Lost" code="86" mandatory="must" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="NAS-Port-Id" code="87" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Framed-Pool" code="88" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="CUI" code="89" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Tunnel-Client-Auth-Id" code="90" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Tunnel-Server-Auth-Id" code="91" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="RADIUS-NAS-Filter-Rule" code="92" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<!-- AVP 93 unassigned -->
+		<avp name="Originating-Line-Info" code="94" mandatory="may" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="NAS-IPv6-Address" code="95" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Framed-Interface-Id" code="96" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="Unsigned64"/>
+		</avp>
+		<avp name="Framed-IPv6-Prefix" code="97" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Login-IPv6-Host" code="98" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Framed-IPv6-Route" code="99" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Framed-IPv6-Pool" code="100" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Error-Cause" code="101" mandatory="may">
+			<type type-name="Enumerated"/>
+			<enum name="Diameter Common Messages" code="0"/>
+			<enum name="Residual Session Context Removed" code="201"/>
+			<enum name="Invalid EAP Packet (Ignored)" code="202"/>
+			<enum name="Unsupported Attribute" code="401"/>
+			<enum name="Missing Attribute" code="402"/>
+			<enum name="NAS Identification Mismatch" code="403"/>
+			<enum name="Invalid Request" code="404"/>
+			<enum name="Unsupported Service" code="405"/>
+			<enum name="Unsupported Extension" code="406"/>
+			<enum name="Invalid Attribute Value" code="407"/>
+			<enum name="Administratively Prohibited" code="501"/>
+			<enum name="Request Not Routable (Proxy)" code="502"/>
+			<enum name="Session Context Not Found" code="503"/>
+			<enum name="Session Context Not Removable" code="504"/>
+			<enum name="Other Proxy Processing Error" code="505"/>
+			<enum name="Resources Unavailable" code="506"/>
+			<enum name="Request Initiated" code="507"/>
+			<enum name="Multiple Session Selection Unsupported" code="508"/>
+		</avp>
+		<avp name="EAP-Key-Name" code="102" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Response" code="103" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Realm" code="104" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Nonce" code="105" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Response-Auth" code="106" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Nextnonce" code="107" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Method" code="108" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-URI" code="109" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Qop" code="110" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Algorithm" code="111" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Entity-Body-Hash" code="112" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-CNonce" code="113" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Nonce-Count" code="114" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Username" code="115" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Opaque" code="116" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Auth-Param" code="117" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-AKA-Auts" code="118" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Domain" code="119" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-Stale" code="120" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Digest-HA1" code="121" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="SIP-AOR" code="122" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Delegated-IPv6-Prefix" code="123" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="MIP6-Feature-Vector" code="124" mandatory="may">
+			<type type-name="Unsigned64"/>
+		</avp>
+		<avp name="MIP6-Home-Link-Prefix" code="125" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<!-- RFC5580 -->
+		<avp name="Operator-Name" code="126" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Location-Information" code="127" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Location-Data" code="128" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Basic-Location-Policy-Rules" code="129" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Extended-Location-Policy-Rules" code="130" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Location-Capable" code="131" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Requested-Location-Info" code="132" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Framed-Management-Protocol" code="133" mandatory="must" may-encrypt="no" protected="may" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="SNMP" code="1"/>
+			<enum name="Web-based" code="2"/>
+			<enum name="NETCONF" code="3"/>
+			<enum name="FTP" code="4"/>
+			<enum name="TFTP" code="5"/>
+			<enum name="SFTP" code="6"/>
+			<enum name="RCP" code="7"/>
+			<enum name="SCP" code="8"/>
+		</avp>
+		<avp name="Management-Transport-Protection" code="134" mandatory="must" may-encrypt="no" protected="may" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="No-Protection" code="1"/>
+			<enum name="Integrity-Protection" code="2"/>
+			<enum name="Integrity-Confidentiality-Protection" code="3"/>
+		</avp>
+		<avp name="Management-Policy-Id" code="135" mandatory="may">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Management-Privilege-Level" code="136" mandatory="must" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="PKM-SS-Cert" code="137" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="PKM-CA-Cert" code="138" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="PKM-Config-Settings" code="139" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="PKM-Cryptosuite-List" code="140" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="PPKM-SAID" code="141" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="PKM-SA-Descriptor" code="142" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="PKM-Auth-Key" code="143" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<!-- AVPs 144-191 unassigned -->
+
+		<!-- 192-223   Experimental Use	[RFC3575] -->
+		<avp name="Experimental-Use-192" code="192" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-193" code="193" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-194" code="194" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-195" code="195" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-196" code="196" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-197" code="197" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-198" code="198" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-199" code="199" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-200" code="200" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-201" code="201" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-202" code="202" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-203" code="203" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-204" code="204" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-205" code="205" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-206" code="206" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-207" code="207" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-208" code="208" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-209" code="209" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-210" code="210" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-211" code="211" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-212" code="212" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-213" code="213" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-214" code="214" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-215" code="215" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-216" code="216" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-217" code="217" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-218" code="218" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-219" code="219" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-220" code="220" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-221" code="221" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-222" code="222" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Experimental-Use-223" code="223" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+
+		<!-- 224-240   Implementation Specific	[RFC3575] -->
+		<avp name="Implementation-Specific-224" code="224" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-225" code="225" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-226" code="226" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-227" code="227" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-228" code="228" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-229" code="229" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-230" code="230" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-231" code="231" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-232" code="232" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-233" code="233" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-234" code="234" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-235" code="235" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-236" code="236" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-237" code="237" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-238" code="238" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-239" code="239" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Implementation-Specific-240" code="240" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+
+		<!--241-255   Reserved	[RFC3575] -->
+		<avp name="Reserved-241" code="241" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-242" code="242" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-243" code="243" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-244" code="244" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-245" code="245" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-246" code="246" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-247" code="247" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-248" code="248" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-249" code="249" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-250" code="250" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-251" code="251" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-252" code="252" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-253" code="253" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-254" code="254" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-255" code="255" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+
+		<!-- ************************************************************************ -->
+		<!-- ******************* DIAMETER BASE PROTOCOL AVPS ************************ -->
+		<!-- ************************************************************************ -->
+		<!-- AVP 256 unassigned -->
+		<avp name="Host-IP-Address" code="257" mandatory="must" protected="may" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Auth-Application-Id" code="258" mandatory="must" protected="mustnot" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="AppId"/>
+		</avp>
+		<avp name="Acct-Application-Id" code="259" mandatory="must" protected="mustnot" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="AppId"/>
+		</avp>
+		<avp name="Vendor-Specific-Application-Id" code="260" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="Vendor-Id"/>
+				<gavp name="Auth-Application-Id"/>
+				<gavp name="Acct-Application-Id"/>
+			</grouped>
+		</avp>
+		<avp name="Redirect-Host-Usage" code="261" mandatory="must" may-encrypt="no" protected="may" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="Don't Care" code="0"/>
+			<enum name="All Session" code="1"/>
+			<enum name="All Realm" code="2"/>
+			<enum name="Realm and Application" code="3"/>
+			<enum name="All Application" code="4"/>
+			<enum name="All Host" code="5"/>
+			<enum name="ALL_USER" code="6"/>
+		</avp>
+		<avp name="Redirect-Max-Cache-Time" code="262" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Session-Id" code="263" mandatory="must" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Origin-Host" code="264" mandatory="must" may-encrypt="no" protected="may" vendor-bit="mustnot">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="Supported-Vendor-Id" code="265" mandatory="must" may-encrypt="no" protected="may" vendor-bit="mustnot">
+			<type type-name="VendorId"/>
+		</avp>
+		<avp name="Vendor-Id" code="266" mandatory="must" may-encrypt="no" protected="may" vendor-bit="mustnot">
+			<type type-name="VendorId"/>
+		</avp>
+		<avp name="Firmware-Revision" code="267" mandatory="mustnot" protected="mustnot" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Result-Code" code="268" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="DIAMETER_MULTI_ROUND_AUTH" code="1001"/>
+			<enum name="DIAMETER_SUCCESS" code="2001"/>
+			<enum name="DIAMETER_LIMITED_SUCCESS" code="2002"/>
+			<enum name="DIAMETER_FIRST_REGISTRATION" code="2003"/>
+			<enum name="DIAMETER_SUBSEQUENT_REGISTRATION" code="2004"/>
+			<enum name="DIAMETER_UNREGISTERED_SERVICE" code="2005"/>
+			<enum name="DIAMETER_SUCCESS_SERVER_NAME_NOT_STORED" code="2006"/>
+			<enum name="DIAMETER_SERVER_SELECTION" code="2007"/>
+			<enum name="DIAMETER_SUCCESS_AUTH_SENT_SERVER_NOT_STORED" code="2008"/>
+			<enum name="DIAMETER_SUCCESS_RELOCATE_HA" code="2009"/>
+			<!-- 2010-2999 Unassigned -->
+			<enum name="DIAMETER_COMMAND_UNSUPPORTED" code="3001"/>
+			<enum name="DIAMETER_UNABLE_TO_DELIVER" code="3002"/>
+			<enum name="DIAMETER_REALM_NOT_SERVED" code="3003"/>
+			<enum name="DIAMETER_TOO_BUSY" code="3004"/>
+			<enum name="DIAMETER_LOOP_DETECTED" code="3005"/>
+			<enum name="DIAMETER_REDIRECT_INDICATION" code="3006"/>
+			<enum name="DIAMETER_APPLICATION_UNSUPPORTED" code="3007"/>
+			<enum name="DIAMETER_INVALID_HDR_BITS" code="3008"/>
+			<enum name="DIAMETER_INVALID_AVP_BITS" code="3009"/>
+			<enum name="DIAMETER_UNKNOWN_PEER" code="3010"/>
+			<enum name="DIAMETER_REALM_REDIRECT_INDICATION" code="3011"/>
+			<!-- 3012-3999 Unassigned -->
+			<enum name="DIAMETER_AUTHENTICATION_REJECTED" code="4001"/>
+			<enum name="DIAMETER_OUT_OF_SPACE" code="4002"/>
+			<enum name="DIAMETER_ELECTION_LOST" code="4003"/>
+			<enum name="DIAMETER_ERROR_MIP_REPLY_FAILURE" code="4005"/>
+			<enum name="DIAMETER_ERROR_HA_NOT_AVAILABLE" code="4006"/>
+			<enum name="DIAMETER_ERROR_BAD_KEY" code="4007"/>
+			<enum name="DIAMETER_ERROR_MIP_FILTER_NOT_SUPPORTED" code="4008"/>
+			<enum name="DIAMETER_END_USER_SERVICE_DENIED" code="4010"/>
+			<enum name="DIAMETER_CREDIT_CONTROL_NOT_APPLICABLE" code="4011"/>
+			<enum name="DIAMETER_CREDIT_LIMIT_REACHED" code="4012"/>
+			<enum name="DIAMETER_USER_NAME_REQUIRED" code="4013"/>
+			<enum name="RESOURCE_FAILURE" code="4014"/>
+			<!-- 4015-4999 Unassigned -->
+			<enum name="DIAMETER_AVP_UNSUPPORTED" code="5001"/>
+			<enum name="DIAMETER_UNKNOWN_SESSION_ID" code="5002"/>
+			<enum name="DIAMETER_AUTHORIZATION_REJECTED" code="5003"/>
+			<enum name="DIAMETER_INVALID_AVP_VALUE" code="5004"/>
+			<enum name="DIAMETER_MISSING_AVP" code="5005"/>
+			<enum name="DIAMETER_RESOURCES_EXCEEDED" code="5006"/>
+			<enum name="DIAMETER_CONTRADICTING_AVPS" code="5007"/>
+			<enum name="DIAMETER_AVP_NOT_ALLOWED" code="5008"/>
+			<enum name="DIAMETER_AVP_OCCURS_TOO_MANY_TIMES" code="5009"/>
+			<enum name="DIAMETER_NO_COMMON_APPLICATION" code="5010"/>
+			<enum name="DIAMETER_UNSUPPORTED_VERSION" code="5011"/>
+			<enum name="DIAMETER_UNABLE_TO_COMPLY" code="5012"/>
+			<enum name="DIAMETER_INVALID_BIT_IN_HEADER" code="5013"/>
+			<enum name="DIAMETER_INVALID_AVP_LENGTH" code="5014"/>
+			<enum name="DIAMETER_INVALID_MESSAGE_LENGTH" code="5015"/>
+			<enum name="DIAMETER_INVALID_AVP_BIT_COMBO" code="5016"/>
+			<enum name="DIAMETER_NO_COMMON_SECURITY" code="5017"/>
+			<enum name="DIAMETER_RADIUS_AVP_UNTRANSLATABLE" code="5018"/>
+			<!-- 5019-5023 Unassigned -->
+			<enum name="DIAMETER_ERROR_NO_FOREIGN_HA_SERVICE" code="5024"/>
+			<enum name="DIAMETER_ERROR_END_TO_END_MIP_KEY_ENCRYPTION" code="5025"/>
+			<!-- 5026-5029 Unassigned -->
+			<enum name="DIAMETER_USER_UNKNOWN" code="5030"/>
+			<enum name="DIAMETER_RATING_FAILED" code="5031"/>
+			<enum name="DIAMETER_ERROR_USER_UNKNOWN" code="5032"/>
+			<enum name="DIAMETER_ERROR_IDENTITIES_DONT_MATCH" code="5033"/>
+			<enum name="DIAMETER_ERROR_IDENTITY_NOT_REGISTERED" code="5034"/>
+			<enum name="DIAMETER_ERROR_ROAMING_NOT_ALLOWED" code="5035"/>
+			<enum name="DIAMETER_ERROR_IDENTITY_ALREADY_REGISTERED" code="5036"/>
+			<enum name="DIAMETER_ERROR_AUTH_SCHEME_NOT_SUPPORTED" code="5037"/>
+			<enum name="DIAMETER_ERROR_IN_ASSIGNMENT_TYPE" code="5038"/>
+			<enum name="DIAMETER_ERROR_TOO_MUCH_DATA" code="5039"/>
+			<enum name="DIAMETER_ERROR_NOT SUPPORTED_USER_DATA" code="5040"/>
+			<enum name="DIAMETER_ERROR_MIP6_AUTH_MODE" code="5041"/>
+			<enum name="UNKNOWN_BINDING_TEMPLATE_NAME" code="5042"/>
+			<enum name="BINDING_FAILURE" code="5043"/>
+			<enum name="MAX_BINDINGS_SET_FAILURE" code="5044"/>
+			<enum name="MAXIMUM_BINDINGS_REACHED_FOR_ENDPOINT" code="5045"/>
+			<enum name="SESSION_EXISTS" code="5046"/>
+			<enum name="INSUFFICIENT_CLASSIFIERS" code="5047"/>
+			<enum name="DIAMETER_ERROR_EAP_CODE_UNKNOWN" code="5048"/>
+
+			<!-- (Ericsson) SCAP Result Codes, see 155 19-FAY 112 51/2 rev B -->
+			<enum name="DIAMETER_END_USER_SERVICE_DENIED" code="4241"/>
+			<enum name="DIAMETER_END_USER_NOT_FOUND" code="5241"/>
+			<!-- END SCAP Result Codes -->
+
+			<!-- 5042-4294967295 Unassigned -->
+		</avp>
+		<avp name="Product-Name" code="269" mandatory="mustnot" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Session-Binding" code="270" mandatory="must" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="RE_AUTH" code="1"/>
+			<enum name="STR" code="2"/>
+			<enum name="Unassigned" code="3"/>
+			<enum name="ACCOUNTING" code="4"/>
+		</avp>
+		<avp name="Session-Server-Failover" code="271" mandatory="must" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="REFUSE_SERVICE" code="0"/>
+			<enum name="TRY_AGAIN" code="1"/>
+			<enum name="ALLOW_SERVICE" code="2"/>
+			<enum name="TRY_AGAIN_ALLOW_SERVICE" code="3"/>
+		</avp>
+		<avp name="Multi-Round-Time-Out" code="272" mandatory="must" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Disconnect-Cause" code="273" mandatory="must" protected="mustnot" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="REBOOTING" code="0"/>
+			<enum name="BUSY" code="1"/>
+			<enum name="DO_NOT_WANT_TO_TALK_TO_YOU" code="2"/>
+		</avp>
+		<avp name="Auth-Request-Type" code="274" mandatory="must" protected="mustnot" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="AUTHENTICATE_ONLY" code="1"/>
+			<enum name="AUTHORIZE_ONLY" code="2"/>
+			<enum name="AUTHORIZE_AUTHENTICATE" code="3"/>
+		</avp>
+		<avp name="Alternate-Peer" code="275" mandatory="must" protected="mustnot" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="Auth-Grace-Period" code="276" mandatory="must" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Auth-Session-State" code="277" mandatory="must" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="STATE_MAINTAINED" code="0"/>
+			<enum name="NO_STATE_MAINTAINED" code="1"/>
+		</avp>
+		<avp name="Origin-State-Id" code="278" mandatory="must" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Failed-AVP" code="279" mandatory="must" may-encrypt="no" vendor-bit="mustnot">
+			<grouped>
+				<!-- This grouped AVP holds any AVP -->
+				<gavp name="Session-Id"/>
+			</grouped>
+		</avp>
+		<avp name="Proxy-Host" code="280" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="Error-Message" code="281" mandatory="mustnot" protected="may" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Route-Record" code="282" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="Destination-Realm" code="283" mandatory="must" protected="mustnot" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="Proxy-Info" code="284" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="Proxy-Host"/>
+				<gavp name="Proxy-State"/>
+			</grouped>
+		</avp>
+		<avp name="Re-Auth-Request-Type" code="285" mandatory="must" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="AUTHORIZE_ONLY" code="0"/>
+			<enum name="AUTHORIZE_AUTHENTICATE" code="1"/>
+		</avp>
+		<!-- AVP 286 unassigned -->
+		<avp name="Accounting-Sub-Session-Id" code="287" mandatory="must" protected="may" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Unsigned64"/>
+		</avp>
+		<!-- 288-290    Unallocated http://www.iana.org/assignments/aaa-parameters  -->
+		<avp name="Authorization-Lifetime" code="291" mandatory="must" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Redirect-Host" code="292" mandatory="must" may-encrypt="no" protected="may" vendor-bit="mustnot">
+			<type type-name="DiameterURI"/>
+		</avp>
+		<avp name="Destination-Host" code="293" mandatory="must" protected="mustnot" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="Error-Reporting-Host" code="294" mandatory="mustnot" protected="may" may-encrypt="no" vendor-bit="mustnot">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="Termination-Cause" code="295" mandatory="must" may-encrypt="no" protected="may" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="DIAMETER_LOGOUT" code="1"/>
+			<enum name="DIAMETER_SERVICE_NOT_PROVIDED" code="2"/>
+			<enum name="DIAMETER_BAD_ANSWER" code="3"/>
+			<enum name="DIAMETER_ADMINISTRATIVE" code="4"/>
+			<enum name="DIAMETER_LINK_BROKEN" code="5"/>
+			<enum name="DIAMETER_AUTH_EXPIRED" code="6"/>
+			<enum name="DIAMETER_USER_MOVED" code="7"/>
+			<enum name="DIAMETER_SESSION_TIMEOUT" code="8"/>
+			<enum name="Unassigned" code="9"/>
+			<enum name="Unassigned" code="10"/>
+			<enum name="User Request" code="11"/>
+			<enum name="Lost Carrier" code="12"/>
+			<enum name="Lost Service" code="13"/>
+			<enum name="Idle Timeout" code="14"/>
+			<enum name="Session Timeout" code="15"/>
+			<enum name="Admin Reset" code="16"/>
+			<enum name="Admin Reboot" code="17"/>
+			<enum name="Port Error" code="18"/>
+			<enum name="NAS Error" code="19"/>
+			<enum name="NAS Request" code="20"/>
+			<enum name="NAS Reboot" code="21"/>
+			<enum name="Port Unneeded" code="22"/>
+			<enum name="Port Preempted" code="23"/>
+			<enum name="Port Suspended" code="24"/>
+			<enum name="Service Unavailable" code="25"/>
+			<enum name="Callback" code="26"/>
+			<enum name="User Error" code="27"/>
+			<enum name="Host Request" code="28"/>
+			<enum name="Supplicant Restart" code="29"/>
+			<enum name="Reauthentication Failure" code="30"/>
+			<enum name="Reauthentication Failure" code="31"/>
+			<enum name="Port Administratively Disabled" code="32"/>
+		</avp>
+		<avp name="Origin-Realm" code="296" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="Experimental-Result" code="297" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="Vendor-Id"/>
+				<gavp name="Experimental-Result-Code"/>
+			</grouped>
+		</avp>
+
+		<!-- Ideally we could specify, in XML, Experimental-Result-Code values for
+		     different Vendor IDs.  So far we don't have a way to do that, so:
+
+		     1) The below values are for 3GPP (why 3GPP? Because that's the most
+			common Vendor ID for the people who did this).  Note that
+			packet-diameter.c assumes that the codes specified here are from 3GPP.
+
+		     2) Other Vendor-IDs are handled by registering a dissector to the
+			"diameter.vnd_exp_res" dissector table.
+		-->
+		<avp name="Experimental-Result-Code" code="298" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<!-- 3GPP TS 29.230 version 13.0.0 -->
+			<type type-name="Enumerated"/>
+			<!-- Success codes -->
+			<enum name="DIAMETER_FIRST_REGISTRATION" code="2001"/>
+			<enum name="DIAMETER_SUBSEQUENT_REGISTRATION" code="2002"/>
+			<enum name="DIAMETER_UNREGISTERED_SERVICE" code="2003"/>
+			<enum name="DIAMETER_SUCCESS_SERVER_NAME_NOT_STORED" code="2004"/>
+			<enum name="DIAMETER_SERVER_SELECTION(Deprecated value)" code="2005"/>
+			<!-- 2006-2020 -->
+			<enum name="DIAMETER_PDP_CONTEXT_DELETION_INDICATION" code="2021"/>
+
+			<!-- Transient failures -->
+			<enum name="DIAMETER_USER_DATA_NOT_AVAILABLE" code="4100"/>
+			<enum name="DIAMETER_PRIOR_UPDATE_IN_PROGRESS" code="4101"/>
+			<!-- 4102-4120 -->
+			<enum name="DIAMETER_ERROR_OUT_OF_RESOURCES" code="4121"/>
+			<!-- 4122-4140 -->
+			<enum name="DIAMETER_PCC_BEARER_EVENT" code="4141"/>
+			<enum name="DIAMETER_BEARER_EVENT" code="4142"/>
+			<enum name="DIAMETER_AN_GW_FAILED" code="4143"/>
+			<enum name="DIAMETER_PENDING_TRANSACTION" code="4144"/>
+			<!-- 4145-4180 -->
+			<enum name="DIAMETER_AUTHENTICATION_DATA_UNAVAILABLE" code="4181"/>
+			<enum name="DIAMETER_ERROR_CAMEL_SUBSCRIPTION_PRESENT" code="4182"/>
+			<!-- 4183-4200 -->
+			<enum name="DIAMETER_ERROR_ABSENT_USER" code="4201"/>
+			<!-- 4202-4220 -->
+			<enum name="DIAMETER_ERROR_UNREACHABLE_USER" code="4221"/>
+			<enum name="DIAMETER_ERROR_SUSPENDED_USER" code="4222"/>
+			<enum name="DIAMETER_ERROR_DETACHED_USER" code="4223"/>
+			<enum name="DIAMETER_ERROR_POSITIONING_DENIED" code="4224"/>
+			<enum name="DIAMETER_ERROR_POSITIONING_FAILED" code="4225"/>
+			<enum name="DIAMETER_ERROR_UNKNOWN_UNREACHABLE LCS_CLIENT" code="4226"/>
+			<!-- 4227-4240 -->
+			<enum name="DIAMETER_ERROR_NO_AVAILABLE_POLICY_COUNTERS LCS_CLIENT" code="4241"/>
+			<!-- 4242 to 4260  -->
+			<enum name="REQUESTED_SERVICE_TEMPORARILY_NOT_AUTHORIZED" code="4261"/>
+
+			<!-- Permanent failures -->
+			<enum name="DIAMETER_ERROR_USER_UNKNOWN" code="5001"/>
+			<enum name="DIAMETER_ERROR_IDENTITIES_DONT_MATCH" code="5002"/>
+			<enum name="DIAMETER_ERROR_IDENTITY_NOT_REGISTERED" code="5003"/>
+			<enum name="DIAMETER_ERROR_ROAMING_NOT_ALLOWED" code="5004"/>
+			<enum name="DIAMETER_ERROR_IDENTITY_ALREADY_REGISTERED" code="5005"/>
+			<enum name="DIAMETER_ERROR_AUTH_SCHEME_NOT_SUPPORTED" code="5006"/>
+			<enum name="DIAMETER_ERROR_IN_ASSIGNMENT_TYPE" code="5007"/>
+			<enum name="DIAMETER_ERROR_TOO_MUCH_DATA" code="5008"/>
+			<enum name="DIAMETER_ERROR_NOT_SUPPORTED_USER_DATA" code="5009"/>
+			<enum name="DIAMETER_MISSING_USER_ID" code="5010"/>
+			<enum name="DIAMETER_ERROR_FEATURE_UNSUPPORTED" code="5011"/>
+			<enum name="DIAMETER_ERROR_SERVING_NODE_FEATURE_UNSUPPORTED" code="5012"/>
+			<!-- 5013-5040 -->
+			<enum name="DIAMETER_ERROR_USER_NO_WLAN_SUBSCRIPTION" code="5041"/>
+			<enum name="DIAMETER_ERROR_W-APN_UNUSED_BY_USER" code="5042"/>
+			<enum name="DIAMETER_ERROR_W-DIAMETER_ERROR_NO_ACCESS_INDEPENDENT_SUBSCRIPTION" code="5043"/>
+			<enum name="DIAMETER_ERROR_USER_NO_W-APN_SUBSCRIPTION" code="5044"/>
+			<enum name="DIAMETER_ERROR_UNSUITABLE_NETWORK" code="5045"/>
+			<!-- 5046-5060 -->
+			<enum name="INVALID_SERVICE_INFORMATION" code="5061"/>
+			<enum name="FILTER_RESTRICTIONS" code="5062"/>
+			<enum name="REQUESTED_SERVICE_NOT_AUTHORIZED" code="5063"/>
+			<enum name="DUPLICATED_AF_SESSION" code="5064"/>
+			<enum name="IP-CAN_SESSION_NOT_AVAILABLE" code="5065"/>
+			<enum name="UNAUTHORIZED_NON_EMERGENCY_SESSION" code="5066"/>
+			<enum name="UNAUTHORIZED_SPONSORED_DATA_CONNECTIVITY" code="5067"/>
+			<enum name="TEMPORARY_NETWORK_FAILURE" code="5068"/>
+			<!-- 5069-5099 -->
+			<enum name="DIAMETER_ERROR_USER_DATA_NOT_RECOGNIZED" code="5100"/>
+			<enum name="DIAMETER_ERROR_OPERATION_NOT_ALLOWED" code="5101"/>
+			<enum name="DIAMETER_ERROR_USER_DATA_CANNOT_BE_READ" code="5102"/>
+			<enum name="DIAMETER_ERROR_USER_DATA_CANNOT_BE_MODIFIED" code="5103"/>
+			<enum name="DIAMETER_ERROR_USER_DATA_CANNOT_BE_NOTIFIED" code="5104"/>
+			<enum name="DIAMETER_ERROR_TRANSPARENT_DATA_OUT_OF_SYNC" code="5105"/>
+			<enum name="DIAMETER_ERROR_SUBS_DATA_ABSENT" code="5106"/>
+			<enum name="DIAMETER_ERROR_NO_SUBSCRIPTION_TO_DATA" code="5107"/>
+			<enum name="DIAMETER_ERROR_DSAI_NOT_AVAILABLE" code="5108"/>
+			<!-- 5109-5119 -->
+			<enum name="DIAMETER_ERROR_START_INDICATION" code="5120"/>
+			<enum name="DIAMETER_ERROR_STOP_INDICATION" code="5121"/>
+			<enum name="DIAMETER_ERROR_UNKNOWN_MBMS_BEARER_SERVICE" code="5122"/>
+			<enum name="DIAMETER_ERROR_SERVICE_AREA" code="5123"/>
+			<!-- 5124-5139 -->
+			<enum name="DIAMETER_ERROR_INITIAL_PARAMETERS" code="5140"/>
+			<enum name="DIAMETER_ERROR_TRIGGER_EVENT" code="5141"/>
+			<enum name="DIAMETER_PCC_RULE_EVENT" code="5142"/>
+			<enum name="DIAMETER_ERROR_BEARER_NOT_AUTHORIZED" code="5143"/>
+			<enum name="DIAMETER_ERROR_TRAFFIC_MAPPING_INFO_REJECTED" code="5144"/>
+			<enum name="DIAMETER_QOS_RULE_EVENT" code="5145"/>
+			<enum name="DIAMETER_ERROR_TRAFFIC_MAPPING_INFO_REJECTED" code="5146"/>
+			<enum name="DIAMETER_ERROR_CONFLICTING_REQUEST" code="5147"/>
+			<enum name="DIAMETER_ADC_RULE_EVENT" code="5148"/>
+			<enum name="DIAMETER_ERROR_NBIFOM_NOT_AUTHORIZED" code="5149"/>
+			<!-- 5150-5400 -->
+			<enum name="DIAMETER_ERROR_IMPI_UNKNOWN" code="5401"/>
+			<enum name="DIAMETER_ERROR_NOT_AUTHORIZED" code="5402"/>
+			<enum name="DIAMETER_ERROR_TRANSACTION_IDENTIFIER_INVALID" code="5403"/>
+			<!-- 5404-5419 -->
+			<enum name="DIAMETER_ERROR_UNKNOWN_EPS_SUBSCRIPTION" code="5420"/>
+			<enum name="DIAMETER_ERROR_RAT_NOT_ALLOWED" code="5421"/>
+			<enum name="DIAMETER_ERROR_EQUIPMENT_UNKNOWN" code="5422"/>
+			<enum name="DIAMETER_ERROR_UNKNOWN_SERVING_NODE" code="5423"/>
+			<!-- 5424-5449 -->
+			<enum name="DIAMETER_ERROR_USER_NO_NON_3GPP_SUBSCRIPTION" code="5450"/>
+			<enum name="DIAMETER_ERROR_USER_NO_APN_SUBSCRIPTION" code="5451"/>
+			<enum name="DIAMETER_ERROR_RAT_TYPE_NOT_ALLOWED" code="5452"/>
+			<enum name="DIAMETER_ERROR_LATE_OVERLAPPING_REQUEST" code="5453"/>
+			<enum name="DIAMETER_ERROR_TIMED_OUT_REQUEST" code="5454"/>
+			<!-- 5455-5469 -->
+			<enum name="DIAMETER_ERROR_SUBSESSION" code="5470"/>
+			<enum name="DIAMETER_ERROR_ONGOING_SESSION_ESTABLISHMENT" code="5471"/>
+			<!-- 5472-5489 -->
+			<enum name="DIAMETER_ERROR_UNAUTHORIZED_REQUESTING_NETWORK" code="5490"/>
+			<!-- 5491-5509 -->
+			<enum name="DIAMETER_ERROR_UNAUTHORIZED_REQUESTING_ENTITY" code="5510"/>
+			<enum name="DIAMETER_ERROR_UNAUTHORIZED_SERVICE" code="5511"/>
+			<enum name="DIAMETER_ERROR_REQUESTED_RANGE_IS_NOT ALLOWED" code="5512"/>
+			<enum name="DIAMETER_ERROR_CONFIGURATION_EVENT_STORAGE_NOT_SUCCESSFUL" code="5513"/>
+			<enum name="DIAMETER_ERROR_CONFIGURATION_EVENT_NON_EXISTANT" code="5514"/>
+			<enum name="DIAMETER_ERROR_SCEF_REFERENCE_ID_UNKNOWN" code="5515"/>
+			<!-- 5516-5529 -->
+			<enum name="DIAMETER_ERROR_INVALID_SME_ADDRESS" code="5530"/>
+			<enum name="DIAMETER_ERROR_SC_CONGESTION" code="5531"/>
+			<enum name="DIAMETER_ERROR_SM_PROTOCOL" code="5532"/>
+			<enum name="DIAMETER_ERROR_TRIGGER_REPLACE_FAILURE" code="5533"/>
+			<enum name="DIAMETER_ERROR_TRIGGER_RECALL_FAILURE" code="5534"/>
+			<enum name="DIAMETER_ERROR_ORIGINAL_MESSAGE_NOT_PENDING" code="5535"/>
+			<!-- 5536-5549 -->
+			<enum name="DIAMETER_ERROR_ABSENT_USER" code="5550"/>
+			<enum name="DIAMETER_ERROR_USER_BUSY_FOR_MT_SMS" code="5551"/>
+			<enum name="DIAMETER_ERROR_FACILITY_NOT_SUPPORTED" code="5552"/>
+			<enum name="DIAMETER_ERROR_ILLEGAL_USER" code="5553"/>
+			<enum name="DIAMETER_ERROR_ILLEGAL_EQUIPMENT" code="5554"/>
+			<enum name="DIAMETER_ERROR_SM_DELIVERY_FAILURE" code="5555"/>
+			<enum name="DIAMETER_ERROR_SERVICE_NOT_SUBSCRIBED" code="5556"/>
+			<enum name="DIAMETER_ERROR_SERVICE_BARRED" code="5557"/>
+			<enum name="DIAMETER_ERROR_MWD_LIST_FULL" code="5558"/>
+			<!-- 5559-5569 -->
+			<enum name="DIAMETER_ERROR_UNKNOWN_POLICY_COUNTERS" code="5570"/>
+			<!-- 5571-5589 -->
+			<enum name="DIAMETER_ERROR_ORIGIN_ALUID_UNKNOWN" code="5590"/>
+			<enum name="DIAMETER_ERROR_TARGET_ALUID_UNKNOWN" code="5591"/>
+			<enum name="DIAMETER_ERROR_PFID_UNKNOWN" code="5592"/>
+			<enum name="DIAMETER_ERROR_APP_REGISTER_REJECT" code="5593"/>
+			<enum name="DIAMETER_ERROR_PROSE_MAP_REQUEST_DISALLOWED" code="5594"/>
+			<enum name="DIAMETER_ERROR_MAP_REQUEST_REJECT" code="5595"/>
+			<enum name="DIAMETER_ERROR_REQUESTING_RPAUID_UNKNOWN" code="5596"/>
+			<enum name="DIAMETER_ERROR_UNKNOWN_OR_INVALID_TARGET_SET" code="5597"/>
+			<enum name="DIAMETER_ERROR_MISSING_APPLICATION_DATA" code="5598"/>
+			<enum name="DIAMETER_ERROR_AUTHORIZATION_REJECT" code="5599"/>
+			<enum name="DIAMETER_ERROR_DISCOVERY_NOT_PERMITTED" code="5600"/>
+			<enum name="DIAMETER_ERROR_TARGET_RPAUID_UNKNOWN" code="5601"/>
+			<enum name="DIAMETER_ERROR_INVALID_APPLICATION_DATA" code="5602"/>
+			<!-- 5603-5609 -->
+			<enum name="DIAMETER_ERROR_UNKNOWN_PROSE_SUBSCRIPTION" code="5610"/>
+			<enum name="PROSE_NOT_ALLOWED" code="5611"/>
+			<enum name="DIAMETER_ERROR_UE_LOCATION_UNKNOWN" code="5612"/>
+			<!-- 5613-5629 -->
+			<enum name="DIAMETER_ERROR_NO_ASSOCIATED_DISCOVERY_FILTER" code="5630"/>
+			<enum name="DIAMETER_ERROR_ANNOUNCING_UNAUTHORIZED_IN_PLMN" code="5631"/>
+			<enum name="DIAMETER_ERROR_INVALID_APPLICATION_CODE" code="5632"/>
+			<enum name="DIAMETER_ERROR_PROXIMITY_UNAUTHORIZED" code="5633"/>
+			<enum name="DIAMETER_ERROR_PROXIMITY_REJECTED" code="5634"/>
+			<enum name="DIAMETER_ERROR_NO_PROXIMITY_REQUEST" code="5635"/>
+			<enum name="DIAMETER_ERROR_UNAUTHORIZED_SERVICE_IN_THIS_PLMN" code="5636"/>
+			<enum name="DIAMETER_ERROR_PROXIMITY_CANCELLED" code="5637"/>
+			<enum name="DIAMETER_ERROR_INVALID_TARGET_PDUID" code="5638"/>
+			<enum name="DIAMETER_ERROR_INVALID_TARGET_RPAUID" code="5639"/>
+			<enum name="DIAMETER_ERROR_NO_ASSOCIATED_RESTRICTED_CODE" code="5640"/>
+			<enum name="DIAMETER_ERROR_INVALID_DISCOVERY_TYPE" code="5641"/>
+			<!-- 5642-5649 -->
+			<enum name="DIAMETER_ERROR_REQUESTED_LOCATION_NOT_SERVED" code="5650"/>
+			<enum name="DIAMETER_ERROR_INVALID_EPS_BEARER" code="5651"/>
+			<enum name="DIAMETER_ERROR_NIDD_CONFIGURATION_NOT_AVAILABLE" code="5652"/>
+			<enum name="DIAMETER_ERROR_USER_TEMPORARILY_UNREACHABLE" code="5653"/>
+			<!-- 5654 to 5669 -->
+			<enum name="DIAMETER_ERROR_UNKNKOWN_DATA" code="5670"/>
+			<enum name="DIAMETER_ERROR_REQUIRED_KEY_NOT_PROVIDED" code="5671"/>
+			<!-- 5672 to 5689  -->
+			<enum name="DIAMETER_ERROR_UNKNOWN_V2X_SUBSCRIPTION" code="5690"/>
+			<enum name="DIAMETER_ERROR_V2X_NOT_ALLOWED" code="5691"/>
+			</avp>
+		<!-- RFC3588 AVP -->
+		<avp name="Inband-Security-Id" code="299" mandatory="must" may-encrypt="no" protected="may" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+				<enum name="NO_INBAND_SECURITY" code="0"/>
+				<enum name="TLS" code="1"/>
+		</avp>
+		<avp name="E2E-Sequence" code="300" mandatory="must">
+			<grouped>
+				<!-- The contents of this (deprecated) AVP aren't defined -->
+				<gavp name="Session-Id"/>
+			</grouped>
+		</avp>
+		<!-- RFC7944 AVP -->
+		<avp name="DRMP" code="301" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+				<enum name="PRIORITY_0" code="0"/>
+				<enum name="PRIORITY_1" code="1"/>
+				<enum name="PRIORITY_2" code="2"/>
+				<enum name="PRIORITY_3" code="3"/>
+				<enum name="PRIORITY_4" code="4"/>
+				<enum name="PRIORITY_5" code="5"/>
+				<enum name="PRIORITY_6" code="6"/>
+				<enum name="PRIORITY_7" code="7"/>
+				<enum name="PRIORITY_8" code="8"/>
+				<enum name="PRIORITY_9" code="9"/>
+				<enum name="PRIORITY_10" code="10"/>
+				<enum name="PRIORITY_11" code="11"/>
+				<enum name="PRIORITY_12" code="12"/>
+				<enum name="PRIORITY_13" code="13"/>
+				<enum name="PRIORITY_14" code="14"/>
+				<enum name="PRIORITY_15" code="15"/>
+		</avp>
+
+		<!-- 302-317    Unallocated -->
+
+		<!-- AVPs 318 - 348 belong to Diameter Mobile IPv4 Application and are defined in mobileipv4.xml
+		318 MIP-FA-to-HA-SPI [RFC4004]
+		319 MIP-FA-to-MN-SPI [RFC4004]
+		320 MIP-Reg-Request [RFC4004]
+		321 MIP-Reg-Reply [RFC4004]
+		322 MIP-MN-AAA-Auth [RFC4004]
+		323 MIP-HA-to-FA-SPI [RFC4004]
+		324 Unassigned
+		325 MIP-MN-to-FA-MSA [RFC4004]
+		326 MIP-FA-to-MN-MSA [RFC4004]
+		327 Unassigned
+		328 MIP-FA-to-HA-MSA [RFC4004]
+		329 MIP-HA-to-FA-MSA [RFC4004]
+		331 MIP-MN-to-HA-MSA [RFC4004]
+		332 MIP-HA-to-MN-MSA [RFC4004]
+		333 MIP-Mobile-Node-Address [RFC4004]
+		334 MIP-Home-Agent-Address [RFC4004]
+		335 MIP-Nonce [RFC4004]
+		336 MIP-Candidate-Home-Agent-Host [RFC4004]
+		337 MIP-Feature-Vector [RFC4004]
+		338 MIP-Auth-Input-Data-Length [RFC4004]
+		339 MIP-Authenticator-Length [RFC4004]
+		340 MIP-Authenticator-Offset [RFC4004]
+		341 MIP-MN-AAA-SPI [RFC4004]
+		342 MIP-Filter-Rule [RFC4004]
+		343 MIP-Session-Key [RFC4004]
+		344 MIP-FA-Challenge [RFC4004]
+		345 MIP-Algorithm-Type [RFC4004]
+		346 MIP-Replay-Mode [RFC4004]
+		347 MIP-Originating-Foreign-AAA [RFC4004]
+		348 MIP-Home-Agent-Host [RFC4004]
+		-->
+
+		<!-- AVPs 349-362 unassigned -->
+
+		<!-- AVPs 368 - 393 are in sip.xml
+		363 Accounting-Input-Octets [RFC4005][RFC4004]
+		364 Accounting-Output-Octets [RFC4005][RFC4004]
+		365 Accounting-Input-Packets [RFC4005][RFC4004]
+		366 Accounting-Output-Packets [RFC4005][RFC4004]
+		367 MIP-MSA-Lifetime [RFC4004]
+		368 SIP-Accounting-Information [RFC4740]
+		369 SIP-Accounting-Server-URI [RFC4740]
+		370 SIP-Credit-Control-Server-URI [RFC4740]
+		371 SIP-Server-URI [RFC4740]
+		372 SIP-Server-Capabilities [RFC4740]
+		373 SIP-Mandatory-Capability [RFC4740]
+		374 SIP-Optional-Capability [RFC4740]
+		375 SIP-Server-Assignment-Type [RFC4740]
+		376 SIP-Auth-Data-Item [RFC4740]
+		377 SIP-Authentication-Scheme [RFC4740]
+		378 SIP-Item-Number [RFC4740]
+		379 SIP-Authenticate [RFC4740]
+		380 SIP-Authorization [RFC4740]
+		381 SIP-Authentication-Info [RFC4740]
+		382 SIP-Number-Auth-Items [RFC4740]
+		383 SIP-Deregistration-Reason [RFC4740]
+		384 SIP-Reason-Code [RFC4740]
+		385 SIP-Reason-Info [RFC4740]
+		386 SIP-Visited-Network-Id [RFC4740]
+		387 SIP-User-Authorization-Type [RFC4740]
+		388 SIP-Supported-User-Data-Type [RFC4740]
+		389 SIP-User-Data [RFC4740]
+		390 SIP-User-Data-Type [RFC4740]
+		391 SIP-User-Data-Contents [RFC4740]
+		392 SIP-User-Data-Already-Available [RFC4740]
+		393 SIP-Method [RFC4740]
+		-->
+
+		<!-- AVPs 394-399 unassigned -->
+
+		<!-- AVPs 400 - 408 are defined in nasreq.xml
+		400 NAS-Filter-Rule [RFC4005]
+		401 Tunneling [RFC4005]
+		402 CHAP-Auth [RFC4005]
+		403 CHAP-Algorithm [RFC4005]
+		404 CHAP-Ident [RFC4005]
+		405 CHAP-Response [RFC4005]
+		406 Acounting-Auth-Method [RFC4005]
+		407 QoS-Filter-Rule [RFC4005]
+		408 Origin-AAA-Protocol [RFC4005]
+		-->
+
+		<!-- AVPs 409-410 unassigned -->
+
+		<!-- AVPs 411 - 461 belong to Charge Control and are defined in chargecontrol.xml
+		411 CC-Correlation-Id [RFC4006]
+		412 CC-Input-Octets [RFC4006]
+		413 CC-Money [RFC4006]
+		414 CC-Output-Octets [RFC4006]
+		415 CC-Request-Number [RFC4006]
+		416 CC-Request-Type [RFC4006]
+		417 CC-Service-Specific-Units [RFC4006]
+		418 CC-Session-Failover [RFC4006]
+		419 CC-Sub-Session-Id [RFC4006]
+		420 CC-Time [RFC4006]
+		421 CC-Total-Octets [RFC4006]
+		422 Check-Balance-Result [RFC4006]
+		423 Cost-Information [RFC4006]
+		424 Cost-Unit [RFC4006]
+		425 Currency-Code [RFC4006]
+		426 Credit-Control [RFC4006]
+		427 Credit-Control-Failure-Handling [RFC4006]
+		428 Direct-Debiting-Failure-Handling [RFC4006]
+		429 Exponent [RFC4006]
+		430 Final-Unit-Indication [RFC4006]
+		431 Granted-Service-Unit [RFC4006]
+		432 Rating-Group [RFC4006]
+		433 Redirect-Address-Type [RFC4006]
+		434 Redirect-Server [RFC4006]
+		435 Redirect-Server-Address [RFC4006]
+		436 Requested-Action [RFC4006]
+		437 Requested-Service-Unit [RFC4006]
+		438 Restriction-Filter-Rule [RFC4006]
+		439 Service-Identifier [RFC4006]
+		440 Service-Parameter-Info [RFC4006]
+		441 Service-Parameter-Type [RFC4006]
+		442 Service-Parameter-Value [RFC4006]
+		443 Subscription-Id [RFC4006]
+		444 Subscription-Id-Data [RFC4006]
+		445 Unit-Value [RFC4006]
+		446 Used-Service-Unit [RFC4006]
+		447 Value-Digits [RFC4006]
+		448 Validity-Time [RFC4006]
+		449 Final-Unit-Action [RFC4006]
+		450 Subscription-Id-Type [RFC4006]
+		451 Tariff-Time-Change [RFC4006]
+		452 Tariff-Change-Usage [RFC4006]
+		453 G-S-U-Pool-Identifier [RFC4006]
+		454 CC-Unit-Type [RFC4006]
+		455 Multiple-Services-Indicator [RFC4006]
+		456 Multiple-Services-Credit-Control [RFC4006]
+		457 G-S-U-Pool-Reference [RFC4006]
+		458 User-Equipment-Info [RFC4006]
+		459 User-Equipment-Info-Type [RFC4006]
+		460 User-Equipment-Info-Value [RFC4006]
+		461 Service-Context-Id [RFC4006]
+		-->
+
+		<!-- eap.xml
+		462 EAP-Payload [RFC4072]
+		463 EAP-Reissued-Payload [RFC4072]
+		464 EAP-Master-Session-Key [RFC4072]
+		465 Accounting-EAP-Auth-Method [RFC4072]
+		-->
+
+		<!-- AVPs 466-479 unassigned -->
+
+		<avp name="Accounting-Record-Type" code="480" mandatory="must" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="Event Record" code="1"/>
+			<enum name="Start Record" code="2"/>
+			<enum name="Interim Record" code="3"/>
+			<enum name="Stop Record" code="4"/>
+		</avp>
+
+		<!-- AVPs 481-482 unassigned -->
+
+		<avp name="Accounting-Realtime-Required" code="483" mandatory="must" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="Reserved" code="0"/>
+			<enum name="DELIVER_AND_GRANT" code="1"/>
+			<enum name="GRANT_AND_STORE" code="2"/>
+			<enum name="GRANT_AND_LOSE" code="3"/>
+		</avp>
+		<!-- AVP 484 unassigned -->
+		<avp name="Accounting-Record-Number" code="485" mandatory="must" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Unsigned32"/>
+		</avp>
+
+		<!-- AVPs 486 - 494 are defined in in mobileipv6.xml -->
+
+		<avp name="TMOD-1" code="495" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="Token-Rate"/>
+				<gavp name="Bucket-Depth"/>
+				<gavp name="Peak-Traffic-Rate"/>
+				<gavp name="Minimum-Policed-Unit"/>
+				<gavp name="Maximum-Packet-Size"/>
+			</grouped>
+		</avp>
+		<avp name="Token-Rate" code="496" mandatory="may">
+			<type type-name="Float32"/>
+		</avp>
+		<avp name="Bucket-Depth" code="497" mandatory="may">
+			<type type-name="Float32"/>
+		</avp>
+		<avp name="Peak-Traffic-Rate" code="498" mandatory="may">
+			<type type-name="Float32"/>
+		</avp>
+		<avp name="Minimum-Policed-Unit" code="499" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Maximum-Packet-Size" code="500" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="TMOD-2" code="501" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="Token-Rate"/>
+				<gavp name="Bucket-Depth"/>
+				<gavp name="Peak-Traffic-Rate"/>
+				<gavp name="Minimum-Policed-Unit"/>
+				<gavp name="Maximum-Packet-Size"/>
+			</grouped>
+		</avp>
+		<avp name="Bandwidth" code="502" mandatory="may">
+			<type type-name="Float32"/>
+		</avp>
+		<avp name="PHB-Class" code="503" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+
+		<!-- AVPs 504 - 507 are defined in mobileipv6.xml -->
+		<avp name="QoS-Resources" code="508" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="Filter-Rule"/>
+			</grouped>
+		</avp>
+		<avp name="Filter-Rule" code="509" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="Filter-Rule-Precedence"/>
+				<gavp name="Classifier"/>
+				<gavp name="Time-Of-Day-Condition"/>
+				<gavp name="Treatment-Action"/>
+				<gavp name="QoS-Semantics"/>
+				<gavp name="QoS-Profile-Template"/>
+				<gavp name="QoS-Parameters"/>
+				<gavp name="Excess-Treatment"/>
+			</grouped>
+		</avp>
+		<avp name="Filter-Rule-Precedence" code="510" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Classifier" code="511" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="Classifier-ID"/>
+				<gavp name="Protocol"/>
+				<gavp name="Direction"/>
+				<gavp name="From-Spec"/>
+				<gavp name="To-Spec"/>
+				<gavp name="Diffserv-Code-Point"/>
+				<gavp name="Fragmentation-Flag"/>
+				<gavp name="IP-Option"/>
+				<gavp name="TCP-Option"/>
+				<gavp name="TCP-Flags"/>
+				<gavp name="ICMP-Type"/>
+				<gavp name="ETH-Option"/>
+			</grouped>
+		</avp>
+		<avp name="Classifier-ID" code="512" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Protocol" code="513" mandatory="may">
+			<type type-name="Enumerated"/>
+			<!-- The values for this AVP are managed by IANA under the Protocol Numbers registry as defined in [RFC2780]
+			For now only add the most common ones to avoid a long value_string (see epan/ipproto.c).
+			-->
+			<enum name="TCP Transmission Control" code="6"/>
+			<enum name="UDP User Datagram" code="17"/>
+			<enum name="SCTP Stream Control Transmission Protocol" code="132"/>
+		</avp>
+		<avp name="Direction" code="514" mandatory="must" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="IN" code="0"/>
+			<enum name="OUT" code="1"/>
+			<enum name="BOTH" code="2"/>
+		</avp>
+		<avp name="From-Spec" code="515" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="IP-Address"/>
+				<gavp name="IP-Address-Range"/>
+				<gavp name="IP-Address-Mask"/>
+				<gavp name="MAC-Address"/>
+				<gavp name="MAC-Address-Mask"/>
+				<gavp name="EUI64-Address"/>
+				<gavp name="EUI64-Address-Mask"/>
+				<gavp name="Port"/>
+				<gavp name="Port-Range"/>
+				<gavp name="Negated"/>
+				<gavp name="Use-Assigned-Address"/>
+			</grouped>
+		</avp>
+		<avp name="To-Spec" code="516" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="IP-Address"/>
+				<gavp name="IP-Address-Range"/>
+				<gavp name="IP-Address-Mask"/>
+				<gavp name="MAC-Address"/>
+				<gavp name="MAC-Address-Mask"/>
+				<gavp name="EUI64-Address"/>
+				<gavp name="EUI64-Address-Mask"/>
+				<gavp name="Port"/>
+				<gavp name="Port-Range"/>
+				<gavp name="Negated"/>
+				<gavp name="Use-Assigned-Address"/>
+			</grouped>
+		</avp>
+		<avp name="Negated" code="517" mandatory="must" may-encrypt="yes" vendor-bit="mustnot">
+			<type type-name="Enumerated"/>
+			<enum name="False" code="0"/>
+			<enum name="True" code="1"/>
+		</avp>
+		<avp name="IP-Address" code="518" mandatory="may">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="IP-Address-Range" code="519" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="IP-Address-Start"/>
+				<gavp name="IP-Address-End"/>
+			</grouped>
+		</avp>
+		<avp name="IP-Address-Start" code="520" mandatory="may">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="IP-Address-End" code="521" mandatory="may">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="IP-Address-Mask" code="522" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="IP-Address"/>
+				<gavp name="IP-Bit-Mask-Width"/>
+			</grouped>
+		</avp>
+		<avp name="IP-Bit-Mask-Width" code="523" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="MAC-Address" code="524" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="MAC-Address-Mask" code="525" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="MAC-Address"/>
+				<gavp name="MAC-Address-Mask-Pattern"/>
+			</grouped>
+		</avp>
+		<avp name="MAC-Address-Mask-Pattern" code="525" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="EUI64-Address" code="527" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="EUI64-Address-Mask" code="528" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="EUI64-Address"/>
+				<gavp name="EUI64-Address-Mask-Pattern"/>
+			</grouped>
+		</avp>
+		<avp name="EUI64-Address-Mask-Pattern" code="529" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Port" code="530" mandatory="may">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Port-Range" code="531" mandatory="may">
+			<grouped>
+				<gavp name="Port-Start"/>
+				<gavp name="Port-End"/>
+			</grouped>
+		</avp>
+		<avp name="Port-Start" code="532" mandatory="may">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Port-End" code="533" mandatory="may">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Use-Assigned-Address" code="534" mandatory="may">
+			<type type-name="Enumerated"/>
+			<enum name="False" code="0"/>
+			<enum name="True" code="1"/>
+		</avp>
+		<avp name="Diffserv-Code-Point" code="535" mandatory="may">
+			<type type-name="Enumerated"/>
+			<enum name="CS0" code="0"/>
+			<enum name="CS1" code="8"/>
+			<enum name="CS2" code="16"/>
+			<enum name="CS3" code="24"/>
+			<enum name="CS4" code="32"/>
+			<enum name="CS5" code="40"/>
+			<enum name="CS6" code="48"/>
+			<enum name="CS7" code="56"/>
+			<enum name="AF11" code="10"/>
+			<enum name="AF12" code="12"/>
+			<enum name="AF13" code="14"/>
+			<enum name="AF21" code="18"/>
+			<enum name="AF22" code="20"/>
+			<enum name="AF23" code="22"/>
+			<enum name="AF31" code="26"/>
+			<enum name="AF32" code="28"/>
+			<enum name="AF33" code="30"/>
+			<enum name="AF41" code="34"/>
+			<enum name="AF42" code="36"/>
+			<enum name="AF43" code="38"/>
+			<enum name="EF" code="46"/>
+			<enum name="VOICE-ADMIT" code="44"/>
+			<!-- ECN fields aren't listed -->
+		</avp>
+		<avp name="Fragmentation-Flag" code="536" mandatory="may">
+			<type type-name="Enumerated"/>
+			<enum name="Don't Fragment (DF)" code="0"/>
+			<enum name="More Fragments (MF)" code="1"/>
+		</avp>
+		<avp name="IP-Option" code="537" mandatory="may">
+			<grouped>
+				<gavp name="IP-Option-Type"/>
+				<gavp name="IP-Option-Value"/>
+			</grouped>
+		</avp>
+		<avp name="IP-Option-Type" code="538" mandatory="may">
+			<type type-name="Enumerated"/>
+			<enum name="End of Options List" code="0"/>
+			<enum name="No Operation" code="1"/>
+			<enum name="Security" code="130"/>
+			<enum name="Loose Source Route" code="131"/>
+			<enum name="Time Stamp" code="68"/>
+			<enum name="Extended Security" code="133"/>
+			<enum name="Commercial Security" code="134"/>
+			<enum name="Record Route" code="7"/>
+			<enum name="Stream ID" code="136"/>
+			<enum name="Strict Source Route" code="137"/>
+			<enum name="Experimental Measurement" code="10"/>
+			<enum name="MTU Probe" code="11"/>
+			<enum name="MTU Reply" code="12"/>
+			<enum name="Experimental Flow Control" code="205"/>
+			<enum name="Experimental Access Control" code="142"/>
+			<enum name="ENCODE" code="15"/>
+			<enum name="IMI Traffic Descriptor" code="144"/>
+			<enum name="Extended Internet Protocol" code="145"/>
+			<enum name="Traceoute" code="82"/>
+			<enum name="Address Extension" code="147"/>
+			<enum name="Router Alert" code="148"/>
+			<enum name="Selective Directed Broadcast" code="149"/>
+			<enum name="Dynamic Packet State" code="151"/>
+			<enum name="Upstream Multicast Pkt." code="152"/>
+			<enum name="Quick-Start" code="25"/>
+			<enum name="RFC3692-style Experiment" code="30"/>
+			<enum name="RFC3692-style Experiment" code="94"/>
+			<enum name="RFC3692-style Experiment" code="158"/>
+			<enum name="RFC3692-style Experiment" code="222"/>
+		</avp>
+		<avp name="IP-Option-Value" code="539" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="TCP-Option" code="540" mandatory="may">
+			<grouped>
+				<gavp name="TCP-Option-Type"/>
+				<gavp name="TCP-Option-Value"/>
+				<gavp name="Negated"/>
+			</grouped>
+		</avp>
+		<avp name="TCP-Option-Type" code="541" mandatory="may">
+			<type type-name="Enumerated"/>
+			<enum name="End of Option List" code="0"/>
+			<enum name="No-Operation" code="1"/>
+			<enum name="Maximum Segment Size" code="2"/>
+			<enum name="Window Scale" code="3"/>
+			<enum name="SACK Permitted" code="4"/>
+			<enum name="SACK" code="5"/>
+			<enum name="Echo" code="6"/>
+			<enum name="Echo Reply" code="7"/>
+			<enum name="Timestamps" code="8"/>
+			<enum name="Partial Order Connection Permitted" code="9"/>
+			<enum name="Partial Order Service Profile" code="10"/>
+			<enum name="CC" code="11"/>
+			<enum name="CC.NEW" code="12"/>
+			<enum name="CC.ECHO" code="13"/>
+			<enum name="TCP Alternate Checksum Request" code="14"/>
+			<enum name="TCP Alternate Checksum Data" code="15"/>
+			<enum name="Skeeter" code="16"/>
+			<enum name="Bubba" code="17"/>
+			<enum name="Trailer Checksum Option" code="18"/>
+			<enum name="MD5 Signature Option" code="19"/>
+			<enum name="SCPS Capabilities" code="20"/>
+			<enum name="Selective Negative Acknowledgements" code="21"/>
+			<enum name="Record Boundaries" code="22"/>
+			<enum name="Corruption experienced" code="23"/>
+			<enum name="SNAP" code="24"/>
+			<enum name="TCP Compression Filter" code="26"/>
+			<enum name="Quick-Start Response" code="27"/>
+			<enum name="User Timeout Option" code="28"/>
+			<enum name="TCP Authentication Option (TCP-AO)" code="29"/>
+			<enum name="Multipath TCP (MPTCP)" code="30"/>
+			<enum name="TCP Fast Open Cookie" code="34"/>
+			<enum name="RFC3692-style Experiment 1" code="253"/>
+			<enum name="RFC3692-style Experiment 2" code="254"/>
+		</avp>
+		<avp name="TCP-Option-Value" code="542" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="TCP-Flags" code="543" mandatory="may">
+			<grouped>
+				<gavp name="TCP-Flag-Type"/>
+				<gavp name="Negated"/>
+			</grouped>
+		</avp>
+		<avp name="TCP-Flag-Type" code="544" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="ICMP-Type" code="545" mandatory="may">
+			<grouped>
+				<gavp name="ICMP-Type-Number"/>
+				<gavp name="ICMP-Code"/>
+				<gavp name="Negated"/>
+			</grouped>
+		</avp>
+		<avp name="ICMP-Type-Number" code="546" mandatory="may">
+			<type type-name="Enumerated"/>
+			<enum name="Echo Reply" code="0"/>
+			<enum name="Destination Unreachable" code="3"/>
+			<enum name="Source Quench" code="4"/>
+			<enum name="Redirect" code="5"/>
+			<enum name="Alternate Host Address" code="6"/>
+			<enum name="Echo" code="8"/>
+			<enum name="Router Advertisement" code="9"/>
+			<enum name="Router Solicitation" code="10"/>
+			<enum name="Time Exceeded" code="11"/>
+			<enum name="Parameter Problem" code="12"/>
+			<enum name="Timestamp" code="13"/>
+			<enum name="Timestamp Reply" code="14"/>
+			<enum name="Information Request" code="15"/>
+			<enum name="Information Reply" code="16"/>
+			<enum name="Address Mask Request" code="17"/>
+			<enum name="Address Mask Reply" code="18"/>
+			<enum name="Reserved (for Security)" code="19"/>
+			<enum name="Traceroute" code="30"/>
+			<enum name="Datagram Conversion Error" code="31"/>
+			<enum name="Mobile Host Redirect" code="32"/>
+			<enum name="IPv6 Where-Are-You" code="33"/>
+			<enum name="IPv6 I-Am-Here" code="34"/>
+			<enum name="Mobile Registration Request" code="35"/>
+			<enum name="Mobile Registration Reply" code="36"/>
+			<enum name="Domain Name Request" code="37"/>
+			<enum name="Domain Name Reply" code="38"/>
+			<enum name="SKIP" code="39"/>
+			<enum name="Photurius" code="40"/>
+			<enum name="ICMP messages utilized by experimental mobility protocols such as Seamoby" code="41"/>
+			<enum name="Extended Echo Request" code="42"/>
+			<enum name="Extended Echo Reply" code="43"/>
+			<enum name="RFC3692-style Experiment 1" code="253"/>
+			<enum name="RFC3692-style Experiment 2" code="254"/>
+			<enum name="Reserved" code="254"/>
+		</avp>
+		<avp name="ICMP-Code" code="547" mandatory="may">
+			<type type-name="Enumerated"/>
+			<!-- The codes depend on the type (above) -->
+		</avp>
+		<avp name="ETH-Option" code="548" mandatory="may">
+			<grouped>
+				<gavp name="ETH-Proto-Type"/>
+				<gavp name="VLAN-ID-Range"/>
+				<gavp name="User-Priority-Range"/>
+			</grouped>
+		</avp>
+		<avp name="ETH-Proto-Type" code="549" mandatory="may">
+			<grouped>
+				<gavp name="ETH-Ether-Type"/>
+				<gavp name="ETH-SAP"/>
+			</grouped>
+		</avp>
+		<avp name="ETH-Ether-Type" code="550" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="ETH-SAP" code="551" mandatory="may">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="VLAN-ID-Range" code="552" mandatory="may">
+			<grouped>
+				<gavp name="S-VID-Start"/>
+				<gavp name="S-VID-End"/>
+				<gavp name="C-VID-Start"/>
+				<gavp name="C-VID-End"/>
+			</grouped>
+		</avp>
+		<avp name="S-VID-Start" code="553" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="S-VID-End" code="554" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="C-VID-Start" code="555" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="C-VID-End" code="556" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="User-Priority-Range" code="557" mandatory="may">
+			<grouped>
+				<gavp name="Low-User-Priority"/>
+				<gavp name="High-User-Priority"/>
+			</grouped>
+		</avp>
+		<avp name="Low-User-Priority" code="558" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="High-User-Priority" code="559" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Time-Of-Day-Condition" code="560" mandatory="may">
+			<grouped>
+				<gavp name="Time-Of-Day-Start"/>
+				<gavp name="Time-Of-Day-End"/>
+				<gavp name="Day-Of-Week-Mask"/>
+				<gavp name="Day-Of-Month-Mask"/>
+				<gavp name="Month-Of-Year-Mask"/>
+				<gavp name="Absolute-Start-Time"/>
+				<gavp name="Absolute-End-Time"/>
+				<gavp name="Timezone-Flag"/>
+			</grouped>
+		</avp>
+		<avp name="Time-Of-Day-Start" code="561" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Time-Of-Day-End" code="562" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Day-Of-Week-Mask" code="563" mandatory="may">
+			<!-- This only works if only 1 bit is set -->
+			<type type-name="Enumerated"/>
+			<enum name="SUNDAY" code="0"/>
+			<enum name="MONDAY" code="2"/>
+			<enum name="TUESDAY" code="4"/>
+			<enum name="WEDNESDAY" code="8"/>
+			<enum name="THURSDAY" code="16"/>
+			<enum name="FRIDAY" code="32"/>
+			<enum name="SATURDAY" code="64"/>
+		</avp>
+		<avp name="Day-Of-Month-Mask" code="564" mandatory="may">
+			<type type-name="Enumerated"/>
+		</avp>
+		<avp name="Month-Of-Year-Mask" code="565" mandatory="may">
+			<!-- This only works if only 1 bit is set -->
+			<type type-name="Enumerated"/>
+			<enum name="JANUARY" code="0"/>
+			<enum name="FEBRUARY" code="2"/>
+			<enum name="MARCH" code="4"/>
+			<enum name="APRIL" code="8"/>
+			<enum name="MAY" code="16"/>
+			<enum name="JUNE" code="32"/>
+			<enum name="JULY" code="64"/>
+			<enum name="AUGUST" code="128"/>
+			<enum name="SEPTEMBER" code="256"/>
+			<enum name="OCTOBER" code="512"/>
+			<enum name="NOVEMBER" code="1024"/>
+			<enum name="DECEMBER" code="2048"/>
+		</avp>
+		<avp name="Absolute-Start-Time" code="566" mandatory="may">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Absolute-Start-Fractional-Seconds" code="567" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Absolute-End-Time" code="568" mandatory="may">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Absolute-End-Fractional-Seconds" code="569" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Timezone-Flag" code="570" mandatory="may">
+			<type type-name="Enumerated"/>
+			<enum name="UTC" code="0"/>
+			<enum name="LOCAL" code="1"/>
+			<enum name="OFFSET" code="2"/>
+		</avp>
+		<avp name="Timezone-Offset" code="571" mandatory="may">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Treatment-Action" code="572" mandatory="may">
+			<type type-name="Enumerated"/>
+			<enum name="Drop" code="0"/>
+			<enum name="Shape" code="1"/>
+			<enum name="Mark" code="2"/>
+			<enum name="Permit" code="3"/>
+		</avp>
+		<avp name="QoS-Profile-Id" code="573" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="QoS-Profile-Template" code="574" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot">
+			<grouped>
+				<gavp name="Vendor-Id"/>
+				<gavp name="QoS-Profile-Id"/>
+			</grouped>
+		</avp>
+		<avp name="QoS-Semantics" code="575" mandatory="may">
+			<type type-name="Enumerated"/>
+			<enum name="QoS-Desired" code="0"/>
+			<enum name="QoS-Available" code="1"/>
+			<enum name="QoS-Delivered" code="2"/>
+			<enum name="Minimum-QoS" code="3"/>
+			<enum name="QoS-Authorized" code="4"/>
+		</avp>
+		<avp name="QoS-Parameters" code="576" mandatory="may">
+			<grouped>
+				<!-- Technically this isn't true; RFC 5777 does
+				     not list any AVPs that can be here;
+				     we use this as a dummy.
+				-->
+				<gavp name="QoS-Profile-Id"/>
+			</grouped>
+		</avp>
+		<avp name="Excess-Treatment" code="577" mandatory="may">
+			<grouped>
+				<gavp name="Treatment-Action"/>
+				<gavp name="QoS-Profile-Template"/>
+				<gavp name="QoS-Parameters"/>
+			</grouped>
+		</avp>
+
+		<!--
+		578 QoS-Capability [RFC5777]
+		579 QoS-Authorization-Data [RFC5866]
+		580 Bound-Auth-Session-Id [RFC5866]
+		581 Key [RFC-ietf-dime-local-keytran-14]
+		582 Key-Type [RFC-ietf-dime-local-keytran-14]
+		583 Keying-Material [RFC-ietf-dime-local-keytran-14]
+		584 Key-Lifetime [RFC-ietf-dime-local-keytran-14]
+		585 Key-SPI [RFC-ietf-dime-local-keytran-14]
+		586 Key-Name [RFC-ietf-dime-local-keytran-14]
+		587 IKEv2-Nonces [RFC6738]
+		588 Ni [RFC6738]
+		589 Nr [RFC6738]
+		590 IKEv2-Identity [RFC6738]
+		591 Initiator-Identity [RFC6738]
+		592 ID-Type [RFC6738]
+		593 Identification-Data [RFC6738]
+		594 Responder-Identity [RFC6738]
+		595 NC-Request-Type [RFC6736]
+		596 NAT-Control-Install [RFC6736]
+		597 NAT-Control-Remove [RFC6736]
+		598 NAT-Control-Definition [RFC6736]
+		599 NAT-Internal-Address [RFC6736]
+		600 NAT-External-Address [RFC6736]
+		601 Max-NAT-Bindings [RFC6736]
+		602 NAT-Control-Binding-Template [RFC6736]
+		603 Duplicate-Session-Id [RFC6736]
+		604 NAT-External-Port-Style [RFC6736]
+		605 NAT-Control-Record [RFC6736]
+		606 NAT-Control-Binding-Status [RFC6736]
+		607 Current-NAT-Bindings [RFC6736]
+		608 Dual-Priority [RFC6735]
+		609 Preemption-Priority [RFC6735]
+		610 Defending-Priority [RFC6735]
+		611 Admission-Priority [RFC6735]
+		612 SIP-Resource-Priority [RFC6735]
+		613 SIP-Resource-Priority-Namespace [RFC6735]
+		614 SIP-Resource-Priority-Value [RFC6735]
+		615 Application-Level-Resource-Priority [RFC6735]
+		616 ALRP-Namespace [RFC6735]
+		617 ALRP-Value [RFC6735]
+		618 ERP-RK-Request [RFC6942]
+		619 ERP-Realm [RFC6942]
+		-->
+		<avp name="Redirect-Realm" code="620" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="OC-Supported-Features" code="621" mandatory="may">
+			<grouped>
+				<gavp name="OC-Feature-Vector"/>
+			</grouped>
+		</avp>
+		<avp name="OC-Feature-Vector" code="622" mandatory="may">
+			<type type-name="Unsigned64"/>
+		</avp>
+		<avp name="OC-OLR" code="623" mandatory="may">
+			<grouped>
+				<gavp name="OC-Sequence-Number"/>
+				<gavp name="OC-Report-Type"/>
+				<gavp name="OC-Reduction-Percentage"/>
+				<gavp name="OC-Validity-Duration"/>
+			</grouped>
+		</avp>
+		<avp name="OC-Sequence-Number" code="624" mandatory="may">
+			<type type-name="Unsigned64"/>
+		</avp>
+		<avp name="OC-Validity-Duration" code="625" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="OC-Report-Type" code="626" mandatory="may">
+			<type type-name="Enumerated"/>
+			<enum name="HOST_REPORT" code="0"/>
+			<enum name="REALM_REPORT" code="1"/>
+		</avp>
+		<avp name="OC-Reduction-Percentage" code="627" mandatory="may">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<!--
+		628 ECN-IP-Codepoint [RFC7660]
+		629 Congestion-Treatment [RFC7660]
+		630 Flow-Count [RFC7660]
+		631 Packet-Count [RFC7660]
+		632 IP-Prefix-Length [RFC7678]
+		633 Border-Router-Name [RFC7678]
+		634 64-Multicast-Attributes [RFC7678]
+		635 ASM-mPrefix64 [RFC7678]
+		636 SSM-mPrefix64 [RFC7678]
+		637 Tunnel-Source-Pref-Or-Addr [RFC7678]
+		638 Tunnel-Source-IPv6-Address [RFC7678]
+		639 Port-Set-Identifier [RFC7678]
+		640 Lw4o6-Binding [RFC7678]
+		641 Lw4o6-External-IPv4-Addr [RFC7678]
+		642 MAP-E-Attributes [RFC7678]
+		643 MAP-Mesh-Mode [RFC7678]
+		644 MAP-Mapping-Rule [RFC7678]
+		645 Rule-IPv4-Addr-Or-Prefix [RFC7678]
+		646 Rule-IPv6-Prefix [RFC7678]
+		647 EA-Field-Length [RFC7678]
+		-->
+
+		<!-- **************************************************************************** -->
+		<!-- ************************ END DIAMETER BASE PROTOCOL AVPS ******************* -->
+		<!-- **************************************************************************** -->
+
+		<!--
+		3GPP TS 29.230 version 8.7.0 Release 8  Table 7.1: 3GPP specific AVP codes
+		100 3GPP-WLAN-APN-Id OctetString 29.234 [6]
+		Note: The AVP codes from 1 to 255 are reserved for backwards compatibility with 3GPP RADIUS Vendor
+		Specific Attributes (See TS 29.061 [13])
+		Note: The AVP codes from 256 to 299 are reserved for future use.
+		-->
+		<avp name="Authentication-Method" code="300" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Enumerated"/>
+			<enum name="WLAN_EAP_SIM" code="0"/>
+			<enum name="WLAN_EAP_AKA" code="1"/>
+		</avp>
+		<avp name="Authentication-Information-SIM" code="301" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Authorization-Information-SIM" code="302" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="OctetString"/>
+		</avp>
+		<!--
+		303 WLAN-User-Data Grouped
+		304 Charging-Data Grouped
+		305 WLAN-Access Enumerated
+		306 WLAN- 3GPP-IP-Access Enumerated
+		307 APN-Authorized Grouped
+		308 APN-Id
+		309 APN-Barring-Type Enumerated
+		310 WLAN-Direct-IP-Access Enumerated
+		311 Session-Request-Type Enumerated
+		312 Routing-Policy IPFilterRule
+		313 Max-Requested-Bandwidth OctetString
+		314 Charging-Characteristics Integer
+		315 Charging-Nodes Grouped
+		316 Primary-OCS-Charging-Function-Name DiameterIdentity
+		317 Secondary-OCS-Charging-Function-Name DiameterIdentity
+		-->
+
+		<avp name="3GPP-AAA-Server-Name" code="318" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Maximum-Number-Accesses" code="319" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+
+		<!--
+		Note: The AVP codes from 320 to 399 are reserved for TS 29.234
+		-->
+
+		<avp name="GBA-UserSecSettings" code="400" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Transaction-Identifier" code="401" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="NAF-Hostname" code="402" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="GAA-Service-Identifier" code="403" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Key-ExpiryTime" code="404" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="ME-Key-Material" code="405" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="UICC-Key-Material" code="406" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="GBA_U-Awareness-Indicator" code="407" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NO" code="0"/>
+			<enum name="YES" code="1"/>
+		</avp>
+		<avp name="BootstrapInfoCreationTime" code="408" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="GUSS-Timestamp" code="409" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="GBA-Type" code="410" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="3G GBA" code="0"/>
+			<enum name="2G GBA" code="1"/>
+		</avp>
+		<avp name="UE-Id" code="411" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="UE-Id-Type" code="412" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Private user identity" code="0"/>
+			<enum name="Public user identity" code="1"/>
+		</avp>
+		<avp name="UICC-App-Label" code="413" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="UICC-ME" code="414" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="GBA_ME" code="0"/>
+			<enum name="GBA_U" code="1"/>
+		</avp>
+		<avp name="Requested-Key-Lifetime" code="415" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Private-Identity-Request" code="416" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Private identity requested" code="0"/>
+			<enum name="Private identity not requested" code="1"/>
+		</avp>
+		<avp name="GBA-Push-Info" code="417" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="NAF-SA-Identifier" code="418" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Security-Feature-Request" code="419" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Security-Feature-Response" code="420" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+
+		<!-- Note: The AVP codes from 421 to 499 are reserved for TS 29.109
+		<avp name="Reserved for TS 29.109" code="421" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="422" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="423" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="424" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="425" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="426" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="427" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="428" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="429" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="430" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="431" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="432" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="433" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="434" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="435" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="436" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="437" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="438" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved for TS 29.109" code="439" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		29.109 [7]
+		Note: The AVP codes from 421 to 499 are reserved for TS 29.109
+		-->
+
+		<!-- Note: The AVP codes from 500 to 599 are reserved for TS 29.209, TS 29.211 and TS 29.214 (TGPP.xml)
+		     Note: The AVP codes from 600 to 699 are reserved for TS 29.229. (TGPP.xml)
+		     Note: The AVP codes from 700 to 799 are reserved for TS 29.329. (TGPP.xml)
+		-->
+
+		<!-- 3GPP Diameter charging applications (3GPP TS 32.299 version 7.0.0 Release 7)-->
+		<!-- Note: The AVP codes from 800 to 822 are reserved for TS 32.299. -->
+
+		<avp name="Event-Type" code="823" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="mustnot" vendor-id="TGPP">
+			<grouped>
+				<gavp name="3GPP-SIP-Method"/>
+				<gavp name="Event"/>
+				<gavp name="Content-Type"/>
+				<gavp name="Content-Length"/>
+				<gavp name="Content-Disposition"/>
+			</grouped>
+		</avp>
+		<avp name="3GPP-SIP-Method" code="824" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Event" code="825" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Content-Type" code="826" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+
+		<!--
+		     In 3GPP TS 32.299 version 6.5.0 Release 6 (2005-12)
+		     type type-name="UTF8String"
+		     but according to 3GPP TS 32.299 version 7.4.0 Release 7(2006-12) it should be:
+		-->
+		<avp name="Content-Length" code="827" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Content-Disposition" code="828" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Role-Of-Node" code="829" mandatory="must" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ORIGINATING_ROLE" code="0"/>
+			<enum name="TERMINATING_ROLE" code="1"/>
+			<enum name="PROXY_ROLE" code="2"/>
+			<enum name="B2BUA_ROLE" code="3"/>
+		</avp>
+		<avp name="User-Session-ID" code="830" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Calling-Party-Address" code="831" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Called-Party-Address" code="832" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Time-Stamps" code="833" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SIP-Request-Timestamp"/>
+				<gavp name="SIP-Response-Timestamp"/>
+			</grouped>
+		</avp>
+		<avp name="SIP-Request-Timestamp" code="834" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="SIP-Response-Timestamp" code="835" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Application-Server" code="836" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Application-Provided-Called-Party-Address" code="837" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Inter-Operator-Identifier" code="838" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Originating-IOI"/>
+				<gavp name="Terminating-IOI"/>
+			</grouped>
+		</avp>
+		<avp name="Originating-IOI" code="839" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Terminating-IOI" code="840" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="IMS-Charging-Identifier" code="841" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="SDP-Session-Description" code="842" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="SDP-Media-Component" code="843" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SDP-Media-Name"/>
+				<gavp name="SDP-Media-Description"/>
+			</grouped>
+		</avp>
+		<avp name="SDP-Media-Name" code="844" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="SDP-Media-Description" code="845" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="CG-Address" code="846" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<!-- ETSI TS 132 299 V7.6.0 (2007-06) -->
+		<avp name="GGSN-Address" code="847" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Served-Party-IP-Address" code="848" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Authorised-QoS" code="849" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Application-Server-Information" code="850" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Application-Server"/>
+				<gavp name="Application-Provided-Called-Party-Address"/>
+			</grouped>
+		</avp>
+		<avp name="Trunk-Group-ID" code="851" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Incoming-Trunk-Group-ID"/>
+				<gavp name="Outgoing-Trunk-Group-ID"/>
+			</grouped>
+		</avp>
+		<avp name="Incoming-Trunk-Group-ID" code="852" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Outgoing-Trunk-Group-ID" code="853" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Bearer-Service" code="854" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Service-Id" code="855" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Associated-URI" code="856" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Charged-Party" code="857" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="PoC-Controlling-Address" code="858" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="PoC-Group-Name" code="859" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Cause" code="860" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Cause-Code"/>
+				<gavp name="Node-Functionality"/>
+			</grouped>
+		</avp>
+		<avp name="Cause-Code" code="861" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="End of REGISTER dialog" code="-3"/>
+			<enum name="End of SUBSCRIBE dialog" code="-2"/>
+			<enum name="Successful transaction" code="-1"/>
+			<enum name="Normal end of session" code="0"/>
+			<enum name="Unspecified error" code="1"/>
+			<enum name="Unsuccessful session setup" code="2"/>
+			<enum name="Internal error" code="3"/>
+			<enum name="Multiple Choices" code="300"/>
+			<enum name="Moved Permanently" code="301"/>
+			<enum name="Moved Temporarily" code="302"/>
+			<enum name="Use Proxy" code="305"/>
+			<enum name="Alternative Service" code="380"/>
+			<enum name="Bad Request" code="400"/>
+			<enum name="Unauthorized" code="401"/>
+			<enum name="Payment Required" code="402"/>
+			<enum name="Forbidden" code="403"/>
+			<enum name="Not Found" code="404"/>
+			<enum name="Method Not Allowed" code="405"/>
+			<enum name="Not Acceptable" code="406"/>
+			<enum name="Proxy Authentication Required" code="407"/>
+			<enum name="Request Timeout" code="408"/>
+			<enum name="Gone" code="410"/>
+			<enum name="Conditional Request Failed" code="412"/>
+			<enum name="Request Entity Too Large" code="413"/>
+			<enum name="Request-URI Too Long" code="414"/>
+			<enum name="Unsupported Media Type" code="415"/>
+			<enum name="Unsupported URI Scheme" code="416"/>
+			<enum name="Unknown Resource-Priority" code="417"/>
+			<enum name="Bad Extension" code="420"/>
+			<enum name="Extension Required" code="421"/>
+			<enum name="Session Interval Too Small" code="422"/>
+			<enum name="Interval Too Brief" code="423"/>
+			<enum name="Use Identity Header" code="428"/>
+			<enum name="Provide Referrer Identity" code="429"/>
+			<enum name="Bad Identity-Info" code="436"/>
+			<enum name="Unsupported Certificate" code="437"/>
+			<enum name="Invalid Identity Header" code="438"/>
+			<enum name="Temporarily Unavailable" code="480"/>
+			<enum name="Call/Transaction Does Not Exist" code="481"/>
+			<enum name="Loop Detected" code="482"/>
+			<enum name="Too Many Hops" code="483"/>
+			<enum name="Address Incomplete" code="484"/>
+			<enum name="Ambiguous" code="485"/>
+			<enum name="Busy Here" code="486"/>
+			<enum name="Request Terminated" code="487"/>
+			<enum name="Not Acceptable Here" code="488"/>
+			<enum name="Bad Event" code="489"/>
+			<enum name="Request Pending" code="491"/>
+			<enum name="Undecipherable" code="493"/>
+			<enum name="Security Agreement Required" code="494"/>
+			<enum name="Server Internal Error" code="500"/>
+			<enum name="Not Implemented" code="501"/>
+			<enum name="Bad Gateway" code="502"/>
+			<enum name="Service Unavailable" code="503"/>
+			<enum name="Server Time-out" code="504"/>
+			<enum name="Version Not Supported" code="505"/>
+			<enum name="Message Too Large" code="513"/>
+			<enum name="Precondition Failure" code="580"/>
+			<enum name="Busy Everywhere" code="600"/>
+			<enum name="Decline" code="603"/>
+			<enum name="Does Not Exist Anywhere" code="604"/>
+			<enum name="Not Acceptable" code="606"/>
+		</avp>
+		<avp name="Node-Functionality" code="862" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="S-CSCF" code="0"/>
+			<enum name="P-CSCF" code="1"/>
+			<enum name="I-CSCF" code="2"/>
+			<enum name="MRFC" code="3"/>
+			<enum name="MGCF" code="4"/>
+			<enum name="BGCF" code="5"/>
+			<enum name="AS" code="6"/>
+			<enum name="IBCF" code="7"/>
+			<enum name="S-GW" code="8"/>
+			<enum name="P-GW" code="9"/>
+			<enum name="HSGW" code="10"/>
+			<enum name="E-CSCF" code="11"/>
+			<enum name="MME" code="12"/>
+			<enum name="TRF" code="13"/>
+			<enum name="TF" code="14"/>
+			<enum name="ATCF" code="15"/>
+			<enum name="Proxy Function" code="16"/>
+			<enum name="ePDG" code="17"/>
+		</avp>
+		<avp name="Service-Specific-Data" code="863" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Originator" code="864" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Calling Party" code="0"/>
+			<enum name="Called Party" code="1"/>
+		</avp>
+		<avp name="PS-Furnish-Charging-Information" code="865" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="3GPP-Charging-Id"/>
+				<gavp name="PS-Free-Format-Data"/>
+				<gavp name="PS-Append-Free-Format-Data"/>
+			</grouped>
+		</avp>
+		<avp name="PS-Free-Format-Data" code="866" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="PS-Append-Free-Format-Data" code="867" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Append" code="0"/>
+			<enum name="Overwrite" code="1"/>
+		</avp>
+		<avp name="Time-Quota-Threshold" code="868" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Volume-Quota-Threshold" code="869" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Trigger-Type" code="870" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="CHANGE_IN_SGSN_IP_ADDRESS" code="1"/>
+			<enum name="CHANGE_IN_QOS" code="2"/>
+			<enum name="CHANGE_IN_LOCATION" code="3"/>
+			<enum name="CHANGE_IN_RAT" code="4"/>
+			<enum name="CHANGE_IN_UE_TIMEZONE" code="5"/>
+
+			<enum name="Undefined" code="6"/>
+			<enum name="Undefined" code="7"/>
+			<enum name="Undefined" code="8"/>
+			<enum name="Undefined" code="9"/>
+
+			<enum name="CHANGEINQOS_TRAFFIC_CLASS" code="10"/>
+			<enum name="CHANGEINQOS_RELIABILITY_CLASS" code="11"/>
+			<enum name="CHANGEINQOS_DELAY_CLASS" code="12"/>
+			<enum name="CHANGEINQOS_PEAK_THROUGHPUT" code="13"/>
+			<enum name="CHANGEINQOS_PRECEDENCE_CLASS" code="14"/>
+			<enum name="CHANGEINQOS_MEAN_THROUGHPUT" code="15"/>
+			<enum name="CHANGEINQOS_MAXIMUM_BIT_RATE_FOR_UPLINK" code="16"/>
+			<enum name="CHANGEINQOS_MAXIMUM_BIT_RATE_FOR_DOWNLINK" code="17"/>
+			<enum name="CHANGEINQOS_RESIDUAL_BER" code="18"/>
+			<enum name="CHANGEINQOS_SDU_ERROR_RATIO" code="19"/>
+			<enum name="CHANGEINQOS_TRANSFER_DELAY" code="20"/>
+			<enum name="CHANGEINQOS_TRAFFIC_HANDLING_PRIORITY" code="21"/>
+			<enum name="CHANGEINQOS_GUARANTEED_BIT_RATE_FOR_UPLINK" code="22"/>
+			<enum name="CHANGEINQOS_GUARANTEED_BIT_RATE_FOR_DOWNLINK" code="23"/>
+			<enum name="CHANGEINQOS_APN_AGGREGATE_MAXIMUM_BIT_RATE" code="24"/>
+
+			<enum name="Undefined" code="25"/>
+			<enum name="Undefined" code="26"/>
+			<enum name="Undefined" code="27"/>
+			<enum name="Undefined" code="28"/>
+			<enum name="Undefined" code="29"/>
+
+			<enum name="CHANGEINLOCATION_MCC" code="30"/>
+			<enum name="CHANGEINLOCATION_MNC" code="31"/>
+			<enum name="CHANGEINLOCATION_RAC" code="32"/>
+			<enum name="CHANGEINLOCATION_LAC" code="33"/>
+			<enum name="CHANGEINLOCATION_CellId" code="34"/>
+			<enum name="CHANGEINLOCATION_TAC" code="35"/>
+			<enum name="CHANGEINLOCATION_ECGI" code="36"/>
+
+			<enum name="Undefined" code="37"/>
+			<enum name="Undefined" code="38"/>
+			<enum name="Undefined" code="39"/>
+
+			<enum name="CHANGE_IN_MEDIA_COMPOSITION" code="40"/>
+
+			<enum name="Undefined" code="41"/>
+			<enum name="Undefined" code="42"/>
+			<enum name="Undefined" code="43"/>
+			<enum name="Undefined" code="44"/>
+			<enum name="Undefined" code="45"/>
+			<enum name="Undefined" code="46"/>
+			<enum name="Undefined" code="47"/>
+			<enum name="Undefined" code="48"/>
+			<enum name="Undefined" code="49"/>
+
+			<enum name="CHANGEINPARTICIPANTS_Number" code="50"/>
+			<enum name="CHANGE_IN_THRSHLD_OF_PARTICIPANTS_NMB" code="51"/>
+			<enum name="CHANGE_IN_USER_PARTICIPATING_TYPE" code="52"/>
+
+			<enum name="Undefined" code="53"/>
+			<enum name="Undefined" code="54"/>
+			<enum name="Undefined" code="55"/>
+			<enum name="Undefined" code="56"/>
+			<enum name="Undefined" code="57"/>
+			<enum name="Undefined" code="58"/>
+			<enum name="Undefined" code="59"/>
+
+			<enum name="CHANGE_IN_SERVICE_CONDITION" code="60"/>
+			<enum name="CHANGE_IN_SERVING_NODE" code="61"/>
+			<enum name="CHANGE_IN_ACCESS_FOR_A_SERVICE_DATA_FLOW" code="62"/>
+
+			<enum name="Undefined" code="63"/>
+			<enum name="Undefined" code="64"/>
+			<enum name="Undefined" code="65"/>
+			<enum name="Undefined" code="66"/>
+			<enum name="Undefined" code="67"/>
+			<enum name="Undefined" code="68"/>
+			<enum name="Undefined" code="69"/>
+
+			<enum name="CHANGE_IN_USER_CSG_INFORMATION" code="70"/>
+			<enum name="CHANGE_IN_HYBRID_SUBSCRIBED_USER_CSG_INFORMATION" code="71"/>
+			<enum name="CHANGE_IN_HYBRID_UNSUBSCRIBED_USER_CSG_INFORMATION" code="72"/>
+			<enum name="CHANGE_OF_UE_PRESENCE_IN_PRESENCE_REPORTING_AREA" code="73"/>
+			<enum name="CHANGE_IN_SERVING_PLMN_RATE_CONTROL" code="74"/>
+			<enum name="CHANGE_IN_APN_RATE_CONTROL" code="75"/>
+		</avp>
+		<avp name="Quota-Holding-Time" code="871" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="3GPP-Reporting-Reason" code="872" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="THRESHOLD" code="0"/>
+			<enum name="QHT" code="1"/>
+			<enum name="FINAL" code="2"/>
+			<enum name="QUOTA_EXHAUSTED" code="3"/>
+			<enum name="VALIDITY_TIME" code="4"/>
+			<enum name="OTHER_QUOTA_TYPE" code="5"/>
+			<enum name="RATING_CONDITION_CHANGE" code="6"/>
+			<enum name="FORCED_REAUTHORISATION" code="7"/>
+			<enum name="POOL_EXHAUSTED" code="8"/>
+		</avp>
+		<avp name="Service-Information" code="873" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="PS-Information"/>
+				<gavp name="WLAN-Information"/>
+				<gavp name="IMS-Information"/>
+				<gavp name="MMS-Information"/>
+				<gavp name="LCS-Information"/>
+				<gavp name="PoC-Information"/>
+				<gavp name="MBMS-Information"/>
+			</grouped>
+		</avp>
+		<avp name="PS-Information" code="874" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="3GPP-Charging-Id"/>
+				<gavp name="PDN-Connection-ID"/>
+				<gavp name="Node-Id"/>
+				<gavp name="3GPP-PDP-Type"/>
+				<gavp name="PDP-Address"/>
+				<gavp name="PDP-Address-Prefix-Length"/>
+				<gavp name="Dynamic-Address-Flag"/>
+				<gavp name="Dynamic-Address-Flag-Extension"/>
+				<gavp name="QoS-Information"/>
+				<gavp name="SGSN-Address"/>
+				<gavp name="GGSN-Address"/>
+				<gavp name="TDF-IP-Address"/>
+				<gavp name="SGW-Address"/>
+				<gavp name="ePDG-Address"/>
+				<gavp name="TWAG-Address"/>
+				<gavp name="CG-Address"/>
+				<gavp name="Serving-Node-Type"/>
+				<gavp name="SGW-Change"/>
+				<gavp name="3GPP-IMSI-MCC-MNC"/>
+				<gavp name="IMSI-Unauthenticated-Flag"/>
+				<gavp name="3GPP-GGSN-MCC-MNC"/>
+				<gavp name="3GPP-NSAPI"/>
+				<gavp name="Called-Station-Id"/>
+				<gavp name="3GPP-Session-Stop-Indicator"/>
+				<gavp name="3GPP-Selection-Mode"/>
+				<gavp name="3GPP-Charging-Characteristics"/>
+				<gavp name="Charging-Characteristics-Selection-Mode"/>
+				<gavp name="3GPP-SGSN-MCC-MNC"/>
+				<gavp name="3GPP-MS-TimeZone"/>
+				<gavp name="Charging-Rule-Base-Name"/>
+				<gavp name="ADC-Rule-Base-Name"/>
+				<gavp name="3GPP-User-Location-Info"/>
+				<gavp name="User-Location-Info-Time"/>
+				<gavp name="User-CSG-Information"/>
+				<gavp name="Presence-Reporting-Area-Information"/>
+				<gavp name="3GPP2-BSID"/>
+				<gavp name="TWAN-User-Location-Info"/>
+				<gavp name="UWAN-User-Location-Info"/>
+				<gavp name="3GPP-RAT-Type"/>
+				<gavp name="PS-Furnish-Charging-Information"/>
+				<gavp name="PDP-Context-Type"/>
+				<gavp name="Offline-Charging"/>
+				<gavp name="Traffic-Data-Volumes"/>
+				<gavp name="Service-Data-Container"/>
+				<gavp name="User-Equipment-Info"/>
+				<gavp name="Terminal-Information"/>
+				<gavp name="Start-Time"/>
+				<gavp name="Stop-Time"/>
+				<gavp name="Change-Condition"/>
+				<gavp name="Diagnostics"/>
+				<gavp name="Low-Priority-Indicator"/>
+				<gavp name="NBIFOM-Mode"/>
+				<gavp name="NBIFOM-Support"/>
+				<gavp name="MME-Number-for-MT-SMS"/>
+				<gavp name="MME-Name"/>
+				<gavp name="MME-Realm"/>
+				<gavp name="Logical-Access-ID"/>
+				<gavp name="Physical-Access-ID"/>
+				<gavp name="Fixed-User-Location-Info"/>
+				<gavp name="CN-Operator-Selection-Entity"/>
+				<gavp name="Enhanced-Diagnostics"/>
+				<gavp name="SGi-PtP-Tunnelling-Method"/>
+				<gavp name="CP-CIoT-EPS-Optimisation-Indicator"/>
+				<gavp name="UNI-PDU-CP-Only-Flag"/>
+				<gavp name="Serving-PLMN-Rate-Control"/>
+				<gavp name="APN-Rate-Control"/>
+				<gavp name="Charging-Per-IP-CAN-Session-Indicator"/>
+				<gavp name="RRC-Cause-Counter"/>
+			</grouped>
+		</avp>
+		<avp name="WLAN-Information" code="875" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="WLAN-Session-Id"/>
+				<gavp name="PDG-Address"/>
+				<!-- <gavp name="NPDG-Charging-Id"/> -->
+				<gavp name="WAG-Address"/>
+				<gavp name="WAG-PLMN-Id"/>
+				<gavp name="WLAN-Radio-Container"/>
+				<gavp name="WLAN-UE-Local-IPAddress"/>
+			</grouped>
+		</avp>
+		<avp name="IMS-Information" code="876" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Event-Type"/>
+				<gavp name="Role-Of-Node"/>
+				<gavp name="Node-Functionality"/>
+				<gavp name="User-Session-ID"/>
+				<gavp name="Outgoing-Session-Id"/>
+				<gavp name="Calling-Party-Address"/>
+				<gavp name="Called-Party-Address"/>
+				<gavp name="Time-Stamps"/>
+				<gavp name="Application-Server-Information"/>
+				<gavp name="Inter-Operator-Identifier"/>
+				<gavp name="IMS-Charging-Identifier"/>
+				<gavp name="SDP-Session-Description"/>
+				<gavp name="SDP-Media-Component"/>
+				<gavp name="GGSN-Address"/>
+				<gavp name="Served-Party-IP-Address"/>
+				<gavp name="Server-Capabilities"/>
+				<gavp name="Trunk-Group-ID"/>
+				<gavp name="Bearer-Service"/>
+				<gavp name="Service-Id"/>
+				<gavp name="Service-Specific-Data"/>
+				<gavp name="Message-Body"/>
+				<gavp name="Cause-Code"/>
+				<gavp name="Access-Network-Information"/>
+				<gavp name="Early-Media-Description"/>
+				<gavp name="IMS-Communication-Service-Identifier"/>
+			</grouped>
+		</avp>
+		<avp name="MMS-Information" code="877" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Originator-Address"/>
+				<gavp name="Recipient-Address"/>
+				<gavp name="Submission-Time"/>
+				<gavp name="MM-Content-Type"/>
+				<gavp name="Priority"/>
+				<gavp name="Message-ID"/>
+				<gavp name="Message-Type"/>
+				<gavp name="Message-Size"/>
+				<gavp name="Message-Class"/>
+				<gavp name="Delivery-Report-Requested"/>
+				<gavp name= "Read-Reply-Report-Requested"/>
+				<gavp name="MMBox-Storage-Requested"/>
+				<gavp name="Applic-ID"/>
+				<gavp name="Reply-Applic-ID"/>
+				<gavp name="Aux-Applic-Info"/>
+				<gavp name="Content-Class"/>
+				<gavp name="DRM-Content"/>
+				<gavp name="Adaptations"/>
+				<gavp name="VASP-ID"/>
+				<gavp name="VAS-ID"/>
+			</grouped>
+		</avp>
+		<avp name="LCS-Information" code="878" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="LCS-Client-ID"/>
+				<gavp name="Location-Type"/>
+				<gavp name="Location-Estimate"/>
+				<gavp name="Positioning-Data"/>
+				<gavp name="3GPP-IMSI"/>
+				<gavp name="MSISDN"/>
+			</grouped>
+		</avp>
+		<avp name="PoC-Information" code="879" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="PoC-Server-Role"/>
+				<gavp name="PoC-Session-Type"/>
+				<gavp name="PoC-User-Role"/>
+				<gavp name="PoC-Session-Initiation-type"/>
+				<gavp name="PoC-Event-Type"/>
+				<gavp name="Number-Of-Participants"/>
+				<gavp name="Participants-Involved"/>
+				<gavp name="Participant-Group"/>
+				<gavp name="Talk-Burst-Exchange"/>
+				<gavp name="PoC-Controlling-Address"/>
+				<gavp name="PoC-Group-Name"/>
+				<gavp name="PoC-Session-Id"/>
+				<gavp name="Charged-Party"/>
+			</grouped>
+		</avp>
+		<avp name="MBMS-Information" code="880" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="TMGI"/>
+				<gavp name="MBMS-Service-Type"/>
+				<gavp name="MBMS-User-Service-Type"/>
+				<gavp name="File-Repair-Supported"/>
+				<gavp name="Required-MBMS-Bearer-Capabilities"/>
+				<gavp name="MBMS-2G-3G-Indicator"/>
+				<gavp name="RAI"/>
+				<gavp name="MBMS-Service-Area"/>
+				<gavp name="MBMS-Session-Identity"/>
+			</grouped>
+		</avp>
+		<avp name="Quota-Consumption-Time" code="881" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Media-Initiator-Flag" code="882" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="called party" code="0"/>
+			<enum name="calling party" code="1"/>
+			<enum name="unknown" code="2"/>
+		</avp>
+		<avp name="PoC-Server-Role" code="883" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Participating PoC Server" code="0"/>
+			<enum name="Controlling PoC Server" code="1"/>
+		</avp>
+		<avp name="PoC-Session-Type" code="884" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="1 to 1 PoC session" code="0"/>
+			<enum name="chat PoC group session" code="1"/>
+			<enum name="pre-arranged PoC group session" code="2"/>
+			<enum name="ad-hoc PoC group session" code="3"/>
+		</avp>
+		<avp name="Number-Of-Participants" code="885" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Originator-Address" code="886" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Address-Type"/>
+				<gavp name="Address-Data"/>
+				<gavp name="Address-Domain"/>
+			</grouped>
+		</avp>
+		<avp name="Participants-Involved" code="887" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Expires" code="888" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Message-Body" code="889" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Content-Type"/>
+				<gavp name="Content-Length"/>
+				<gavp name="Content-Disposition"/>
+				<gavp name="Originator"/>
+			</grouped>
+		</avp>
+		<avp name="WAG-Address" code="890" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="WAG-PLMN-Id" code="891" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP" >
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="WLAN-Radio-Container" code="892" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Operator-Name"/>
+				<gavp name="Location-Type"/>
+				<gavp name="Location-Information"/>
+				<gavp name="WLAN-Technology"/>
+			</grouped>
+		</avp>
+		<avp name="WLAN-Technology" code="893" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="WLAN-UE-Local-IPAddress" code="894" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="PDG-Address" code="895" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="PDG-Charging-Id" code="896" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Address-Data" code="897" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Address-Domain" code="898" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Domain-Name"/>
+				<gavp name="3GPP-IMSI-MCC-MNC"/>
+			</grouped>
+		</avp>
+		<avp name="Address-Type" code="899" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="e-mail address" code="0"/>
+			<enum name="MSISDN" code="1"/>
+			<enum name="IPv4 Address" code="2"/>
+			<enum name="IPv6 Address" code="3"/>
+			<enum name="Numeric Shortcode" code="4"/>
+			<enum name="Alphanumeric Shortcode" code="5"/>
+			<enum name="Other" code="6"/>
+		</avp>
+
+		<!--
+		Note: The AVP codes from 900 to 999 are reserved for TS 29.061 (TGPP.xml)
+		-->
+
+		<avp name="Bearer-Usage" code="1000" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="GENERAL" code="0"/>
+			<enum name="IMS SIGNALLING" code="1"/>
+			<enum name="DEDICATED" code="2"/>
+		</avp>
+		<avp name="Charging-Rule-Install" code="1001" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Charging-Rule-Definition"/>
+				<gavp name="Charging-Rule-Name"/>
+				<gavp name="Charging-Rule-Base-Name"/>
+				<gavp name="Bearer-Identifier"/>
+				<gavp name="Rule-Activation-Time"/>
+				<gavp name="Rule-Deactivation-Time"/>
+				<gavp name="Resource-Allocation-Notification"/>
+			</grouped>
+		</avp>
+		<avp name="Charging-Rule-Remove" code="1002" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Charging-Rule-Name"/>
+				<gavp name="Charging-Rule-Base-Name"/>
+			</grouped>
+		</avp>
+		<avp name="Charging-Rule-Definition" code="1003" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Charging-Rule-Name"/>
+				<gavp name="Service-Identifier"/>
+				<gavp name="Rating-Group"/>
+				<gavp name="Flow-Information"/>
+				<gavp name="TDF-Application-Identifier"/>
+				<gavp name="Flow-Status"/>
+				<gavp name="QoS-Information"/>
+				<gavp name="PS-to-CS-Session-Continuity"/>
+				<gavp name="Reporting-Level"/>
+				<gavp name="Online"/>
+				<gavp name="Offline"/>
+				<gavp name="Metering-Method"/>
+				<gavp name="Precedence"/>
+				<gavp name="AF-Charging-Identifier"/>
+				<gavp name="Flows"/>
+				<gavp name="Monitoring-Key"/>
+				<gavp name="Redirect-Information"/>
+				<gavp name="Mute-Notification"/>
+				<gavp name="AF-Signalling-Protocol"/>
+				<gavp name="Sponsor-Identity"/>
+				<gavp name="Application-Service-Provider-Identity"/>
+				<gavp name="Required-Access-Info"/>
+				<gavp name="Sharing-Key-DL"/>
+				<gavp name="Sharing-Key-UL"/>
+				<gavp name="Traffic-Steering-Policy-Identifier-DL"/>
+				<gavp name="Traffic-Steering-Policy-Identifier-UL"/>
+			</grouped>
+		</avp>
+		<avp name="Charging-Rule-Base-Name" code="1004" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Charging-Rule-Name" code="1005" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Event-Trigger" code="1006" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SGSN_CHANGE"					code="0"/>
+			<enum name="QOS_CHANGE"						code="1"/>
+			<enum name="RAT_CHANGE"						code="2"/>
+			<enum name="TFT_CHANGE"						code="3"/>
+			<enum name="PLMN_CHANGE"					code="4"/>
+			<enum name="LOSS_OF_BEARER" 					code="5"/>
+			<enum name="RECOVERY_OF_BEARER" 				code="6"/>
+			<enum name="IP-CAN_CHANGE"					code="7"/>
+			<enum name="GW-PCEF-MALFUNCTION"				code="8"/>
+			<enum name="RESOURCES_LIMITATION"				code="9"/>
+			<enum name="MAX_NR_BEARERS_REACHED"				code="10"/>
+			<enum name="QOS_CHANGE_EXCEEDING_AUTHORIZATION"			code="11"/>
+			<enum name="RAI_CHANGE"						code="12"/>
+			<enum name="USER_LOCATION_CHANGE"				code="13"/>
+			<enum name="NO_EVENT_TRIGGERS"					code="14"/>
+			<enum name="OUT_OF_CREDIT"					code="15"/>
+			<enum name="REALLOCATION_OF_CREDIT"				code="16"/>
+			<enum name="REVALIDATION_TIMEOUT"				code="17"/>
+			<enum name="UE_IP_ADDRESS_ALLOCATE"				code="18"/>
+			<enum name="UE_IP_ADDRESS_RELEASE"				code="19"/>
+			<enum name="DEFAULT_EPS_BEARER_QOS_CHANGE"			code="20"/>
+			<enum name="AN_GW_CHANGE"					code="21"/>
+			<enum name="SUCCESSFUL_RESOURCE_ALLOCATION"			code="22"/>
+			<enum name="RESOURCE_MODIFICATION_REQUEST"			code="23"/>
+			<enum name="PGW_TRACE_CONTROL"					code="24"/>
+			<enum name="UE_TIME_ZONE_CHANGE"				code="25"/>
+			<enum name="TAI_CHANGE"						code="26"/>
+			<enum name="ECGI_CHANGE"					code="27"/>
+			<enum name="CHARGING_CORRELATION_EXCHANGE"			code="28"/>
+			<enum name="APN-AMBR_MODIFICATION_FAILURE"			code="29"/>
+			<enum name="USER_CSG_INFORMATION_CHANGE"			code="30"/>
+			<enum name="USAGE_REPORT"					code="33"/>
+			<enum name="DEFAULT-EPS-BEARER-QOS_MODIFICATION_FAILURE"	code="34"/>
+			<enum name="USER_CSG_HYBRID_SUBSCRIBED_INFORMATION_CHANGE"	code="35"/>
+			<enum name="USER_CSG_ HYBRID_UNSUBSCRIBED_INFORMATION_CHANGE"	code="36"/>
+			<enum name="ROUTING_RULE_CHANGE"				code="37"/>
+			<enum name="MAX_MBR_APN_AMBR_CHANGE"				code="38"/>
+			<enum name="APPLICATION_START"					code="39"/>
+			<enum name="APPLICATION_STOP"					code="40"/>
+			<enum name="ADC_REVALIDATION_TIMEOUT"				code="41"/>
+			<enum name="CS_TO_PS_HANDOVER"					code="42"/>
+			<enum name="UE_LOCAL_IP_ADDRESS_CHANGE"				code="43"/>
+			<enum name="H(E)NB_LOCAL_IP_ADDRESS_CHANGE"			code="44"/>
+			<enum name="ACCESS_NETWORK_INFO_REPORT"				code="45"/>
+			<enum name="CREDIT_MANAGEMENT_SESSION_FAILURE"			code="46"/>
+			<enum name="DEFAULT_QOS_CHANGE"					code="47"/>
+			<enum name="CHANGE_OF_UE_PRESENCE_IN_PRESENCE_REPORTING_AREA_REPORT"	code="48"/>
+			<enum name="TIME_CHANGE"					code="100"/>
+			<enum name="TFT DELETED"					code="1000"/>
+			<enum name="LOSS OF BEARER"					code="1001"/>
+			<enum name="RECOVERY OF BEARER"					code="1002"/>
+			<enum name="POLICY ENFORCEMENT FAILED"				code="1003"/>
+		</avp>
+		<avp name="Metering-Method" code="1007" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="DURATION" code="0"/>
+			<enum name="VOLUME" code="1"/>
+			<enum name="DURATION_VOLUME" code="2"/>
+		</avp>
+		<avp name="Offline" code="1008" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="DISABLE_OFFLINE" code="0"/>
+			<enum name="ENABLE_OFFLINE" code="1"/>
+		</avp>
+		<avp name="Online" code="1009" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="DISABLE_ONLINE" code="0"/>
+			<enum name="ENABLE_ONLINE" code="1"/>
+		</avp>
+		<avp name="Precedence" code="1010" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Reporting-Level" code="1011" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SERVICE_IDENTIFIER_LEVEL" code="0"/>
+			<enum name="RATING_GROUP_LEVEL" code="1"/>
+			<enum name="SPONSORED_CONNECTIVITY_LEVEL" code="2"/>
+		</avp>
+		<avp name="TFT-Filter" code="1012" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPFilterRule"/>
+		</avp>
+		<avp name="TFT-Packet-Filter-Information" code="1013" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Precedence"/>
+				<gavp name="TFT-Filter"/>
+				<gavp name="ToS-Traffic-Class"/>
+				<gavp name="Security-Parameter-Index"/>
+				<gavp name="Flow-Label"/>
+			</grouped>
+		</avp>
+		<avp name="ToS-Traffic-Class" code="1014" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="PDP-Session-operation" code="1015" vendor-id="TGPP" protected="may" mandatory="must"	may-encrypt="yes" vendor-bit="must">
+			<type type-name="Enumerated" />
+			<enum name="PDP-SESSION-TERMINATION" code="0"/>
+		</avp>
+		<avp name="QoS-Information" code="1016" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="QoS-Class-Identifier"/>
+				<gavp name="Max-Requested-Bandwidth-DL"/>
+				<gavp name="Max-Requested-Bandwidth-UL"/>
+				<gavp name="Guaranteed-Bitrate-UL"/>
+				<gavp name="Guaranteed-Bitrate-DL"/>
+				<gavp name="Bearer-Identifier"/>
+				<gavp name="Allocation-Retention-Priority"/>
+				<gavp name="APN-Aggregate-Max-Bitrate-UL"/>
+				<gavp name="APN-Aggregate-Max-Bitrate-DL"/>
+			</grouped>
+		</avp>
+		<avp name="Charging-Rule-Report" code="1018" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Charging-Rule-Base-Name"/>
+				<gavp name="Charging-Rule-Name"/>
+				<gavp name="Bearer-Identifier"/>
+				<gavp name="PCC-Rule-Status"/>
+				<gavp name="Rule-Failure-Code"/>
+				<gavp name="Final-Unit-Indication"/>
+			</grouped>
+		</avp>
+		<avp name="PCC-Rule-Status" code="1019" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ACTIVE"		code="0"/>
+			<enum name="INACTIVE"		code="1"/>
+			<enum name="TEMPORARY_INACTIVE"	code="2"/>
+		</avp>
+		<avp name="Bearer-Identifier" code="1020" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Bearer-Operation" code="1021" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="TERMINATION" 	code="0"/>
+			<enum name="ESTABLISHMENT" 	code="1"/>
+			<enum name="MODIFICATION" 	code="2"/>
+		</avp>
+		<avp name="Access-Network-Charging-Identifier-Gx" code="1022" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Access-Network-Charging-Identifier-Value"/>
+				<gavp name="Charging-Rule-Base-Name"/>
+				<gavp name="Charging-Rule-Name"/>
+			</grouped>
+		</avp>
+		<avp name="Bearer-Control-Mode" code="1023" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="UE_ONLY" 	code="0"/>
+			<enum name="RESERVED" 	code="1"/>
+			<enum name="UE_NW" 	code="2"/>
+		</avp>
+		<avp name="Network-Request-Support" code="1024" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NETWORK_REQUEST NOT SUPPORTED" 	code="0"/>
+			<enum name="NETWORK_REQUEST SUPPORTED"		code="1"/>
+		</avp>
+		<avp name="Guaranteed-Bitrate-DL" code="1025" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Guaranteed-Bitrate-UL" code="1026" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="IP-CAN-Type" code="1027" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="3GPP-GPRS" 		code="0"/>
+			<enum name="DOCSIS" 		code="1"/>
+			<enum name="xDSL" 		code="2"/>
+			<enum name="WiMAX" 		code="3"/>
+			<enum name="3GPP2" 		code="4"/>
+			<enum name="3GPP-EPS" 		code="5"/>
+			<enum name="Non-3GPP-EPS" 	code="6"/>
+		</avp>
+		<avp name="QoS-Class-Identifier" code="1028" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="QCI_1" 	code="1"/>
+			<enum name="QCI_2" 	code="2"/>
+			<enum name="QCI_3" 	code="3"/>
+			<enum name="QCI_4"	code="4"/>
+			<enum name="QCI_5"	code="5"/>
+			<enum name="QCI_6"	code="6"/>
+			<enum name="QCI_7" 	code="7"/>
+			<enum name="QCI_8"	code="8"/>
+			<enum name="QCI_9"	code="9"/>
+			<enum name="QCI_65"	code="65"/>
+			<enum name="QCI_66"	code="66"/>
+			<enum name="QCI_69"	code="69"/>
+			<enum name="QCI_70"	code="70"/>
+			<!-- The values shall be used to indicate standardized characteristics associated with standardized QCI values from
+				3GPP TS 23.203 -->
+		</avp>
+		<avp name="QoS-Negotiation" code="1029" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NO_QoS_NEGOTIATION" 	code="0"/>
+			<enum name="QoS_NEGOTIATION_SUPPORTED" 	code="1"/>
+		</avp>
+		<avp name="QoS-Upgrade" code="1030" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="QoS_UPGRADE_NOT_SUPPORTED" 	code="0"/>
+			<enum name="QoS_UPGRADE_SUPPORTED" 	code="1"/>
+		</avp>
+		<avp name="Rule-Failure-Code" code="1031" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="UNKNOWN_RULE_NAME"			code="1"/>
+			<enum name="RATING_GROUP_ERROR"			code="2"/>
+			<enum name="SERVICE_IDENTIFIER_ERROR"		code="3"/>
+			<enum name="GW/PCEF_MALFUNCTION"		code="4"/>
+			<enum name="RESOURCES_LIMITATION"		code="5"/>
+			<enum name="MAX_NR_BEARERS_REACHED"		code="6"/>
+			<enum name="UNKNOWN_BEARER_ID"			code="7"/>
+			<enum name="MISSING_BEARER_ID"			code="8"/>
+			<enum name="MISSING_FLOW_DESCRIPTION"		code="9"/>
+			<enum name="RESOURCE_ALLOCATION_FAILURE"	code="10"/>
+			<enum name="UNSUCCESSFUL_QOS_VALIDATION"	code="11"/>
+			<enum name="INCORRECT_FLOW_INFORMATION"		code="12"/>
+			<enum name="PS_TO_CS_HANDOVER"			code="13"/>
+			<enum name="TDF_APPLICATION_IDENTIFIER_ERROR"	code="14"/>
+			<enum name="NO_BEARER_BOUND"			code="15"/>
+			<enum name="FILTER_RESTRICTIONS"		code="16"/>
+			<enum name="AN_GW_FAILED"			code="17"/>
+			<enum name="MISSING_REDIRECT_SERVER_ADDRESS"	code="18"/>
+			<enum name="CM_END_USER_SERVICE_DENIED"		code="19"/>
+			<enum name="CM_CREDIT_CONTROL_NOT_APPLICABLE"	code="20"/>
+			<enum name="CM_AUTHORIZATION_REJECTED"		code="21"/>
+			<enum name="CM_USER_UNKNOWN"			code="22"/>
+			<enum name="CM_RATING_FAILED"			code="23"/>
+			<enum name="ROUTING_RULE_REJECTION"		code="24"/>
+		</avp>
+		<avp name="RAT-Type" code="1032" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated" />
+			<enum name="WLAN"		code="0"/>
+			<enum name="VIRTUAL"		code="1"/>
+			<enum name="UTRAN"		code="1000"/>
+			<enum name="GERAN"		code="1001"/>
+			<enum name="GAN"		code="1002"/>
+			<enum name="HSPA_EVOLUTION"	code="1003"/>
+			<enum name="EUTRAN"		code="1004"/>
+			<enum name="EUTRAN-NB-IoT"	code="1005"/>
+			<enum name="CDMA2000_1X"	code="2000"/>
+			<enum name="HRPD"		code="2001"/>
+			<enum name="UMB"		code="2002"/>
+			<enum name="EHRPD"		code="2003"/>
+		</avp>
+		<avp name="Event-Report-Indication" code="1033" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Event-Trigger"/>
+				<gavp name="RAT-Type"/>
+				<gavp name="QoS-Information"/>
+				<gavp name="RAI"/>
+				<gavp name="3GPP-User-Location-Info"/>
+			</grouped>
+		</avp>
+		<avp name="Allocation-Retention-Priority" code="1034" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Priority-Level"/>
+				<gavp name="Pre-emption-Capability"/>
+				<gavp name="Pre-emption-Vulnerability"/>
+			</grouped>
+		</avp>
+		<avp name="CoA-IP-Address" code="1035" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Tunnel-Header-Filter" code="1036" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPFilterRule"/>
+		</avp>
+		<avp name="Tunnel-Header-Length" code="1037" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Tunnel-Information" code="1038" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Tunnel-Header-Length"/>
+				<gavp name="Tunnel-Header-Filter"/>
+			</grouped>
+		</avp>
+		<avp name="CoA-Information" code="1039" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Tunnel-Information"/>
+				<gavp name="CoA-IP-Address"/>
+			</grouped>
+		</avp>
+		<avp name="APN-Aggregate-Max-Bitrate-DL" code="1040" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="APN-Aggregate-Max-Bitrate-UL" code="1041" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Revalidation-Time" code="1042" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Rule-Activation-Time" code="1043" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Rule-Deactivation-Time" code="1044" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Session-Release-Cause" code="1045" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="UNSPECIFIED_REASON" 		code="0"/>
+			<enum name="UE_SUBSCRIPTION_REASON" 		code="1"/>
+			<enum name="INSUFFICIENT_SERVER_RESOURCES" 	code="2"/>
+		</avp>
+		<avp name="Priority-Level" code="1046" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Pre-emption-Capability" code="1047" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="PRE-EMPTION_CAPABILITY_ENABLED" 	code="0"/>
+			<enum name="PRE-EMPTION_CAPABILITY_DISABLED" 	code="1"/>
+		</avp>
+		<avp name="Pre-emption-Vulnerability" code="1048" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="PRE-EMPTION_VULNERABILITY_ENABLED" 	code="0"/>
+			<enum name="PRE-EMPTION_VULNERABILITY_DISABLED"	code="1"/>
+		</avp>
+		<avp name="Default-EPS-Bearer-QoS" code="1049" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="QoS-Class-Identifier"/>
+				<gavp name="Allocation-Retention-Priority"/>
+			</grouped>
+		</avp>
+		<avp name="AN-GW-Address" code="1050" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="QoS-Rule-Install" code="1051" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="QoS-Rule-Definition"/>
+				<gavp name="Tunnel-Information"/>
+				<gavp name="Access-Network-Charging-Identifier-Value"/>
+				<gavp name="Resource-Allocation-Notification"/>
+			</grouped>
+		</avp>
+		<avp name="QoS-Rule-Remove" code="1052" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="QoS-Rule-Name"/>
+			</grouped>
+		</avp>
+		<avp name="QoS-Rule-Definition" code="1053" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="QoS-Rule-Name"/>
+				<gavp name="Flow-Information"/>
+				<gavp name="QoS-Information"/>
+				<gavp name="Precedence"/>
+			</grouped>
+		</avp>
+		<avp name="QoS-Rule-Name" code="1054" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="QoS-Rule-Report" code="1055" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="QoS-Rule-Name"/>
+				<gavp name="PCC-Rule-Status"/>
+				<gavp name="Rule-Failure-Code"/>
+			</grouped>
+		</avp>
+		<avp name="Security-Parameter-Index" code="1056" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Flow-Label" code="1057" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Flow-Information" code="1058" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Flow-Description"/>
+				<gavp name="Packet-Filter-Identifier"/>
+				<gavp name="ToS-Traffic-Class"/>
+				<gavp name="Security-Parameter-Index"/>
+				<gavp name="Flow-Label"/>
+			</grouped>
+		</avp>
+		<avp name="Packet-Filter-Content" code="1059" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPFilterRule"/>
+		</avp>
+		<avp name="Packet-Filter-Identifier" code="1060" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Packet-Filter-Information" code="1061" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Packet-Filter-Identifier"/>
+				<gavp name="Precedence"/>
+				<gavp name="Packet-Filter-Content"/>
+				<gavp name="ToS-Traffic-Class"/>
+				<gavp name="Security-Parameter-Index"/>
+				<gavp name="Flow-Label"/>
+			</grouped>
+		</avp>
+		<avp name="Packet-Filter-Operation" code="1062" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="DELETION" 		code="0"/>
+			<enum name="ADDITION"		code="1"/>
+			<enum name="MODIFICATION" 	code="2"/>
+		</avp>
+		<avp name="Resource-Allocation-Notification" code="1063" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ENABLE_NOTIFICATION"  code="0"/>
+		</avp>
+		<avp name="Session-Linking-Indicator" code="1064" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SESSION_LINKING_IMMEDIATE"  code="0"/>
+			<enum name="SESSION_LINKING_DEFERRED"   code="1"/>
+		</avp>
+		<avp name="PDN-Connection-ID" code="1065" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Monitoring-Key" code="1066" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Usage-Monitoring-Information" code="1067" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Monitoring-Key"/>
+				<gavp name="Granted-Service-Unit"/>
+				<gavp name="Used-Service-Unit"/>
+				<gavp name="Usage-Monitoring-Level"/>
+				<gavp name="Usage-Monitoring-Report"/>
+				<gavp name="Usage-Monitoring-Support"/>
+			</grouped>
+		</avp>
+		<avp name="Usage-Monitoring-Level" code="1068" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SESSION_LEVEL"	code="0"/>
+			<enum name="PCC_RULE_LEVEL"	code="1"/>
+		</avp>
+		<avp name="Usage-Monitoring-Report" code="1069" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="USAGE_MONITORING_REPORT_REQUIRED"  code="0"/>
+		</avp>
+		<avp name="Usage-Monitoring-Support" code="1070" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="USAGE_MONITORING_DISABLED"  code="0"/>
+		</avp>
+		<avp name="CSG-Information-Reporting" code="1071" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="CHANGE_CSG_CELL"				code="0"/>
+			<enum name="CHANGE_CSG_SUBSCRIBED_HYBRID_CELL"		code="1"/>
+			<enum name="CHANGE_CSG_UNSUBSCRIBED_HYBRID_CELL"	code="2"/>
+		</avp>
+		<avp name="Packet-Filter-Usage" code="1072" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SEND_TO_UE"  code="1"/>
+		</avp>
+		<avp name="Charging-Correlation-Indicator" code="1073" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="CHARGING_IDENTIFIER_REQUIRED"	code="0"/>
+		</avp>
+		<avp name="QoS-Rule-Base-Name" code="1074" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Routing-Rule-Remove" code="1075" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Routing-Rule-Identifier"/>
+			</grouped>
+		</avp>
+		<avp name="Routing-Rule-Definition" code="1076" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Routing-Rule-Identifier"/>
+				<gavp name="Routing-Filter"/>
+				<gavp name="Precedence"/>
+				<gavp name="Routing-IP-Address"/>
+			</grouped>
+		</avp>
+		<avp name="Routing-Rule-Identifier" code="1077" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Routing-Filter" code="1078" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Flow-Description"/>
+				<gavp name="Flow-Direction"/>
+				<gavp name="ToS-Traffic-Class"/>
+				<gavp name="Security-Parameter-Index"/>
+				<gavp name="Security-Parameter-Index"/>
+				<gavp name="Flow-Label"/>
+			</grouped>
+		</avp>
+		<avp name="Routing-IP-Address" code="1079" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Flow-Direction" code="1080" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="UNSPECIFIED"	code="0"/>
+			<enum name="DOWNLINK"		code="1"/>
+			<enum name="UPLINK"		code="2"/>
+			<enum name="BIDIRECTIONAL"	code="3"/>
+		</avp>
+		<avp name="Routing-Rule-Install" code="1081" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Routing-Rule-Definition"/>
+			</grouped>
+		</avp>
+		<avp name="Credit-Management-Status" code="1082" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<!-- TS 29.212 V13.3.0 (2015-09) 86-->
+		<avp name="Redirect-Information" code="1085" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Redirect-Support"/>
+				<gavp name="Redirect-Address-Type"/>
+				<gavp name="Redirect-Server-Address"/>
+			</grouped>
+		</avp>
+		<avp name="Redirect-Support" code="1086" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="REDIRECTION_DISABLED"	code="0"/>
+			<enum name="REDIRECTION_ENABLED"	code="1"/>
+		</avp>
+		<avp name="TDF-Information" code="1087" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="TDF-Destination-Realm"/>
+				<gavp name="TDF-Destination-Host"/>
+				<gavp name="TDF-IP-Address"/>
+			</grouped>
+		</avp>
+		<avp name="TDF-Application-Identifier" code="1088" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="TDF-Destination-Host" code="1089" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="TDF-Destination-Realm" code="1090" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="TDF-IP-Address" code="1091" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+				<type type-name="IPAddress"/>
+		</avp>
+		<!-- TS 29.212 V13.1.0 (2015-03) -->
+		<avp name="ADC-Rule-Install" code="1092" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="ADC-Rule-Definition"/>
+				<gavp name="ADC-Rule-Name"/>
+				<gavp name="ADC-Rule-Base-Name"/>
+				<gavp name="Monitoring-Flags"/>
+				<gavp name="Rule-Activation-Time"/>
+				<gavp name="Rule-Deactivation-Time"/>
+			</grouped>
+		</avp>
+		<avp name="ADC-Rule-Remove" code="1093" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="ADC-Rule-Name"/>
+				<gavp name="ADC-Rule-Base-Name"/>
+			</grouped>
+		</avp>
+		<avp name="ADC-Rule-Definition" code="1094" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="ADC-Rule-Name"/>
+				<gavp name="TDF-Application-Identifier"/>
+				<gavp name="Flow-Information"/>
+				<gavp name="Service-Identifier"/>
+				<gavp name="Rating-Group"/>
+				<gavp name="Reporting-Level"/>
+				<gavp name="Online"/>
+				<gavp name="Offline"/>
+				<gavp name="Metering-Method"/>
+				<gavp name="Precedence"/>
+				<gavp name="Flow-Status"/>
+				<gavp name="QoS-Information"/>
+				<gavp name="Monitoring-Key"/>
+				<gavp name="Redirect-Information"/>
+				<gavp name="Mute-Notification"/>
+				<gavp name="Traffic-Steering-Policy-Identifier-DL"/>
+				<gavp name="Traffic-Steering-Policy-Identifier-UL"/>
+				<gavp name="ToS-Traffic-Class"/>
+			</grouped>
+		</avp>
+		<avp name="ADC-Rule-Base-Name" code="1095" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="ADC-Rule-Name" code="1096" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="ADC-Rule-Report" code="1097" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="ADC-Rule-Name"/>
+				<gavp name="ADC-Rule-Base-Name"/>
+				<gavp name="PCC-Rule-Status"/>
+				<gavp name="Rule-Failure-Code"/>
+				<gavp name="Final-Unit-Indication"/>
+			</grouped>
+		</avp>
+		<avp name="Application-Detection-Information" code="1098" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="TDF-Application-Identifier"/>
+				<gavp name="TDF-Application-Instance-Identifier"/>
+				<gavp name="Flow-Information"/>
+			</grouped>
+		</avp>
+		<avp name="PS-to-CS-Session-Continuity" code="1099" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="VIDEO_PS2CS_CONT_CANDIDATE" code="0"/>
+		</avp>
+		<!-- Note: The AVP codes from 1085 to 1099 are reserved for TS 29.212 -->
+
+		<!-- ETSI TS 129 140 V6.3.0 (2005-12) -->
+		<avp name="Served-User-Identity" code="1100" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="MSISDN"/>
+				<gavp name="VASP-ID"/>
+				<gavp name="VAS-ID"/>
+			</grouped>
+		</avp>
+		<avp name="VASP-ID" code="1101" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="VAS-ID" code="1102" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Trigger-Event" code="1103" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="MM1 Message Submission, Profile based" code="0"/>
+			<enum name="MM1 Message Submission, Address based" code="1"/>
+			<enum name="MM1 Message Delivery"		   code="2"/>
+			<enum name="MM7 Message Submission, Profile based" code="3"/>
+			<enum name="MM7 Message Submission, Address based" code="4"/>
+		</avp>
+		<avp name="Sender-Address" code="1104" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Initial-Recipient-Address" code="1105" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="MM10-Sequence-Number"/>
+				<gavp name="MM10-Recipient-Address"/>
+			</grouped>
+		</avp>
+		<avp name="Result-Recipient-Address" code="1106" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="MM10-Sequence-Number"/>
+				<gavp name="MM10-Recipient-Address"/>
+				<gavp name="Routeing-Address"/>
+				<gavp name="Sender-Address"/>
+			</grouped>
+		</avp>
+		<avp name="MM10-Sequence-Number" code="1107" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="MM10-Recipient-Address" code="1108" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Routeing-Address" code="1109" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Originating-Interface" code="1110" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="MM1" code="0"/>
+			<enum name="MM3" code="1"/>
+			<enum name="MM4" code="2"/>
+			<enum name="MM7" code="3"/>
+		</avp>
+		<avp name="Delivery-Report" code="1111" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="No Delivery Report Requested" code="0"/>
+			<enum name="Delivery Report Requested" code="1"/>
+		</avp>
+		<avp name="Read-Reply" code="1112" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="No Read Reply Requested" code="0"/>
+			<enum name="Read Reply Requested" code="1"/>
+		</avp>
+		<avp name="Sender-Visibility" code="1113" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Sender Identification requested not to be hidden" code="0"/>
+			<enum name="Sender Identification requested to be hidden" code="1"/>
+		</avp>
+		<avp name="Service-Key" code="1114" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Billing-Information" code="1115" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Status" code="1116" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Status-Code"/>
+				<gavp name="Status-Text"/>
+			</grouped>
+		</avp>
+		<avp name="Status-Code" code="1117" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Status-Text" code="1118" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Routeing-Address-Resolution" code="1119" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="unresolved" code="0"/>
+			<enum name="resolved" code="1"/>
+		</avp>
+
+		<!-- 29.140 [16]
+		Note: The AVP codes from 1119 to 1199 are reserved for TS 29.140
+		32.299
+		-->
+
+		<avp name="Domain-Name" code="1200" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Recipient-Address" code="1201" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Address-Type"/>
+				<gavp name="Address-Data"/>
+				<gavp name="Address-Domain"/>
+				<gavp name="Addressee-Type"/>
+			</grouped>
+		</avp>
+		<avp name="Submission-Time" code="1202" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="MM-Content-Type" code="1203" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Type-Number"/>
+				<gavp name="Additional-Type-Information"/>
+				<gavp name="Content-Size"/>
+				<gavp name="Additional-Content-Information"/>
+			</grouped>
+		</avp>
+
+		<!-- The Type-Number AVP (AVP code 1204) is of type Enumerated and identifies the well-known -->
+		<!-- media types. The values are taken from OMNA WSP Content Type Codes database -->
+		<!-- http://www.openmobilealliance.org/tech/omna/omna-wsp-content-type.aspx -->
+		<avp name="Type-Number" code="1204" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="*/*" code="0"/>
+			<enum name="text/*" code="1"/>
+			<enum name="text/html" code="2"/>
+			<enum name="text/plain" code="3"/>
+			<enum name="text/x-hdml" code="4"/>
+			<enum name="text/x-ttml" code="5"/>
+			<enum name="text/x-vCalendar" code="6"/>
+			<enum name="text/x-vCard" code="7"/>
+			<enum name="text/vnd.wap.wml" code="8"/>
+			<enum name="text/vnd.wap.wmlscript" code="9"/>
+			<enum name="text/vnd.wap.wta-event" code="10"/>
+			<enum name="multipart/*" code="11"/>
+			<enum name="multipart/mixed" code="12"/>
+			<enum name="multipart/form-data" code="13"/>
+			<enum name="multipart/byterantes" code="14"/>
+			<enum name="multipart/alternative" code="15"/>
+			<enum name="application/*" code="16"/>
+			<enum name="application/java-vm" code="17"/>
+			<enum name="application/x-www-form-urlencoded" code="18"/>
+			<enum name="application/x-hdmlc" code="19"/>
+			<enum name="application/vnd.wap.wmlc" code="20"/>
+			<enum name="application/vnd.wap.wmlscriptc" code="21"/>
+			<enum name="application/vnd.wap.wta-eventc" code="22"/>
+			<enum name="application/vnd.wap.uaprof" code="23"/>
+			<enum name="application/vnd.wap.wtls-ca-certificate" code="24"/>
+			<enum name="application/vnd.wap.wtls-user-certificate" code="25"/>
+			<enum name="application/x-x509-ca-cert" code="26"/>
+			<enum name="application/x-x509-user-cert" code="27"/>
+			<enum name="image/*" code="28"/>
+			<enum name="image/gif" code="29"/>
+			<enum name="image/jpeg" code="30"/>
+			<enum name="image/tiff" code="31"/>
+			<enum name="image/png" code="32"/>
+			<enum name="image/vnd.wap.wbmp" code="33"/>
+			<enum name="application/vnd.wap.multipart.*" code="34"/>
+			<enum name="application/vnd.wap.multipart.mixed" code="35"/>
+			<enum name="application/vnd.wap.multipart.form-data" code="36"/>
+			<enum name="application/vnd.wap.multipart.byteranges" code="37"/>
+			<enum name="application/vnd.wap.multipart.alternative" code="38"/>
+			<enum name="application/xml" code="39"/>
+			<enum name="text/xml" code="40"/>
+			<enum name="application/vnd.wap.wbxml" code="41"/>
+			<enum name="application/x-x968-cross-cert" code="42"/>
+			<enum name="application/x-x968-ca-cert" code="43"/>
+			<enum name="application/x-x968-user-cert" code="44"/>
+			<enum name="text/vnd.wap.si" code="45"/>
+			<enum name="application/vnd.wap.sic" code="46"/>
+			<enum name="text/vnd.wap.sl" code="47"/>
+			<enum name="application/vnd.wap.slc" code="48"/>
+			<enum name="text/vnd.wap.co" code="49"/>
+			<enum name="application/vnd.wap.coc" code="50"/>
+			<enum name="application/vnd.wap.multipart.related" code="51"/>
+			<enum name="application/vnd.wap.sia" code="52"/>
+			<enum name="text/vnd.wap.connectivity-xml" code="53"/>
+			<enum name="application/vnd.wap.connectivity-wbxml" code="54"/>
+			<enum name="application/pkcs7-mime" code="55"/>
+			<enum name="application/vnd.wap.hashed-certificate" code="56"/>
+			<enum name="application/vnd.wap.signed-certificate" code="57"/>
+			<enum name="application/vnd.wap.cert-response" code="58"/>
+			<enum name="application/xhtml+xml" code="59"/>
+			<enum name="application/wml+xml" code="60"/>
+			<enum name="text/css" code="61"/>
+			<enum name="application/vnd.wap.mms-message" code="62"/>
+			<enum name="application/vnd.wap.rollover-certificate" code="63"/>
+			<enum name="application/vnd.wap.locc+wbxml" code="64"/>
+			<enum name="application/vnd.wap.loc+xml" code="65"/>
+			<enum name="application/vnd.syncml.dm+wbxml" code="66"/>
+			<enum name="application/vnd.syncml.dm+xml" code="67"/>
+			<enum name="application/vnd.syncml.notification" code="68"/>
+			<enum name="application/vnd.wap.xhtml+xml" code="69"/>
+			<enum name="application/vnd.wv.csp.cir" code="70"/>
+			<enum name="application/vnd.oma.dd+xml" code="71"/>
+			<enum name="application/vnd.oma.drm.message" code="72"/>
+			<enum name="application/vnd.oma.drm.content" code="73"/>
+			<enum name="application/vnd.oma.drm.rights+xml" code="74"/>
+			<enum name="application/vnd.oma.drm.rights+wbxml" code="75"/>
+			<enum name="application/vnd.wv.csp+xml" code="76"/>
+			<enum name="application/vnd.wv.csp+wbxml" code="77"/>
+			<enum name="application/vnd.syncml.ds.notification" code="78"/>
+			<enum name="audio/*" code="79"/>
+			<enum name="video/*" code="80"/>
+			<enum name="application/vnd.oma.dd2+xml" code="81"/>
+			<enum name="application/mikey" code="82"/>
+			<enum name="application/vnd.oma.dcd" code="83"/>
+			<enum name="application/vnd.oma.dcdc" code="84"/>
+		</avp>
+		<avp name="Additional-Type-Information" code="1205" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Content-Size" code="1206" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Additional-Content-Information" code="1207" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Type-Number"/>
+				<gavp name="Additional-Type-Information"/>
+				<gavp name="Content-Size"/>
+			</grouped>
+		</avp>
+		<avp name="Addressee-Type" code="1208" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="TO" code="0"/>
+			<enum name="CC" code="1"/>
+			<enum name="BCC" code="2"/>
+		</avp>
+		<avp name="Priority" code="1209" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Low" code="0"/>
+			<enum name="Normal" code="1"/>
+			<enum name="High" code="2"/>
+		</avp>
+		<avp name="Message-ID" code="1210" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Message-Type" code="1211" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="m-send-req" code="1"/>
+			<enum name="m-send-conf" code="2"/>
+			<enum name="m-notification-ind" code="3"/>
+			<enum name="m-notifyresp-ind" code="4"/>
+			<enum name="m-retrieve-conf" code="5"/>
+			<enum name="m-acknowledge-ind" code="6"/>
+			<enum name="m-delivery-ind" code="7"/>
+			<enum name="m-read-rec-ind" code="8"/>
+			<enum name="m-read-orig-ind" code="9"/>
+			<enum name="m-forward-req" code="10"/>
+			<enum name="m-forward-conf" code="11"/>
+			<enum name="m-mbox-store-conf" code="12"/>
+			<enum name="m-mbox-view-conf" code="13"/>
+			<enum name="m-mbox-upload-conf" code="14"/>
+			<enum name="m-mbox-delete-conf" code="15"/>
+		</avp>
+		<avp name="Message-Size" code="1212" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Message-Class" code="1213" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Class-Identifier"/>
+				<gavp name="Token-Text"/>
+			</grouped>
+		</avp>
+		<avp name="Class-Identifier" code="1214" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Personal" code="0"/>
+			<enum name="Advertisement" code="1"/>
+			<enum name="Informational" code="2"/>
+			<enum name="Auto" code="3"/>
+		</avp>
+		<avp name="Token-Text" code="1215" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Delivery-Report-Requested" code="1216" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="No" code="0"/>
+			<enum name="Yes" code="1"/>
+		</avp>
+		<avp name="Adaptations" code="1217" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="No" code="0"/>
+			<enum name="Yes" code="1"/>
+		</avp>
+		<avp name="Applic-ID" code="1218" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Aux-Applic-Info" code="1219" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Content-Class" code="1220" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="text" code="0"/>
+			<enum name="image-basic" code="1"/>
+			<enum name="image-rich" code="2"/>
+			<enum name="video-basic" code="3"/>
+			<enum name="video-rich" code="4"/>
+			<enum name="megapixel" code="5"/>
+			<enum name="content-basic" code="6"/>
+			<enum name="content-rich" code="7"/>
+		</avp>
+		<avp name="DRM-Content" code="1221" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="No" code="0"/>
+			<enum name="Yes" code="1"/>
+		</avp>
+		<avp name="Read-Reply-Report-Requested" code="1222" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="No" code="0"/>
+			<enum name="Yes" code="1"/>
+		</avp>
+		<avp name="Reply-Applic-ID" code="1223" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="File-Repair-Supported" code="1224" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SUPPORTED" code="1"/>
+			<enum name="NOT_SUPPORTED" code="2"/>
+		</avp>
+		<avp name="MBMS-User-Service-Type" code="1225" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="DOWNLOAD" code="1"/>
+			<enum name="STREAMING" code="2"/>
+		</avp>
+		<avp name="Unit-Quota-Threshold" code="1226" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="PDP-Address" code="1227" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="SGSN-Address" code="1228" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="PoC-Session-Id" code="1229" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Deferred-Location-Event-Type" code="1230" mandatory="must"  may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="LCS-APN" code="1231" mandatory="must" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="LCS-Client-ID" code="1232" mandatory="may" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="LCS-Client-Type"/>
+				<gavp name="LCS-Client-External-ID"/>
+				<gavp name="LCS-Client-Dialed-By-MS"/>
+				<gavp name="LCS-Client-Name"/>
+				<gavp name="LCS-APN"/>
+				<gavp name="LCS-Requestor-ID"/>
+			</grouped>
+		</avp>
+		<avp name="LCS-Client-Dialed-By-MS" code="1233" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="LCS-Client-External-ID" code="1234" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="LCS-Client-Name" code="1235" mandatory="may"  vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="LCS-Data-Coding-Scheme"/>
+				<gavp name="LCS-Name-String"/>
+				<gavp name="LCS-Format-Indicator"/>
+			</grouped>
+		</avp>
+		<avp name="LCS-Data-Coding-Scheme" code="1236" mandatory="must" may-encrypt="yes" protected="may"  vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="LCS-Format-Indicator" code="1237" mandatory="may"  vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="LOGICAL_NAME" code="0"/>
+			<enum name="EMAIL_ADDRESS" code="1"/>
+			<enum name="MSISDN" code="2"/>
+			<enum name="URL" code="3"/>
+			<enum name="SIP_URL" code="4"/>
+		</avp>
+		<avp name="LCS-Name-String" code="1238" mandatory="must" may-encrypt="yes" protected="may"  vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="LCS-Requestor-ID" code="1239" mandatory="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="LCS-Data-Coding-Scheme"/>
+				<gavp name="LCS-Requestor-ID-String"/>
+			</grouped>
+		</avp>
+		<avp name="LCS-Requestor-ID-String" code="1240" mandatory="must" may-encrypt="yes" protected="may"  vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="LCS-Client-Type" code="1241" mandatory="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="EMERGENCY_SERVICES" code="0"/>
+			<enum name="VALUE_ADDED_SERVICES" code="1"/>
+			<enum name="PLMN_OPERATOR_SERVICES" code="2"/>
+			<enum name="LAWFUL_INTERCEPT_SERVICES" code="3"/>
+		</avp>
+		<avp name="Location-Estimate" code="1242" mandatory="must" may-encrypt="yes" protected="may"  vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Location-Estimate-Type" code="1243" mandatory="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="CURRENT_LOCATION" code="0"/>
+			<enum name="CURRENT_LAST_KNOWN_LOCATION" code="1"/>
+			<enum name="INITIAL_LOCATION" code="2"/>
+			<enum name="ACTIVATE_DEFERRED_LOCATION" code="3"/>
+			<enum name="CANCEL_DEFERRED_LOCATION" code="4"/>
+		</avp>
+		<avp name="Location-Type" code="1244" mandatory="may" may-encrypt="no" protected="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Location-Estimate-Type"/>
+				<gavp name="Deferred-Location-Event-Type"/>
+			</grouped>
+		</avp>
+		<avp name="Positioning-Data" code="1245" mandatory="must" may-encrypt="yes" protected="may"  vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="WLAN-Session-Id" code="1246" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="PDP-Context-Type" code="1247" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="PRIMARY" code="0"/>
+			<enum name="SECONDARY" code="1"/>
+		</avp>
+		<avp name="MMBox-Storage-Requested" code="1248" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="No" code="0"/>
+			<enum name="Yes" code="1"/>
+		</avp>
+		<avp name="Service-Specific-Info" code="1249" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Service-Specific-Data"/>
+				<gavp name="Service-Specific-Type"/>
+			</grouped>
+		</avp>
+		<avp name="Called-Asserted-Identity" code="1250" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Requested-Party-Address" code="1251" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="PoC-User-Role" code="1252" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="PoC-User-Role-IDs"/>
+				<gavp name="PoC-User-Role-info-Units"/>
+			</grouped>
+		</avp>
+		<avp name="PoC-User-Role-IDs" code="1253" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="PoC-User-Role-info-Units" code="1254" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Moderator" code="1"/>
+			<enum name="Dispatcher" code="2"/>
+			<enum name="Session-Owner" code="3"/>
+			<enum name="Session-Participant" code="4"/>
+		</avp>
+		<avp name="Talk-Burst-Exchange" code="1255" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="PoC-Change-Time"/>
+				<gavp name="Number-Of-Talk-Bursts"/>
+				<gavp name="Talk-Burst-Volume"/>
+				<gavp name="Talk-Burst-Time"/>
+				<gavp name="Number-Of-Received-Talk-Bursts"/>
+				<gavp name="Received-Talk-Burst-Volume"/>
+				<gavp name="Received-Talk-Burst-Time"/>
+				<gavp name="Number-Of-Participants"/>
+				<gavp name="PoC-Change-Condition"/>
+			</grouped>
+		</avp>
+		<avp name="Service-Generic-Information" code="1256" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<!-- From OMA-DDS-Charging_Data -->
+				<gavp name="Application-Server-ID"/>
+				<gavp name="Application-Service-Type"/>
+				<gavp name="Application-Session-ID"/>
+				<gavp name="Delivery-Status"/>
+			</grouped>
+		</avp>
+		<avp name="Service-Specific-Type" code="1257" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Event-Charging-TimeStamp" code="1258" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Participant-Access-Priority" code="1259" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Pre-emptive priority" code="1"/>
+			<enum name="High priority" code="2"/>
+			<enum name="Normal priority" code="3"/>
+			<enum name="Low priority" code="4"/>
+		</avp>
+		<avp name="Participant-Group" code="1260" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Called-Party-Address"/>
+				<gavp name="Participant-Access-Priority"/>
+				<gavp name="User-Participating-Type"/>
+			</grouped>
+		</avp>
+		<avp name="PoC-Change-Condition" code="1261" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="serviceChange" code="0"/>
+			<enum name="volumeLimit" code="1"/>
+			<enum name="timeLimit" code="2"/>
+			<enum name="numberofTalkBurstLimit" code="3"/>
+			<enum name="numberofActiveParticipants" code="4"/>
+			<enum name="tariffTime" code="5"/>
+		</avp>
+		<avp name="PoC-Change-Time" code="1262" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<!-- The Access-Network-Information AVP (AVP code 1263) is of type OctetString and indicates the SIP P-header
+		     "P-Access-Network-Information".
+		     As it's a SIP Header the actual content will be text so for Wireshark displays sake we treat this as
+		     an UTF8String
+		-->
+		<avp name="Access-Network-Information" code="1263" vendor-bit="must" vendor-id="TGPP">
+			<!-- <type type-name="OctetString"/>  -->
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Trigger" code="1264" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Trigger-Type"/>
+			</grouped>
+		</avp>
+		<avp name="Base-Time-Interval" code="1265" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Envelope" code="1266" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Envelope-Start-Time"/>
+				<gavp name="Envelope-End-Time"/>
+				<gavp name="CC-Total-Octets"/>
+				<gavp name="CC-Input-Octets"/>
+				<gavp name="CC-Output-Octets"/>
+				<gavp name="CC-Service-Specific-Units"/>
+			</grouped>
+		</avp>
+		<avp name="Envelope-End-Time" code="1267" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Envelope-Reporting" code="1268" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="DO_NOT_REPORT_ENVELOPES" code="0"/>
+			<enum name="REPORT_ENVELOPES" code="1"/>
+			<enum name="REPORT_ENVELOPES_WITH_VOLUME" code="2"/>
+			<enum name="REPORT_ENVELOPES_WITH_EVENTS" code="3"/>
+			<enum name="REPORT_ENVELOPES_WITH_VOLUME_AND_EVENTS" code="4"/>
+		</avp>
+		<avp name="Envelope-Start-Time" code="1269" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Time-Quota-Mechanism" code="1270" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Time-Quota-Type"/>
+				<gavp name="Base-Time-Interval"/>
+			</grouped>
+		</avp>
+		<avp name="Time-Quota-Type" code="1271" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="DISCRETE_TIME_PERIOD" code="0"/>
+			<enum name="CONTINUOUS_TIME_PERIOD" code="1"/>
+		</avp>
+		<avp name="Early-Media-Description" code="1272" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SDP-TimeStamps"/>
+				<gavp name="SDP-Media-Component"/>
+				<gavp name="SDP-Session-Description"/>
+			</grouped>
+		</avp>
+		<avp name="SDP-TimeStamps" code="1273" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SDP-Offer-Timestamp"/>
+				<gavp name="SDP-Answer-Timestamp"/>
+			</grouped>
+		</avp>
+		<avp name="SDP-Offer-Timestamp" code="1274" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="SDP-Answer-Timestamp" code="1275" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="AF-Correlation-Information" code="1276" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="AF-Charging-Identifier"/>
+				<gavp name="Flows"/>
+			</grouped>
+		</avp>
+		<avp name="PoC-Session-Initiation-type" code="1277" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Pre-established" code="0"/>
+			<enum name="On-demand" code="1"/>
+		</avp>
+		<avp name="Offline-Charging" code="1278" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Quota-Consumption-Time"/>
+				<gavp name="Time-Quota-Mechanism"/>
+				<gavp name="Envelope-Reporting"/>
+				<gavp name="Multiple-Services-Credit-Control"/>
+			</grouped>
+		</avp>
+		<avp name="User-Participating-Type" code="1279" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Normal" code="0"/>
+			<enum name="NW PoC Box" code="1"/>
+			<enum name="UE PoC Box" code="2"/>
+		</avp>
+		<avp name="Alternate-Charged-Party-Address" code="1280" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="IMS-Communication-Service-Identifier" code="1281" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Number-Of-Received-Talk-Bursts" code="1282" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Number-Of-Talk-Bursts" code="1283" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Received-Talk-Burst-Time" code="1284" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Received-Talk-Burst-Volume" code="1285" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Talk-Burst-Time" code="1286" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Talk-Burst-Volume" code="1287" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Media-Initiator-Party" code="1288" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+
+		<!-- Note: The AVP codes from 1289 to 1399 are reserved for TS 32.299 -->
+		<avp name="RAN-End-Timestamp" code="1301" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="RAN-Secondary-RAT-Usage-Report" code="1302" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Secondary-RAT-Type"/>
+				<gavp name="RAN-Start-Timestamp"/>
+				<gavp name="RAN-End-Timestamp"/>
+				<gavp name="Accounting-Input-Octets"/>
+				<gavp name="Accounting-Output-Octets"/>
+				<gavp name="3GPP-Charging-Id"/>
+			</grouped>
+		</avp>
+		<avp name="RAN-Start-Timestamp" code="1303" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Secondary-RAT-Type" code="1304" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+
+		<!-- 3GPP TS 29.272 V9.1.0 (2009-12 -->
+		<avp name="Subscription-Data" code="1400" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Subscriber-Status"/>
+				<gavp name="MSISDN"/>
+				<gavp name="A-MSISDN"/>
+				<gavp name="STN-SR"/>
+				<gavp name="ICS-Indicator"/>
+				<gavp name="Network-Access-Mode"/>
+				<gavp name="Operator-Determined-Barring"/>
+				<gavp name="HPLMN-ODB"/>
+				<gavp name="Regional-Subscription-Zone-Code"/>
+				<gavp name="Access-Restriction-Data"/>
+				<gavp name="APN-OI-Replacement"/>
+				<gavp name="LCS-Info"/>
+				<gavp name="Teleservice-List"/>
+				<gavp name="Call-Barring-Infor-List"/>
+				<gavp name="3GPP-Charging-Characteristics"/>
+				<gavp name="AMBR"/>
+				<gavp name="APN-Configuration-Profile"/>
+				<gavp name="RAT-Frequency-Selection-Priority-ID"/>
+				<gavp name="Trace-Data"/>
+				<gavp name="GPRS-Subscription-Data"/>
+				<gavp name="CSG-Subscription-Data"/>
+				<gavp name="Roaming-Restricted-Due-To-Unsupported-Feature"/>
+				<gavp name="Subscribed-Periodic-RAU-TAU-Timer"/>
+				<gavp name="MPS-Priority"/>
+				<gavp name="VPLMN-LIPA-Allowed"/>
+				<gavp name="Relay-Node-Indicator"/>
+				<gavp name="MDT-User-Consent"/>
+				<gavp name="Subscribed-VSRVCC"/>
+				<gavp name="ProSe-Subscription-Data"/>
+				<gavp name="Subscription-Data-Flags"/>
+				<gavp name="Adjacent-Access-Restriction-Data"/>
+				<gavp name="DL-Buffering-Suggested-Packet-Count"/>
+				<gavp name="IMSI-Group-Id"/>
+				<gavp name="UE-Usage-Type"/>
+				<gavp name="AESE-Communication-Pattern"/>
+				<gavp name="Monitoring-Event-Configuration"/>
+				<gavp name="Emergency-Info"/>
+				<gavp name="V2X-Subscription-Data"/>
+				<gavp name="eDRX-Cycle-Length"/>
+				<gavp name="External-Identifier"/>
+				<gavp name="Active-Time"/>
+				<gavp name="Service-Gap-Time"/>
+				<gavp name="Broadcast-Location-Assistance-Data-Types"/>
+				<gavp name="Aerial-UE-Subscription-Information"/>
+			</grouped>
+		</avp>
+		<avp name="Terminal-Information" code="1401" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="IMEI"/>
+				<gavp name="3GPP2-MEID"/>
+				<gavp name="Software-Version"/>
+			</grouped>
+		</avp>
+		<avp name="IMEI" code="1402" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Software-Version" code="1403" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="QoS-Subscribed" code="1404" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="ULR-Flags" code="1405" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="ULA-Flags" code="1406" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Visited-PLMN-Id" code="1407" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Requested-EUTRAN-Authentication-Info" code="1408" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Number-Of-Requested-Vectors"/>
+				<gavp name="Immediate-Response-Preferred"/>
+				<gavp name="Re-Synchronization-Info"/>
+			</grouped>
+		</avp>
+		<avp name="Requested-UTRAN-GERAN-Authentication-Info" code="1409" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Number-Of-Requested-Vectors"/>
+				<gavp name="Immediate-Response-Preferred"/>
+				<gavp name="Re-Synchronization-Info"/>
+			</grouped>
+		</avp>
+		<avp name="Number-Of-Requested-Vectors" code="1410" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Re-Synchronization-Info" code="1411" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Immediate-Response-Preferred" code="1412" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Authentication-Info" code="1413" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="E-UTRAN-Vector"/>
+				<gavp name="UTRAN-Vector"/>
+				<gavp name="GERAN-Vector"/>
+			</grouped>
+		</avp>
+		<avp name="E-UTRAN-Vector"	code="1414" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Item-Number"/>
+				<gavp name="RAND"/>
+				<gavp name="XRES"/>
+				<gavp name="AUTN"/>
+				<gavp name="KASME"/>
+			</grouped>
+		</avp>
+		<avp name="UTRAN-Vector" code="1415" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Item-Number"/>
+				<gavp name="RAND"/>
+				<gavp name="XRES"/>
+				<gavp name="AUTN"/>
+				<gavp name="Confidentiality-Key"/>
+				<gavp name="Integrity-Key"/>
+			</grouped>
+		</avp>
+		<avp name="GERAN-Vector" code="1416" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Item-Number"/>
+				<gavp name="RAND"/>
+				<gavp name="SRES"/>
+				<gavp name="Kc"/>
+			</grouped>
+		</avp>
+		<avp name="Network-Access-Mode" code="1417" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="PACKET_AND_CIRCUIT" code="0"/>
+			<enum name="Reserved" code="1"/>
+			<enum name="ONLY_PACKET" code="2"/>
+		</avp>
+		<avp name="HPLMN-ODB" code="1418" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Item-Number" code="1419" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Cancellation-Type" code="1420" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="MME_UPDATE_PROCEDURE" code="0"/>
+			<enum name="SGSN_UPDATE_PROCEDURE" code="1"/>
+			<enum name="SUBSCRIPTION_WITHDRAWAL" code="2"/>
+			<enum name="UPDATE_PROCEDURE_IWF" code="3"/>
+			<enum name="INITIAL_ATTACH_PROCEDURE" code="4"/>
+		</avp>
+		<avp name="DSR-Flags" code="1421" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="DSA-Flags" code="1422" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Context-Identifier" code="1423" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Subscriber-Status" code="1424" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SERVICE_GRANTED" code="0"/>
+			<enum name="OPERATOR_DETERMINED_BARRING" code="1"/>
+		</avp>
+		<avp name="Operator-Determined-Barring" code="1425" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Access-Restriction-Data" code="1426" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="APN-OI-Replacement" code="1427" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="All-APN-Configurations-Included-Indicator" code="1428" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ALL_APN_CONFIGURATIONS_INCLUDED" code="0"/>
+			<enum name="MODIFIED/ADDED_APN_CONFIGURATIONS_INCLUDED" code="1"/>
+		</avp>
+		<avp name="APN-Configuration-Profile" code="1429" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Context-Identifier"/>
+				<gavp name="Additional-Context-Identifier"/>
+				<gavp name="All-APN-Configurations-Included-Indicator"/>
+				<gavp name="APN-Configuration"/>
+			</grouped>
+		</avp>
+		<avp name="APN-Configuration" code="1430" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Context-Identifier"/>
+				<gavp name="Served-Party-IP-Address"/>
+				<gavp name="Served-Party-IP-Address"/>
+				<gavp name="PDN-Type"/>
+				<gavp name="Service-Selection"/>
+				<gavp name="EPS-Subscribed-QoS-Profile"/>
+				<gavp name="VPLMN-Dynamic-Address-Allowed"/>
+				<gavp name="MIP6-Agent-Info"/>
+				<gavp name="PDN-GW-Allocation-Type"/>
+				<gavp name="3GPP-Charging-Characteristics"/>
+				<gavp name="AMBR"/>
+				<gavp name="Specific-APN-Info"/>
+				<gavp name="APN-OI-Replacement"/>
+				<gavp name="SIPTO-Permission"/>
+				<gavp name="LIPA-Permission"/>
+				<gavp name="Restoration-Priority"/>
+				<gavp name="SIPTO-Local-Network-Permission"/>
+				<gavp name="WLAN-offloadability"/>
+				<gavp name="Non-IP-PDN-Type-Indicator"/>
+				<gavp name="Non-IP-Data-Delivery-Mechanism"/>
+				<gavp name="SCEF-ID"/>
+				<gavp name="SCEF-Realm"/>
+				<gavp name="Preferred-Data-Mode"/>
+				<gavp name="PDN-Connection-Continuity"/>
+				<gavp name="RDS-Indicator"/>
+			</grouped>
+		</avp>
+		<avp name="EPS-Subscribed-QoS-Profile" code="1431" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="QoS-Class-Identifier"/>
+				<gavp name="Allocation-Retention-Priority"/>
+			</grouped>
+		</avp>
+		<avp name="VPLMN-Dynamic-Address-Allowed" code="1432" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NOTALLOWED" code="0"/>
+			<enum name="ALLOWED" code="1"/>
+		</avp>
+		<avp name="STN-SR" code="1433" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Alert-Reason" code="1434" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="UE_PRESENT" code="0"/>
+			<enum name="UE_MEMORY_AVAILABLE" code="1"/>
+		</avp>
+		<avp name="AMBR" code="1435" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Max-Requested-Bandwidth-UL"/>
+				<gavp name="Max-Requested-Bandwidth-DL"/>
+			</grouped>
+		</avp>
+		<avp name="CSG-Subscription-Data" code="1436" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="CSG-Id"/>
+				<gavp name="Expiration-Date"/>
+				<gavp name="Service-Selection"/>
+				<gavp name="Visited-PLMN-Id"/>
+			</grouped>
+		</avp>
+		<avp name="CSG-Id" code="1437" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="PDN-GW-Allocation-Type" code="1438" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="STATIC" code="0"/>
+			<enum name="DYNAMIC" code="1"/>
+		</avp>
+		<avp name="Expiration-Date" code="1439" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="RAT-Frequency-Selection-Priority-ID" code="1440" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="IDA-Flags" code="1441" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="PUA-Flags" code="1442" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="NOR-Flags" code="1443" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="User-Id" code="1444" vendor-bit="must" mandatory="mustnot" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Equipment-Status" code="1445" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="WHITELISTED" code="0"/>
+			<enum name="BLACKLISTED" code="1"/>
+			<enum name="GREYLISTED" code="2"/>
+		</avp>
+		<avp name="Regional-Subscription-Zone-Code" code="1446" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="RAND" code="1447" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="XRES" code="1448" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="AUTN" code="1449" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="KASME" code="1450" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Trace-Collection-Entity" code="1452" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Kc" code="1453" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="SRES" code="1454" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<!-- Requesting-Node-Type is from old (v8.1.0 - v8.2.0) versions of 29.272. -->
+		<avp name="Requesting-Node-Type" code="1455" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="MME" code="0"/>
+			<enum name="SGSN" code="1"/>
+			<enum name="MME/SGSN" code="2"/>
+		</avp>
+		<avp name="PDN-Type" code="1456" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="IPv4" code="0"/>
+			<enum name="IPv6" code="1"/>
+			<enum name="IPv4v6" code="2"/>
+			<enum name="IPv4_OR_IPv6" code="3"/>
+			<enum name="Non-IP" code="4"/>
+		</avp>
+		<avp name="Roaming-Restricted-Due-To-Unsupported-Feature" code="1457" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Roaming-Restricted-Due-To-Unsupported-Feature" code="0"/>
+		</avp>
+		<avp name="Trace-Data" code="1458" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Trace-Reference"/>
+				<gavp name="Trace-Depth"/>
+				<gavp name="Trace-NE-Type-List"/>
+				<gavp name="Trace-Interface-List"/>
+				<gavp name="Trace-Event-List"/>
+				<gavp name="OMC-Id"/>
+				<gavp name="Trace-Collection-Entity"/>
+				<gavp name="MDT-Configuration"/>
+			</grouped>
+		</avp>
+		<avp name="Trace-Reference" code="1459" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Trace-Depth" code="1462" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Minimum" code="0"/>
+			<enum name="Medium" code="1"/>
+			<enum name="Maximum" code="2"/>
+			<enum name="MinimumWithoutVendorSpecificExtension" code="3"/>
+			<enum name="MediumWithoutVendorSpecificExtension" code="4"/>
+			<enum name="MaximumWithoutVendorSpecificExtension" code="5"/>
+			<!--
+			  The Trace-Depth AVP is of type Enumerated.
+			  The possible values are those defined in 3GPP TS 32.422 [23] for Trace Depth.
+			-->
+		</avp>
+		<avp name="Trace-NE-Type-List" code="1463" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Trace-Interface-List" code="1464" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Trace-Event-List" code="1465" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="OMC-Id" code="1466" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="GPRS-Subscription-Data" code="1467" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Complete-Data-List-Included-Indicator"/>
+				<gavp name="PDP-Context"/>
+			</grouped>
+		</avp>
+		<avp name="Complete-Data-List-Included-Indicator" code="1468" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ALL_PDP_CONTEXTS_INCLUDED" code="0"/>
+			<enum name="MODIFIED/ADDED_PDP CONTEXTS_INCLUDED" code="1"/>
+		</avp>
+		<avp name="PDP-Context" code="1469" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Context-Identifier"/>
+				<gavp name="PDP-Type"/>
+				<gavp name="PDP-Address"/>
+				<gavp name="QoS-Subscribed"/>
+				<gavp name="VPLMN-Dynamic-Address-Allowed"/>
+				<gavp name="Service-Selection"/>
+				<gavp name="3GPP-Charging-Characteristics"/>
+				<gavp name="Ext-PDP-Type"/>
+				<gavp name="Ext-PDP-Address"/>
+				<gavp name="AMBR"/>
+				<gavp name="APN-OI-Replacement"/>
+				<gavp name="SIPTO-Permission"/>
+				<gavp name="LIPA-Permission"/>
+				<gavp name="Restoration-Priority"/>
+				<gavp name="SIPTO-Local-Network-Permission"/>
+				<gavp name="Non-IP-Data-Delivery-Mechanism"/>
+				<gavp name="SCEF-ID"/>
+			</grouped>
+		</avp>
+		<avp name="PDP-Type" code="1470" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="3GPP2-MEID" code="1471" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Specific-APN-Info" code="1472" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Service-Selection"/>
+				<gavp name="MIP6-Agent-Info"/>
+				<gavp name="Visited-Network-Identifier"/>
+			</grouped>
+		</avp>
+		<avp name="LCS-Info" code="1473" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="GMLC-Number"/>
+				<gavp name="LCS-PrivacyException"/>
+				<gavp name="MO-LR"/>
+			</grouped>
+		</avp>
+		<avp name="GMLC-Number" code="1474" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="LCS-PrivacyException" code="1475" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SS-Code"/>
+				<gavp name="SS-Status"/>
+				<gavp name="Notification-To-UE-User"/>
+				<gavp name="External-Client"/>
+				<gavp name="PLMN-Client"/>
+				<gavp name="3GPP-Service-Type"/>
+			</grouped>
+		</avp>
+		<avp name="SS-Code" code="1476" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="SS-Status" code="1477" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Notification-To-UE-User" code="1478" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NOTIFY_LOCATION_ALLOWED" code="0"/>
+			<enum name="NOTIFYANDVERIFY_LOCATION_ALLOWED_IF_NO_RESPONSE" code="1"/>
+			<enum name="NOTIFYANDVERIFY_LOCATION_NOT_ALLOWED_IF_NO_RESPONSE" code="2"/>
+			<enum name="LOCATION_NOT_ALLOWED" code="3"/>
+		</avp>
+		<avp name="External-Client" code="1479" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Client-Identity"/>
+				<gavp name="GMLC-Restriction"/>
+				<gavp name="Notification-To-UE-User"/>
+			</grouped>
+		</avp>
+		<avp name="Client-Identity" code="1480" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="GMLC-Restriction" code="1481" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="GMLC_LIST" code="0"/>
+			<enum name="HOME_COUNTRY" code="1"/>
+		</avp>
+		<avp name="PLMN-Client" code="1482" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="BROADCAST_SERVICE" code="0"/>
+			<enum name="O_AND_M_HPLMN" code="1"/>
+			<enum name="O_AND_M_VPLMN" code="2"/>
+			<enum name="ANONYMOUS_LOCATION" code="3"/>
+			<enum name="TARGET_UE_SUBSCRIBED_SERVICE" code="4"/>
+		</avp>
+		<avp name="3GPP-Service-Type" code="1483" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="ServiceTypeIdentity"/>
+				<gavp name="GMLC-Restriction"/>
+				<gavp name="Notification-To-UE-User"/>
+			</grouped>
+		</avp>
+		<avp name="ServiceTypeIdentity" code="1484" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="MO-LR" code="1485" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SS-Code"/>
+				<gavp name="SS-Status"/>
+			</grouped>
+		</avp>
+		<avp name="Teleservice-List" code="1486" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="TS-Code"/>
+			</grouped>
+		</avp>
+		<avp name="TS-Code" code="1487" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Call-Barring-Infor-List" code="1488" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SS-Code"/>
+			</grouped>
+		</avp>
+		<avp name="SGSN-Number" code="1489" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="IDR-Flags" code="1490" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="ICS-Indicator" code="1491" vendor-bit="must" mandatory="mustnot" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="FALSE" code="0"/>
+			<enum name="TRUE" code="1"/>
+		</avp>
+		<avp name="IMS-Voice-Over-PS-Sessions-Supported" code="1492"  mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NOT_SUPPORTED" code="0"/>
+			<enum name="SUPPORTED" code="1"/>
+		</avp>
+		<avp name="Homogeneous-Support-of-IMS-Voice-Over-PS-Sessions" code="1493"  mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NOT_SUPPORTED" code="0"/>
+			<enum name="SUPPORTED" code="1"/>
+		</avp>
+		<avp name="Last-UE-Activity-Time" code="1494" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="EPS-User-State" code="1495"  mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="MME-User-State"/>
+				<gavp name="SGSN-User-State"/>
+			</grouped>
+		</avp>
+		<avp name="EPS-Location-Information" code="1496" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="MME-Location-Information"/>
+				<gavp name="SGSN-Location-Information"/>
+			</grouped>
+		</avp>
+		<avp name="MME-User-State" code="1497" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="User-State"/>
+			</grouped>
+		</avp>
+		<avp name="SGSN-User-State" code="1498" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="User-State"/>
+			</grouped>
+		</avp>
+		<avp name="User-State" code="1499" vendor-bit="mustnot" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="DETACHED" code="0"/>
+			<enum name="ATTACHED_NOT_REACHABLE_FOR_PAGING" code="1"/>
+			<enum name="ATTACHED_REACHABLE_FOR_PAGING" code="2"/>
+			<enum name="CONNECTED_NOT_REACHABLE_FOR_PAGING" code="3"/>
+			<enum name="CONNECTED_REACHABLE_FOR_PAGING" code="4"/>
+			<enum name="NETWORK_DETERMINED_NOT_REACHABLE" code="5"/>
+		</avp>
+		<!--
+		Note: The AVP codes from 1400 to 1499 are reserved for TS 29.272.
+		-->
+		<avp name="Non-3GPP-User-Data" code="1500" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Subscription-Id"/>
+				<gavp name="Non-3GPP-IP-Access"/>
+				<gavp name="Non-3GPP-IP-Access-APN"/>
+				<gavp name="RAT-Type"/>
+				<gavp name="Session-Timeout"/>
+				<gavp name="MIP6-Feature-Vector"/>
+				<gavp name="AMBR"/>
+				<gavp name="3GPP-Charging-Characteristics"/>
+				<gavp name="APN-OI-Replacement"/>
+				<gavp name="APN-Configuration"/>
+				<gavp name="Trace-Info"/>
+			</grouped>
+		</avp>
+		<avp name="Non-3GPP-IP-Access" code="1501" vendor-bit="must" mandatory="mustnot" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NON_3GPP_SUBSCRIPTION_ALLOWED" code="0"/>
+			<enum name="NON_3GPP_SUBSCRIPTION_BARRED" code="1"/>
+		</avp>
+		<avp name="Non-3GPP-IP-Access-APN" code="1502" vendor-bit="must" mandatory="mustnot" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NON_3GPP_APNS_ENABLE" code="0"/>
+			<enum name="NON_3GPP_APNS_DISABLE" code="1"/>
+		</avp>
+		<avp name="AN-Trusted" code="1503" vendor-bit="must" mandatory="mustnot" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="TRUSTED" code="0"/>
+			<enum name="UNTRUSTED" code="1"/>
+		</avp>
+		<avp name="ANID" code="1504" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Trace-Info" code="1505" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Trace-Data"/>
+				<gavp name="Trace-Reference"/>
+			</grouped>
+		</avp>
+		<avp name="MIP-FA-RK" code="1506" may-encrypt="yes" vendor-id="TGPP" vendor-bit="must" mandatory="must">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="MIP-FA-RK-SPI" code="1507" may-encrypt="yes" vendor-id="TGPP" vendor-bit="must" mandatory="must">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="PPR-Flags" code="1508" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="WLAN-Identifier" code="1509" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SSID"/>
+				<gavp name="HESSID"/>
+			</grouped>
+		</avp>
+		<avp name="TWAN-Access-Info" code="1510" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Access-Authorization-Flags"/>
+				<gavp name="WLAN-Identifier"/>
+			</grouped>
+		</avp>
+		<avp name="Access-Authorization-Flags" code="1511" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="TWAN-Default-APN-Context-Id" code="1512" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<!--
+		1513 Reserved -
+		1514 Reserved -
+		1515 Reserved -
+		-->
+		<avp name="Full-Network-Name" code="1516" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Short-Network-Name" code="1517" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="AAA-Failure-Indication" code="1518" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Transport-Access-Type" code="1519" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="BBF" code="0"/>
+		</avp>
+		<avp name="DER-Flags" code="1520" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="DEA-Flags" code="1521" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="RAR-Flags" code="1522" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="DER-S6b-Flags" code="1523" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="SSID" code="1524" may-encrypt="yes" vendor-id="TGPP" vendor-bit="must" mandatory="must">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="HESSID" code="1525" may-encrypt="yes" vendor-id="TGPP" vendor-bit="must" mandatory="must">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Access-Network-Info" code="1526" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SSID"/>
+				<gavp name="BSSID "/>
+				<gavp name="Location-Information"/>
+				<gavp name="Location-Data"/>
+				<gavp name="Operator-Name"/>
+				<gavp name="Logical-Access-ID"/>
+			</grouped>
+		</avp>
+		<avp name="TWAN-Connection-Mode" code="1527" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="TWAN-Connectivity-Parameters" code="1528" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Connectivity-Flags"/>
+				<gavp name="Service-Selection"/>
+				<gavp name="PDN-Type"/>
+				<gavp name="Served-Party-IP-Address"/>
+				<gavp name="TWAN-PCO"/>
+				<gavp name="TWAG-UP-Address"/>
+				<gavp name="TWAN-S2a-Failure-Cause"/>
+				<gavp name="SM-Back-Off-Timer"/>
+			</grouped>
+		</avp>
+		<avp name="Connectivity-Flags" code="1529" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="TWAN-PCO" code="1530" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="TWAG-CP-Address" code="1531" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="TWAG-UP-Address" code="1532" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="TWAN-S2a-Failure-Cause" code="1533" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="SM-Back-Off-Timer" code="1534" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="WLCP-Key" code="1535" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Origination-Time-Stamp" code="1536" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned64"/>
+		</avp>
+		<avp name="Maximum-Wait-Time" code="1537" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Emergency-Services" code="1538" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="AAR-Flags" code="1539" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="IMEI-Check-In-VPLMN-Result" code="1540" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="ERP-Authorization" code="1541" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+
+		<!--
+		Note: The AVP codes from 1542 to 1599 are reserved for TS 29.273
+		-->
+
+		<avp name="MME-Location-Information" code="1600" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="E-UTRAN-Cell-Global-Identity"/>
+				<gavp name="Tracking-Area-Identity"/>
+				<gavp name="Geographical-Information"/>
+				<gavp name="Geodetic-Information"/>
+				<gavp name="Current-Location-Retrieved"/>
+				<gavp name="Age-Of-Location-Information"/>
+				<gavp name="User-CSG-Information"/>
+				<gavp name="eNodeB-ID"/>
+				<gavp name="Extended-eNodeB-ID"/>
+			</grouped>
+		</avp>
+		<avp name="SGSN-Location-Information" code="1601" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Cell-Global-Identity"/>
+				<gavp name="Location-Area-Identity"/>
+				<gavp name="Service-Area-Identity"/>
+				<gavp name="Routing-Area-Identity"/>
+				<gavp name="Geographical-Information"/>
+				<gavp name="Geodetic-Information"/>
+				<gavp name="Current-Location-Retrieved"/>
+				<gavp name="Age-Of-Location-Information"/>
+				<gavp name="User-CSG-Information"/>
+			</grouped>
+		</avp>
+		<avp name="E-UTRAN-Cell-Global-Identity" code="1602" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Tracking-Area-Identity" code="1603" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Cell-Global-Identity" code="1604" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Routing-Area-Identity" code="1605" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Location-Area-Identity" code="1606" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Service-Area-Identity" code="1607" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Geographical-Information" code="1608" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Geodetic-Information" code="1609" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Current-Location-Retrieved" code="1610" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ACTIVE-LOCATION-RETRIEVAL" code="0"/>
+		</avp>
+		<avp name="Age-Of-Location-Information" code="1611" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Active-APN" code="1612" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Context-Identifier"/>
+				<gavp name="Service-Selection"/>
+				<gavp name="MIP6-Agent-Info"/>
+				<gavp name="Visited-Network-Identifier"/>
+				<gavp name="Specific-APN-Info"/>
+			</grouped>
+		</avp>
+		<avp name="SIPTO-Permission" code="1613" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SIPTO_ALLOWED" code="0"/>
+			<enum name="SIPTO_NOTALLOWED" code="1"/>
+		</avp>
+		<avp name="Error-Diagnostic" code="1614" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="GPRS_DATA_SUBSCRIBED" code="0"/>
+			<enum name="NO_GPRS_DATA_SUBSCRIBED" code="1"/>
+			<enum name="ODB-ALL-APN" code="2"/>
+			<enum name="ODB-HPLMN-APN" code="3"/>
+			<enum name="ODB-VPLMN-APN" code="4"/>
+		</avp>
+		<avp name="UE-SRVCC-Capability" code="1615" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="UE-SRVCC-NOT-SUPPORTED" code="0"/>
+			<enum name="UE-SRVCC-SUPPORTED" code="1"/>
+		</avp>
+		<avp name="MPS-Priority" code="1616" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="VPLMN-LIPA-Allowed" code="1617" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="LIPA-NOTALLOWED" code="0"/>
+			<enum name="LIPA-ALLOWED" code="1"/>
+		</avp>
+		<avp name="LIPA-Permission" code="1618" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="LIPA-PROHIBITED" code="0"/>
+			<enum name="LIPA-ONLY" code="1"/>
+			<enum name="LIPA-CONDITIONAL" code="2"/>
+		</avp>
+		<avp name="Subscribed-Periodic-RAU-TAU-Timer" code="1619" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Ext-PDP-Type" code="1620" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Ext-PDP-Address" code="1621" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="MDT-Configuration" code="1622" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Job-Type"/>
+				<gavp name="Area-Scope"/>
+				<gavp name="List-Of-Measurements"/>
+				<gavp name="Reporting-Trigger"/>
+				<gavp name="Report-Interval"/>
+				<gavp name="Report-Amount"/>
+				<gavp name="Event-Threshold-RSRP"/>
+				<gavp name="Event-Threshold-RSRQ"/>
+				<gavp name="Logging-Interval"/>
+				<gavp name="Logging-Duration"/>
+				<gavp name="Measurement-Period-LTE"/>
+				<gavp name="Measurement-Period-UMTS"/>
+				<gavp name="Collection-Period-RRM-LTE"/>
+				<gavp name="Collection-Period-RRM-UMTS"/>
+				<gavp name="Positioning-Method"/>
+				<gavp name="Measurement-Quantity"/>
+				<gavp name="Event-Threshold-Event-1F"/>
+				<gavp name="Event-Threshold-Event-1I"/>
+				<gavp name="MDT-Allowed-PLMN-Id"/>
+				<gavp name="MBSFN-Area"/>
+			</grouped>
+		</avp>
+		<avp name="Job-Type" code="1623" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Immediate-MDT-only" code="0"/>
+			<enum name="Logged-MDT-only" code="1"/>
+			<enum name="Trace-only" code="2"/>
+			<enum name="Immediate-MDT-and-Trace" code="3"/>
+			<enum name="RLF-reports-only" code="4"/>
+		</avp>
+		<avp name="Area-Scope" code="1624" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Cell-Global-Identity"/>
+				<gavp name="E-UTRAN-Cell-Global-Identity"/>
+				<gavp name="Routing-Area-Identity"/>
+				<gavp name="Location-Area-Identity"/>
+				<gavp name="Tracking-Area-Identity"/>
+			</grouped>
+		</avp>
+		<avp name="List-Of-Measurements" code="1625" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Reporting-Trigger" code="1626" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Report-Interval" code="1627" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="UMTS_250_ms" code="0"/>
+			<enum name="UMTS_500_ms" code="1"/>
+			<enum name="UMTS_1000_ms" code="2"/>
+			<enum name="UMTS_2000_ms" code="3"/>
+			<enum name="UMTS_3000_ms" code="4"/>
+			<enum name="UMTS_4000_ms" code="5"/>
+			<enum name="UMTS_6000_ms" code="6"/>
+			<enum name="UMTS_8000_ms" code="7"/>
+			<enum name="UMTS_12000_ms" code="8"/>
+			<enum name="UMTS_16000_ms" code="9"/>
+			<enum name="UMTS_20000_ms" code="10"/>
+			<enum name="UMTS_24000_ms" code="11"/>
+			<enum name="UMTS_28000_ms" code="12"/>
+			<enum name="UMTS_32000_ms" code="13"/>
+			<enum name="UMTS_64000_ms" code="14"/>
+			<enum name="LTE_120_ms" code="15"/>
+			<enum name="LTE_240_ms" code="16"/>
+			<enum name="LTE_480_ms" code="17"/>
+			<enum name="LTE_640_ms" code="18"/>
+			<enum name="LTE_1024_ms" code="19"/>
+			<enum name="LTE_2048_ms" code="20"/>
+			<enum name="LTE_5120_ms" code="21"/>
+			<enum name="LTE_10240_ms" code="22"/>
+			<enum name="LTE_60000_ms" code="23"/>
+			<enum name="LTE_360000_ms" code="24"/>
+			<enum name="LTE_720000_ms" code="25"/>
+			<enum name="LTE_1800000_ms" code="26"/>
+			<enum name="LTE_3600000_ms" code="27"/>
+		</avp>
+		<avp name="Report-Amount" code="1628" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="1" code="0"/>
+			<enum name="2" code="1"/>
+			<enum name="4" code="2"/>
+			<enum name="8" code="3"/>
+			<enum name="16" code="4"/>
+			<enum name="32" code="5"/>
+			<enum name="64" code="6"/>
+			<enum name="infinity" code="7"/>
+		</avp>
+		<avp name="Event-Threshold-RSRP" code="1629" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Event-Threshold-RSRQ" code="1630" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Logging-Interval" code="1631" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="1.28" code="0"/>
+			<enum name="2.56" code="1"/>
+			<enum name="5.12" code="2"/>
+			<enum name="10.24" code="3"/>
+			<enum name="20.48" code="4"/>
+			<enum name="30.72" code="5"/>
+			<enum name="40.96" code="6"/>
+			<enum name="61.44" code="7"/>
+		</avp>
+		<avp name="Logging-Duration" code="1632" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="600_sec" code="0"/>
+			<enum name="1200_sec" code="1"/>
+			<enum name="2400_sec" code="2"/>
+			<enum name="3600_sec" code="3"/>
+			<enum name="5400_sec" code="4"/>
+			<enum name="7200_sec" code="5"/>
+		</avp>
+		<avp name="Relay-Node-Indicator" code="1633" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NOT_RELAY_NODE" code="0"/>
+			<enum name="RELAY_NODE" code="1"/>
+		</avp>
+		<avp name="MDT-User-Consent" code="1634" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="CONSENT_NOT_GIVEN" code="0"/>
+			<enum name="CONSENT_GIVEN" code="1"/>
+		</avp>
+		<avp name="PUR-Flags" code="1635" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Subscribed-VSRVCC" code="1636" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="VSRVCC_SUBSCRIBED" code="0"/>
+		</avp>
+		<avp name="Equivalent-PLMN-List" code="1637" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Visited-PLMN-Id"/>
+			</grouped>
+		</avp>
+		<avp name="CLR-Flags" code="1638" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="UVR-Flags" code="1639" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="UVA-Flags" code="1640" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="VPLMN-CSG-Subscription-Data" code="1641" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+			<gavp name="CSG-Id"/>
+			<gavp name="Expiration-Date"/>
+			</grouped>
+		</avp>
+		<avp name="Time-Zone" code="1642" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="A-MSISDN" code="1643" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="MME-Number-for-MT-SMS" code="1645" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="SMS-Register-Request" code="1648" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SMS_REGISTRATION_REQUIRED" code="0"/>
+			<enum name="SMS_REGISTRATION_NOT_PREFERRED" code="1"/>
+			<enum name="NO_PREFERENCE" code="2"/>
+		</avp>
+		<avp name="Local-Time-Zone" code="1649" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+			<gavp name="Time-Zone"/>
+			<gavp name="Daylight-Saving-Time"/>
+			</grouped>
+		</avp>
+		<avp name="Daylight-Saving-Time" code="1650" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NO_ADJUSTMENT" code="0"/>
+			<enum name="PLUS_ONE_HOUR_ADJUSTMENT" code="1"/>
+			<enum name="PLUS_TWO_HOURS_ADJUSTMENT" code="2"/>
+		</avp>
+		<avp name="Subscription-Data-Flags" code="1654" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Measurement-Period-LTE" code="1655" vendor-bit="must" vendor-id="TGPP">
+			<!-- The possible values are those defined in 3GPP TS 32.422 -->
+			<type type-name="Enumerated"/>
+			<enum name="1024 ms" code="0"/>
+			<enum name="1280 ms" code="1"/>
+			<enum name="2048 ms" code="2"/>
+			<enum name="2560 ms" code="3"/>
+			<enum name="5120 ms" code="4"/>
+			<enum name="10240 ms" code="5"/>
+			<enum name="1 min" code="6"/>
+		</avp>
+		<avp name="Measurement-Period-UMTS" code="1656" vendor-bit="must" vendor-id="TGPP">
+			<!-- The possible values are those defined in 3GPP TS 32.422 -->
+			<type type-name="Enumerated"/>
+			<enum name="250 ms" code="0"/>
+			<enum name="500 ms" code="1"/>
+			<enum name="1000 ms" code="2"/>
+			<enum name="2000 ms" code="3"/>
+			<enum name="3000 ms" code="4"/>
+			<enum name="4000 ms" code="5"/>
+			<enum name="6000 ms" code="6"/>
+			<enum name="8000 ms" code="7"/>
+			<enum name="12000 ms" code="8"/>
+			<enum name="16000 ms" code="9"/>
+			<enum name="20000 ms" code="10"/>
+			<enum name="24000 ms" code="11"/>
+			<enum name="28000 ms" code="12"/>
+			<enum name="32000 ms" code="13"/>
+			<enum name="64000 ms" code="14"/>
+		</avp>
+		<avp name="Collection-Period-RRM-LTE" code="1657" vendor-bit="must" vendor-id="TGPP">
+			<!-- The possible values are those defined in 3GPP TS 32.422 -->
+			<type type-name="Enumerated"/>
+		</avp>
+		<avp name="Collection-Period-RRM-UMTS" code="1658" vendor-bit="must" vendor-id="TGPP">
+			<!-- The possible values are those defined in 3GPP TS 32.422 -->
+			<type type-name="Enumerated"/>
+		</avp>
+		<avp name="Positioning-Method" code="1659" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Measurement-Quantity" code="1660" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Event-Threshold-Event-1F" code="1661" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Event-Threshold-Event-1I" code="1662" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Restoration-Priority" code="1663" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="SGs-MME-Identity" code="1664" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="SIPTO-Local-Network-Permission" code="1665" vendor-bit="must" vendor-id="TGPP">
+			<!-- TS 29.272 defines it as Unsigned32 -->
+			<type type-name="Enumerated"/>
+			<enum name="SIPTO at Local Network ALLOWED" code="0"/>
+			<enum name="SIPTO at Local Network NOTALLOWED" code="1"/>
+		</avp>
+		<avp name="Coupled-Node-Diameter-ID" code="1666" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="WLAN-offloadability" code="1667" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="WLAN-offloadability-EUTRAN"/>
+				<gavp name="WLAN-offloadability-UTRAN"/>
+			</grouped>
+		</avp>
+		<avp name="WLAN-offloadability-EUTRAN" code="1668" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="WLAN-offloadability-UTRAN" code="1669" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Reset-ID" code="1670" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="MDT-Allowed-PLMN-Id" code="1671" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Adjacent-PLMNs" code="1672" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Visited-PLMN-Id"/>
+			</grouped>
+		</avp>
+		<avp name="Adjacent-Access-Restriction-Data" code="1673" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Visited-PLMN-Id"/>
+				<gavp name="Access-Restriction-Data"/>
+			</grouped>
+		</avp>
+		<avp name="DL-Buffering-Suggested-Packet-Count" code="1674" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="IMSI-Group-Id" code="1675" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Group-Service-Id"/>
+				<gavp name="Group-PLMN-Id"/>
+				<gavp name="Local-Group-Id"/>
+			</grouped>
+		</avp>
+		<avp name="Group-Service-Id" code="1676" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Group-PLMN-Id" code="1677" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Local-Group-Id" code="1678" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="AIR-Flags" code="1679" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="UE-Usage-Type" code="1680" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Non-IP-PDN-Type-Indicator" code="1681" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="FALSE" code="0"/>
+			<enum name="TRUE" code="1"/>
+		</avp>
+		<avp name="Non-IP-Data-Delivery-Mechanism" code="1682" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<!-- TS 29.272 defines it as Unsigned32 -->
+			<type type-name="Enumerated"/>
+			<enum name="SGi-BASED-DATA-DELIVERY" code="0"/>
+			<enum name="SCEF-BASED-DATA-DELIVERY" code="1"/>
+		</avp>
+		<avp name="Additional-Context-Identifier" code="1683" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="SCEF-Realm" code="1684" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="Subscription-Data-Deletion" code="1685" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="DSR-Flags"/>
+				<gavp name="SCEF-ID"/>
+				<gavp name="Context-Identifier"/>
+				<gavp name="Trace-Reference"/>
+				<gavp name="TS-Code"/>
+				<gavp name="SS-Code"/>
+			</grouped>
+		</avp>
+		<avp name="Preferred-Data-Mode" code="1686" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Emergency-Info" code="1687" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="MIP6-Agent-Info"/>
+			</grouped>
+		</avp>
+		<avp name="V2X-Subscription-Data" code="1688" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="V2X-Permission"/>
+				<gavp name="UE-PC5-AMBR"/>
+			</grouped>
+		</avp>
+		<avp name="V2X-Permission" code="1689" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="PDN-Connection-Continuity" code="1690" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<!-- TS 29.272 defines it as Unsigned32 -->
+			<type type-name="Enumerated"/>
+			<enum name="MAINTAIN-PDN-CONNECTION" code="0"/>
+			<enum name="DISCONNECT-PDN-CONNECTION-WITH-REACTIVATION-REQUEST" code="1"/>
+			<enum name="DISCONNECT-PDN-CONNECTION-WITHOUT-REACTIVATION-REQUEST" code="2"/>
+		</avp>
+		<avp name="eDRX-Cycle-Length" code="1691" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="RAT-Type"/>
+				<gavp name="eDRX-Cycle-Length-Value"/>
+			</grouped>
+		</avp>
+		<avp name="eDRX-Cycle-Length-Value" code="1692" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="UE-PC5-AMBR" code="1693" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="MBSFN-Area" code="1694" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="MBSFN-Area-ID"/>
+				<gavp name="Carrier-Frequency"/>
+			</grouped>
+		</avp>
+		<avp name="MBSFN-Area-ID" code="1695" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Carrier-Frequency" code="1696" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="RDS-Indicator" code="1697" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="DISABLED" code="0"/>
+			<enum name="ENABLED" code="1"/>
+		</avp>
+		<avp name="Service-Gap-Time" code="1698" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Aerial-UE-Subscription-Information" code="1699" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Broadcast-Location-Assistance-Data-Types" code="1700" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned64"/>
+		</avp>
+		<avp name="Paging-Time-Window" code="1701" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Operation-Mode"/>
+				<gavp name="Paging-Time-Window-Length"/>
+			</grouped>
+		</avp>
+		<avp name="Operation-Mode" code="1702" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Iu mode" code="1"/>
+			<enum name="WB-S1 mode" code="2"/>
+			<enum name="NB-S1 mode" code="3"/>
+		</avp>
+		<avp name="Paging-Time-Window-Length" code="1703" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Core-Network-Restrictions" code="1704" mandatory="mustnot" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+
+		<avp name="SMS-Information" code="2000" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SMS-Node"/>
+				<gavp name="Client-Address"/>
+				<gavp name="Originator-SCCP-Address"/>
+				<gavp name="Recipient-SCCP-Address"/>
+				<gavp name="SMSC-Address"/>
+				<gavp name="Data-Coding-Scheme"/>
+				<gavp name="Destination-Interface"/>
+				<gavp name="SM-Discharge-Time"/>
+				<gavp name="SM-Message-Type"/>
+				<gavp name="Originator-Interface"/>
+				<gavp name="SM-Protocol-ID"/>
+				<gavp name="Reply-Path-Requested"/>
+				<gavp name="SM-Status"/>
+				<gavp name="SM-User-Data-Header"/>
+				<gavp name="Number-of-Messages-Sent"/>
+				<gavp name="Recipient-Info"/>
+			</grouped>
+		</avp>
+		<avp name="Data-Coding-Scheme" code="2001" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Destination-Interface" code="2002" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Interface-Id"/>
+				<gavp name="Interface-Text"/>
+				<gavp name="Interface-Port"/>
+				<gavp name="Interface-Type"/>
+			</grouped>
+		</avp>
+		<avp name="Interface-Id" code="2003" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Interface-Port" code="2004" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Interface-Text" code="2005" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Interface-Type" code="2006" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Unknown" code="0"/>
+			<enum name="MOBILE_ORIGINATING" code="1"/>
+			<enum name="MOBILE_TERMINATING" code="2"/>
+			<enum name="APPLICATION_ORIGINATING" code="3"/>
+			<enum name="APPLICATION_TERMINATION" code="4"/>
+		</avp>
+		<avp name="SM-Message-Type" code="2007" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SUBMISSION" code="0"/>
+			<enum name="DELIVERY_REPORT" code="1"/>
+			<enum name="SM Service Request" code="2"/>
+		</avp>
+		<avp name="Originator-SCCP-Address" code="2008" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Originator-Interface" code="2009" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Interface-Id"/>
+				<gavp name="Interface-Text"/>
+				<gavp name="Interface-Port"/>
+				<gavp name="Interface-Type"/>
+			</grouped>
+		</avp>
+		<avp name="Recipient-SCCP-Address" code="2010" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Reply-Path-Requested" code="2011" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="No Reply Path Set" code="0"/>
+			<enum name="Reply path Set" code="1"/>
+		</avp>
+		<avp name="SM-Discharge-Time" code="2012" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="SM-Protocol-ID" code="2013" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="SM-Status" code="2014" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="SM-User-Data-Header" code="2015" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="SMS-Node" code="2016" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SMS Router" code="0"/>
+			<enum name="IP-SM-GW" code="1"/>
+			<enum name="SMS Router and IP-SM-GW" code="2"/>
+			<enum name="SMS-SC" code="3"/>
+		</avp>
+		<avp name="SMSC-Address" code="2017" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Client-Address" code="2018" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Number-of-Messages-Sent" code="2019" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Low-Balance-Indication" code="2020" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NOT-APPLICABLE" code="0"/>
+			<enum name="YES" code="1"/>
+		</avp>
+		<avp name="Remaining-Balance" code="2021" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Unit-Value"/>
+				<gavp name="Currency-Code"/>
+			</grouped>
+		</avp>
+		<avp name="Refund-Information" code="2022" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Carrier-Select-Routing-Information" code="2023" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Number-Portability-Routing-Information" code="2024" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="PoC-Event-Type" code="2025" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Normal" code="0"/>
+			<enum name="Instant Personal Aalert event" code="1"/>
+			<enum name="PoC Group Advertisement event" code="2"/>
+			<enum name="Early Ssession Setting-up event" code="3"/>
+			<enum name="PoC Talk Burst" code="4"/>
+		</avp>
+		<avp name="Recipient-Info" code="2026" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Destination-Interface"/>
+				<gavp name="Recipient-Address"/>
+				<gavp name="Recipient-Received-Address"/>
+				<gavp name="Recipient-SCCP-Address "/>
+				<gavp name="SM-Protocol-ID"/>
+			</grouped>
+		</avp>
+		<avp name="Originator-Received-Address" code="2027" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Address-Type"/>
+				<gavp name="Address-Data"/>
+				<gavp name="Address-Domain"/>
+			</grouped>
+		</avp>
+		<avp name="Recipient-Received-Address" code="2028" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Address-Type"/>
+				<gavp name="Address-Data"/>
+				<gavp name="Address-Domain"/>
+			</grouped>
+		</avp>
+		<avp name="SM-Service-Type" code="2029" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="VAS4SMS Short Message content processing" code="0"/>
+			<enum name="VAS4SMS Short Message forwarding" code="1"/>
+			<enum name="VAS4SMS Short Message Forwarding multiple subscriptions" code="2"/>
+			<enum name="VAS4SMS Short Message filtering" code="3"/>
+			<enum name="VAS4SMS Short Message receipt" code="4"/>
+			<enum name="VAS4SMS Short Message Network Storage" code="5"/>
+			<enum name="VAS4SMS Short Message to multiple destinations" code="6"/>
+			<enum name="VAS4SMS Short Message Virtual Private Network (VPN)" code="7"/>
+			<enum name="VAS4SMS Short Message Auto Reply" code="8"/>
+			<enum name="VAS4SMS Short Message Personal Signature" code="9"/>
+			<enum name="VAS4SMS Short Message Deferred Delivery" code="10"/>
+		</avp>
+		<avp name="MMTel-Information" code="2030" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="MMTel-Service-Type"/>
+				<gavp name="Service-Mode"/>
+				<gavp name="Subscriber-Role"/>
+				<gavp name="Number-Of-Diversions"/>
+				<gavp name="Associated-Party-Address"/>
+			</grouped>
+		</avp>
+		<avp name="MMTel-Service-Type" code="2031" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Originating Identification Presentation (OIP)" code="0"/>
+			<enum name="Originating Identification Restriction (OIR)" code="1"/>
+			<enum name="Terminating Identification Presentation (TIP)" code="2"/>
+			<enum name="Terminating Identification Restriction (TIR)" code="3"/>
+			<enum name="Communication HOLD (HOLD)" code="4"/>
+			<enum name="Communications Barring (CB )" code="5"/>
+			<enum name="Communication Diversion (CDIV)" code="6"/>
+			<enum name="Communication Diversion Notification (CDIVN)" code="7"/>
+			<enum name="Communication Waiting (CW)" code="8"/>
+			<enum name="Message Waiting Indication (MWI)" code="9"/>
+			<enum name="Conference (CONF)" code="10"/>
+			<enum name="Flexible Alerting (FA)" code="11"/>
+			<enum name="Completion of Communication to Busy Subscriber (CCBS)" code="12"/>
+			<enum name="Completion of Communications on No Reply (CCNR)" code="13"/>
+			<enum name="Malicious Communication Identification (MCID)" code="14"/>
+			<enum name="Customized Alerting Tone (CAT)" code="15"/>
+			<enum name="Closed User Group (CUG)" code="16"/>
+			<enum name="Personal Network management (PNM)" code="17"/>
+			<enum name="Customized Ringing Signal (CRS)" code="18"/>
+			<enum name="Advice of Charge (AoC)" code="19"/>
+		</avp>
+		<avp name="Service-Mode" code="2032" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+		</avp>
+		<avp name="Subscriber-Role" code="2033" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ORIGINATING" code="0"/>
+			<enum name="TERMINATING" code="1"/>
+		</avp>
+		<avp name="Number-Of-Diversions" code="2034" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Associated-Party-Address" code="2035" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="SDP-Type" code="2036" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SDP Offer" code="0"/>
+			<enum name="SDP Answer" code="1"/>
+		</avp>
+		<avp name="Change-Condition" code="2037" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Normal Release" code="0"/>
+			<enum name="Abnormal Release" code="1"/>
+			<enum name="Qos Change" code="2"/>
+			<enum name="Volume Limit" code="3"/>
+			<enum name="Time Limit" code="4"/>
+			<enum name="Serving Node Change" code="5"/>
+			<enum name="Serving Node PLMN Change" code="6"/>
+			<enum name="User Location Change" code="7"/>
+			<enum name="RAT Change" code="8"/>
+			<enum name="UE Time Zone Change" code="9"/>
+			<enum name="Tariff Time Change" code="10"/>
+			<enum name="Service Idled Out" code="11"/>
+			<enum name="Service Specific Time Limit" code="12"/>
+			<enum name="Max Number of Changes in Changing conditions" code="13"/>
+			<enum name="CGI-SAI Change" code="14"/>
+			<enum name="RAI Change" code="15"/>
+			<enum name="ECGI Change" code="16"/>
+			<enum name="TAI Change" code="17"/>
+			<enum name="Service Data Volume Limit" code="18"/>
+			<enum name="Service Data Time Limit" code="19"/>
+			<enum name="Management Intervantion" code="20"/>
+			<enum name="Service Stop" code="21"/>
+			<enum name="User CSG Information Change" code="22"/>
+			<enum name="S-GW Change" code="23"/>
+			<enum name="Change of UE Presence in Presence Reporting Area" code="24"/>
+			<enum name="Proximity alerted" code="25"/>
+			<enum name="Time expired with no renewal" code="26"/>
+			<enum name="Requestor cancellation" code="27"/>
+			<enum name="Maximum number of reports" code="28"/>
+			<enum name="PLMN Change" code="29"/>
+			<enum name="Coverage status change" code="30"/>
+			<enum name="Removal of access" code="31"/>
+			<enum name="Unavailability of access" code="32"/>
+			<enum name="Access change of service data flow" code="33"/>
+			<enum name="Indirect change condition" code="34"/>
+			<enum name="Maximum number of NIDD submissions" code="35"/>
+			<enum name="Change in UE to PE" code="36"/>
+			<enum name="Serving PLMN Rate Control Change" code="37"/>
+			<enum name="APN Rate Control Change" code="38"/>
+			<!-- duplicated 39 values: issue from 32.299, update once it's fixed
+			<enum name="MO exception data counter" code="39"/>
+			<enum name="NIDD Submission Response Receipt" code="39"/>
+			<enum name="NIDD Submission Response Sending" code="40"/>
+			<enum name="NIDD Delivery to UE" code="41"/>
+			<enum name="NIDD Delivery from UE Error" code="42"/>
+			<enum name="NIDD Submission Timeout" code="43"/>
+			-->
+		</avp>
+		<avp name="Change-Time" code="2038" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Diagnostics" code="2039" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="UNSPECIFIED" code="0"/>
+			<enum name="SESSION_TIMEOUT" code="1"/>
+			<enum name="RESOURCE_LIMITATION" code="2"/>
+			<enum name="ADMIN_DISCONNECT" code="3"/>
+			<enum name="IDLE_TIMEOUT" code="4"/>
+			<enum name="PCRF_UNREACHABLE" code="5"/>
+			<enum name="AAA_UNREACHABLE" code="6"/>
+			<enum name="AAA_INITIATED_SESSION_TERMINATION" code="7"/>
+			<enum name="REAUTHENTICATION_FAILED" code="8"/>
+			<enum name="PCRF_INITIATED_SESSION_TERMINATION" code="9"/>
+			<enum name="PCRF_INITIATED_FLOW_TERMINATION" code="10"/>
+			<enum name="PCRF_ACCOUNTING_PARAMETERS_CHANGED" code="11"/>
+			<enum name="PMIP_INITIATED_SESSION_TERMINATION" code="12"/>
+			<enum name="PPP_INITIATED_SESSION_TERMINATION" code="13"/>
+			<enum name="GTP_INITIATED_SESSION_TERMINATION" code="14"/>
+			<enum name="PMIP_REVOCATION" code="15"/>
+			<enum name="HANDOVER_ERROR" code="16"/>
+			<enum name="PMIP_LIFETIME_EXPIRED" code="17"/>
+			<enum name="REAUTHORIZATION_FAILED" code="18"/>
+		</avp>
+		<avp name="Service-Data-Container" code="2040" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="AF-Correlation-Information"/>
+				<gavp name="Charging-Rule-Base-Name"/>
+				<gavp name="Accounting-Input-Octets"/>
+				<gavp name="Accounting-Output-Octets"/>
+				<gavp name="Local-Sequence-Number"/>
+				<gavp name="QoS-Information"/>
+				<gavp name="Rating-Group"/>
+				<gavp name="Change-Time"/>
+				<gavp name="Service-Identifier"/>
+				<gavp name="Service-Specific-Info"/>
+				<gavp name="ADC-Rule-Base-Name"/>
+				<gavp name="SGSN-Address"/>
+				<gavp name="Time-First-Usage"/>
+				<gavp name="Time-Last-Usage"/>
+				<gavp name="Time-Usage"/>
+				<gavp name="Change-Condition"/>
+				<gavp name="3GPP-User-Location-Info"/>
+				<gavp name="3GPP2-BSID"/>
+				<gavp name="UWAN-User-Location-Info"/>
+				<gavp name="Sponsor-Identity"/>
+				<gavp name="Application-Service-Provider-Identity"/>
+				<gavp name="Presence-Reporting-Area-Status"/>
+				<gavp name="User-CSG-Information"/>
+				<gavp name="3GPP-RAT-Type"/>
+				<gavp name="Related-Change-Condition-Information"/>
+				<gavp name="Serving-PLMN-Rate-Control"/>
+				<gavp name="APN-Rate-Control"/>
+			</grouped>
+		</avp>
+		<avp name="Start-Time" code="2041" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Stop-Time" code="2042" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Time-First-Usage" code="2043" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Time-Last-Usage" code="2044" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Time-Usage" code="2045" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Traffic-Data-Volumes" code="2046" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="QoS-Information"/>
+				<gavp name="Accounting-Input-Octets"/>
+				<gavp name="Accounting-Output-Octets"/>
+				<gavp name="Change-Condition"/>
+				<gavp name="Change-Time"/>
+				<gavp name="3GPP-User-Location-Info"/>
+				<gavp name="UWAN-User-Location-Info"/>
+				<gavp name="3GPP-Charging-Id"/>
+				<gavp name="Presence-Reporting-Area-Status"/>
+				<gavp name="User-CSG-Information"/>
+				<gavp name="3GPP-RAT-Type"/>
+				<gavp name="Access-Availability-Change-Reason"/>
+				<gavp name="Related-Change-Condition-Information"/>
+				<gavp name="Diagnostics"/>
+				<gavp name="Enhanced-Diagnostics"/>
+				<gavp name="CP-CIoT-EPS-Optimisation-Indicator"/>
+				<gavp name="Serving-PLMN-Rate-Control"/>
+			</grouped>
+		</avp>
+		<avp name="Serving-Node-Type" code="2047" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SGSN" code="0"/>
+			<enum name="PMIPSGW" code="1"/>
+			<enum name="GTPSGW" code="2"/>
+			<enum name="ePDG" code="3"/>
+			<enum name="hSGW" code="4"/>
+			<enum name="MME" code="5"/>
+		</avp>
+		<avp name="Supplementary-Service" code="2048" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="3GPP-Service-Type"/>
+				<gavp name="Service-Mode"/>
+				<gavp name="Number-Of-Diversions"/>
+				<gavp name="Associated-Party-Address"/>
+				<gavp name="Service-Id"/>
+				<gavp name="Change-Time"/>
+				<gavp name="Number-Of-Participants"/>
+				<gavp name="Participant-Action-Type"/>
+			</grouped>
+		</avp>
+		<avp name="Participant-Action-Type" code="2049" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="CREATE_CONF" code="0"/>
+			<enum name="JOIN_CONF" code="1"/>
+			<enum name="INVITE_INTO_CONF" code="2"/>
+			<enum name="QUIT_CONF" code="3"/>
+		</avp>
+		<avp name="PDN-Connection-Charging-ID" code="2050" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Dynamic-Address-Flag" code="2051" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Static" code="0"/>
+			<enum name="Dynamic" code="1"/>
+		</avp>
+		<avp name="Accumulated-Cost" code="2052" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Value-Digits"/>
+				<gavp name="Exponent"/>
+			</grouped>
+		</avp>
+		<avp name="AoC-Cost-Information" code="2053" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Accumulated-Cost"/>
+				<gavp name="Incremental-Cost"/>
+				<gavp name="Currency-Code"/>
+			</grouped>
+		</avp>
+		<avp name="AoC-Information" code="2054" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="AoC-Cost-Information"/>
+				<gavp name="Incremental-Cost"/>
+				<gavp name="Tariff-Information"/>
+			</grouped>
+		</avp>
+		<avp name="AoC-Request-Type" code="2055" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="AoC_NOT_REQUESTED" code="0"/>
+			<enum name="AoC_FULL" code="1"/>
+			<enum name="AoC_COST_ONLY" code="2"/>
+			<enum name="AoC_TARIFF_ONLY" code="3"/>
+		</avp>
+		<avp name="Current-Tariff" code="2056" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Value-Digits"/>
+				<gavp name="Exponent"/>
+			</grouped>
+		</avp>
+		<avp name="Next-Tariff" code="2057" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Currency-Code"/>
+				<gavp name="Scale-Factor"/>
+				<gavp name="Rate-Element"/>
+			</grouped>
+		</avp>
+		<avp name="Rate-Element" code="2058" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="CC-Unit-Type"/>
+				<gavp name="Unit-Value"/>
+				<gavp name="Unit-Cost"/>
+				<gavp name="Unit-Quota-Threshold"/>
+			</grouped>
+		</avp>
+		<avp name="Scale-Factor" code="2059" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Value-Digits"/>
+				<gavp name="Exponent"/>
+			</grouped>
+		</avp>
+		<avp name="Tariff-Information" code="2060" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Current-Tariff"/>
+				<gavp name="Tariff-Time-Change"/>
+				<gavp name="Next-Tariff"/>
+			</grouped>
+		</avp>
+		<avp name="Unit-Cost" code="2061" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Value-Digits"/>
+				<gavp name="Exponent"/>
+			</grouped>
+		</avp>
+		<avp name="Incremental-Cost" code="2062" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Value-Digits"/>
+				<gavp name="Exponent"/>
+			</grouped>
+		</avp>
+		<avp name="Local-Sequence-Number" code="2063" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Node-Id" code="2064" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="SGW-Change" code="2065" mandatory="must" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ACR_Start_NOT_due_to_SGW_Change" code="0"/>
+			<enum name="ACR_Start_due_to_SGW_Change" code="1"/>
+		</avp>
+		<avp name="Charging-Characteristics-Selection-Mode" code="2066" mandatory="must" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Serving-Node-Supplied" code="0"/>
+			<enum name="Subscription-specific" code="1"/>
+			<enum name="APN-specific" code="2"/>
+			<enum name="Home-Default" code="3"/>
+			<enum name="Roaming-Default" code="4"/>
+			<enum name="Visiting-Default" code="5"/>
+		</avp>
+		<avp name="SGW-Address" code="2067" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Dynamic-Address-Flag-Extension" code="2068" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Static" code="0"/>
+			<enum name="Dynamic" code="1"/>
+		</avp>
+
+		<!-- Note: The AVP codes from 2067 to 2099 are reserved for TS 32.299 -->
+
+		<avp name="Reserved-2100" code="2100" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Application-Server-ID" code="2101" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Application-Service-Type" code="2102" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SENDING" code="100"/>
+			<enum name="RECEIVING" code="101"/>
+			<enum name="RETRIEVAL" code="102"/>
+			<enum name="INVITING" code="103"/>
+			<enum name="LEAVING" code="104"/>
+			<enum name="JOINING" code="105"/>
+		</avp>
+		<avp name="Application-Session-ID" code="2103" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Delivery-Status" code="2104" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Reserved-2105" code="2105" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-2106" code="2106" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-2107" code="2107" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-2108" code="2108" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Reserved-2109" code="2109" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="IM-Information" code="2110" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Interface-Id"/>
+				<gavp name="Interface-Text"/>
+				<gavp name="Interface-Port"/>
+				<gavp name="Interface-Type"/>
+			</grouped>
+		</avp>
+		<avp name="Number-Of-Messages-Successfully-Exploded" code="2111" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Number-Of-Messages-Successfully-Sent" code="2112" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Total-Number-Of-Messages-Exploded" code="2113" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Total-Number-Of-Messages-Sent" code="2114" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<!-- The AVP is defined in OMA-DDS-Charging_Data -->
+		<avp name="DCD-Information" code="2115" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Content-ID"/>
+				<gavp name="Content-provider-ID"/>
+			</grouped>
+		 </avp>
+		<avp name="Content-ID" code="2116" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Content-provider-ID" code="2117" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Charge-Reason-Code" code="2118" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="UNKNOWN" code="0"/>
+			<enum name="USAGE" code="1"/>
+			<enum name="COMMUNICATION-ATTEMPT-CHARGE" code="2"/>
+			<enum name="SETUP-CHARGE" code="3"/>
+			<enum name="ADD-ON-CHARGE" code="4"/>
+		</avp>
+
+		<!--
+		32.299 [5]
+		Note: The AVP codes from 2118 to 2199 are reserved for TS 32.299
+
+		Note: The AVP codes from 2200 to 2299 are reserved for TS 29.215 (TGPP.xml)
+		-->
+
+		<avp name="Reserved-2300" code="2300" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="SIP-Request-Timestamp-Fraction" code="2301" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="SIP-Response-Timestamp-Fraction" code="2302" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Online-Charging-Flag" code="2303" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ECF address not provided" code="0"/>
+			<enum name="ECF address provided" code="1"/>
+		</avp>
+		<avp name="CUG-Information" code="2304" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Real-Time-Tariff-Information" code="2305" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Tariff-Information"/>
+				<gavp name="Tariff-XML"/>
+			</grouped>
+		</avp>
+		<avp name="Tariff-XML" code="2306" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="MBMS-GW-Address" code="2307" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="IMSI-Unauthenticated-Flag" code="2308" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Authenticated" code="0"/>
+			<enum name="Unauthenticated" code="1"/>
+		</avp>
+		<avp name="Account-Expiration" code="2309" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Time"/>
+		</avp>
+		<avp name="AoC-Format" code="2310" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="MONETARY" code="0"/>
+			<enum name="NON_MONETARY" code="1"/>
+			<enum name="CAI" code="2"/>
+		</avp>
+		<avp name="AoC-Service" code="2311" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+			<gavp name="AoC-Service-Obligatory-Type"/>
+			<gavp name="AoC-Service-Type"/>
+			</grouped>
+		</avp>
+		<avp name="AoC-Service-Obligatory-Type" code="2312" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NON_BINDING" code="0"/>
+			<enum name="BINDING" code="1"/>
+		</avp>
+		<avp name="AoC-Service-Type" code="2313" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NONE" code="0"/>
+			<enum name="AOC-S" code="1"/>
+			<enum name="AOC-D" code="2"/>
+			<enum name="AOC-E" code="3"/>
+		</avp>
+		<avp name="AoC-Subscription-Information" code="2314" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+			<gavp name="AoC-Service"/>
+			<gavp name="AoC-Format"/>
+			<gavp name="Preferred-AoC-Currency"/>
+			</grouped>
+		</avp>
+		<!-- Specified by using the numeric values defined in the ISO 4217 standard, refer RFC 4006 XXX Add them as enum-->
+		<avp name="Preferred-AoC-Currency" code="2315" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+
+		<!--
+			2316	Reason-Code	Enumerated
+		-->
+		<avp name="CSG-Access-Mode" code="2317" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Closed mode" code="0"/>
+			<enum name="Hybrid Mode" code="1"/>
+		</avp>
+		<avp name="CSG-Membership-Indication" code="2318" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Not CSG member" code="0"/>
+			<enum name="CSG Member" code="1"/>
+		</avp>
+		<avp name="User-CSG-Information" code="2319" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="CSG-Id"/>
+				<gavp name="CSG-Access-Mode"/>
+				<gavp name="CSG-Membership-Indication"/>
+			</grouped>
+		</avp>
+		<avp name="Outgoing-Session-Id" code="2320" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Initial-IMS-Charging-Identifier" code="2321" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+
+		<!--
+		Note: The AVP codes from 2322 to 2399 are reserved for TS 32.299
+		-->
+
+		<avp name="LMSI" code="2400" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Serving-Node" code="2401" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SGSN-Number"/>
+				<gavp name="SGSN-Name"/>
+				<gavp name="SGSN-Realm"/>
+				<gavp name="MME-Name"/>
+				<gavp name="MME-Realm"/>
+				<gavp name="MSC-Number"/>
+				<gavp name="3GPP-AAA-Server-Name"/>
+				<gavp name="LCS-Capabilities-Sets"/>
+				<gavp name="GMLC-Address"/>
+				<gavp name="IP-SM-GW-Number"/>
+				<gavp name="IP-SM-GW-Name"/>
+			</grouped>
+		</avp>
+		<avp name="MME-Name" code="2402" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="MSC-Number" code="2403" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="LCS-Capabilities-Sets" code="2404" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="GMLC-Address" code="2405" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Additional-Serving-Node" code="2406" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SGSN-Number"/>
+				<gavp name="MME-Name"/>
+				<gavp name="SGSN-Name"/>
+				<gavp name="SGSN-Realm"/>
+				<gavp name="MME-Realm"/>
+				<gavp name="MSC-Number"/>
+				<gavp name="3GPP-AAA-Server-Name"/>
+				<gavp name="LCS-Capabilities-Sets"/>
+				<gavp name="GMLC-Address"/>
+			</grouped>
+		</avp>
+		<avp name="PSR-Address" code="2407" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="MME-Realm" code="2408" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="SGSN-Name" code="2409" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="SGSN-Realm" code="2410" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="RIA-Flags" code="2411" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+
+		<!--
+		Note: The AVP codes from 2412 to 2499 are reserved for TS 29.173
+		-->
+
+		<avp name="Slg-Location-Type" code="2500" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="Enumerated"/>
+			<enum name="CURRENT_LOCATION" code="0"/>
+			<enum name="CURRENT_OR_LAST_KNOWN_LOCATION" code="1"/>
+			<enum name="INITIAL_LOCATION " code="2"/>
+			<enum name="RESERVED" code="3"/>
+			<enum name="RESERVED" code="4"/>
+			<enum name="NOTIFICATION_VERIFICATION_ONLY" code="5"/>
+		</avp>
+		<avp name="LCS-EPS-Client-Name" code="2501" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="LCS-Name-String"/>
+				<gavp name="LCS-Format-Indicator"/>
+			</grouped>
+		</avp>
+		<avp name="LCS-Requestor-Name" code="2502" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="LCS-Requestor-ID-String"/>
+				<gavp name="LCS-Format-Indicator"/>
+			</grouped>
+		</avp>
+		<avp name="LCS-Priority" code="2503" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+
+		<avp name="LCS-QoS" code="2504" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="LCS-QoS-Class"/>
+				<gavp name="Vertical-Accuracy "/>
+				<gavp name="Vertical-Requested"/>
+				<gavp name="Response-Time"/>
+			</grouped>
+		</avp>
+		<avp name="Horizontal-Accuracy" code="2505" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Vertical-Accuracy" code="2506" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Vertical-Requested" code="2507" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="VERTICAL_COORDINATE_IS_NOT_REQUESTED" code="0"/>
+			<enum name="VERTICAL_COORDINATE_IS_REQUESTED " code="1"/>
+		</avp>
+		<avp name="Velocity-Requested" code="2508" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="VELOCITY_IS_NOT_REQUESTED" code="0"/>
+			<enum name="BEST VELOCITY_IS_REQUESTED" code="1"/>
+		</avp>
+		<avp name="Response-Time" code="2509" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="LOW_DELAY" code="0"/>
+			<enum name="DELAY_TOLERANT" code="1"/>
+		</avp>
+		<avp name="Supported-GAD-Shapes" code="2510" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="LCS-Codeword" code="2511" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="LCS-Privacy-Check" code="2512" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ALLOWED_WITHOUT_NOTIFICATION" code="0"/>
+			<enum name="ALLOWED_WITH_NOTIFICATION" code="1"/>
+			<enum name="ALLOWED_IF_NO_RESPONSE" code="2"/>
+			<enum name="RESTRICTED_IF_NO_RESPONSE" code="3"/>
+			<enum name="NOT_ALLOWED" code="4"/>
+		</avp>
+
+		<avp name="Accuracy-Fulfilment-Indicator" code="2513" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="REQUESTED_ACCURACY_FULFILLED" code="0"/>
+			<enum name="REQUESTED_ACCURACY_NOT_FULFILLED" code="1"/>
+		</avp>
+
+		<avp name="Age-Of-Location-Estimate" code="2514" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Velocity-Estimate" code="2515" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+		</avp>
+		<avp name="EUTRAN-Positioning-Data" code="2516" vendor-bit="must" vendor-id="TGPP">
+		<type type-name="OctetString"/>
+		</avp>
+		<avp name="ECGI" code="2517" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Location-Event" code="2518" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="EMERGENCY_CALL_ORIGINATION" code="0"/>
+			<enum name="EMERGENCY_CALL_RELEASE" code="1"/>
+			<enum name="MO_LR" code="2"/>
+			<enum name="EMERGENCY_CALL_HANDOVER" code="3"/>
+		</avp>
+		<avp name="Pseudonym-Indicator" code="2519" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="PSEUDONYM_NOT_REQUESTED" code="0"/>
+			<enum name="PSEUDONYM_REQUESTED" code="1"/>
+		</avp>
+		<avp name="LCS-Service-Type-ID" code="2520" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+
+		<avp name="LCS-Privacy-Check-Non-Session" code="2521" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="LCS-Privacy-Check"/>
+			</grouped>
+		</avp>
+		<avp name="LCS-Privacy-Check-Session" code="2522" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="LCS-Privacy-Check"/>
+			</grouped>
+		</avp>
+		<avp name="LCS-QoS-Class" code="2523" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ASSURED" code="0"/>
+			<enum name="BEST EFFORT" code="1"/>
+		</avp>
+
+		<!--
+		GERAN-Positioning-Info 2524 7.4.29 Grouped V M No
+		GERAN-Positioning-Data 2525 7.4.30 OctetString V M No
+		GERAN-GANSS-Positioning-Data 2526 7.4.31 OctetString V M No
+		UTRAN-Positioning-Info 2527 7.4.32 Grouped V M No
+		UTRAN-Positioning-Data 2528 7.4.33 OctetString V M No
+		UTRAN-GANSS-Positioning-Data 2529 7.4.34 OctetString V M No
+		LRR-Flags 2530 7.4.35 Unsigned32 V M No
+		LCS-Reference-Number 2531 7.4.37 OctetString V M No
+		Deferred-Location-Type 2532 7.4.36 Unsigned32 V M No
+		Area-Event-Info 2533 7.4.38 Grouped V M No
+		Area-Definition 2534 7.4.39 Grouped V M No
+		Area 2535 7.4.40 Grouped V M No
+		Area-Type 2536 7.4.41 Unsigned32 V M No
+		Area-Identification 2537 7.4.42 Grouped V M No
+		Occurrence-Info 2538 7.4.43 Enumerated V M No
+		Interval-Time 2539 7.4.44 Unsigned32 V M No
+		Periodic-LDR-Information 2540 7.4.45 Grouped V M No
+		Reporting-Amount 2541 7.4.46 Unsigned32 V M No
+		Reporting-Interval 2542 7.4.47 Unsigned32 V M No
+		Reporting-PLMN-List 2543 7.4.48 Grouped V M No
+		PLMN-ID-List 2544 7.4.49 Grouped V M No
+		PLR-Flags 2545 7.4.52 Unsigned32 V M No
+		PLA-Flags 2546 7.4.53 Unsigned32 V M No
+		Deferred-MT-LR-Data 2547 7.4.54 Grouped V M No
+		Termination-Cause 2548 7.4.55 Unsigned32 V M No
+		LRA-Flags 2549 7.4.56 Unsigned32 V M No
+		Periodic-Location-Support-Indicator 2550 7.4.50 Enumerated V M No
+		Prioritized-List-Indicator 2551 7.4.51 Enumerated V M No
+		ESMLC-Cell-Info 2552 7.4.57 Grouped V M No
+		Cell-Portion-ID 2553 7.4.58 Unsigned32 V M No
+		1xRTT-RCID 2554 7.4.59 OctetString V M No
+		-->
+
+		<avp name="Civic-Address" code="2556" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Barometric-Pressure" code="2557" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+
+		<!--
+		UTRAN-Additional-Positioning-Data 2558 7.4.63 OctetString V M No
+		Note: The AVP codes from 2524 to 2599 are reserved for TS 29.172
+		-->
+
+		<avp name="Reserved-2600" code="2600" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="IMS-Application-Reference-Identifier" code="2601" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Low-Priority-Indicator" code="2602" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NO" code="0"/>
+			<enum name="YES" code="1"/>
+		</avp>
+		<avp name="IP-Realm-Default-Indicator" code="2603" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Default IP Realm Not used" code="0"/>
+			<enum name="Default IP realm used" code="1"/>
+		</avp>
+		<avp name="Local-GW-Inserted-Indicator" code="2604" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Local GW Not Inserted" code="0"/>
+			<enum name="Local GW Inserted" code="1"/>
+		</avp>
+		<avp name="Transcoder-Inserted-Indicator" code="2605" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Transcoder Not Inserted" code="0"/>
+			<enum name="Transcoder Inserted" code="1"/>
+		</avp>
+		<avp name="PDP-Address-Prefix-Length" code="2606" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<!--
+		Note: The AVP codes from 2607 to 2699 are reserved for TS 32.299
+		-->
+		<avp name="NNI-Information" code="2703" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Session-Direction"/>
+				<gavp name="NNI-Type"/>
+				<gavp name="Relationship-Mode"/>
+				<gavp name="Neighbour-Node-Address"/>
+			</grouped>
+		</avp>
+		<avp name="NNI-Type" code="2704" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="non-roaming" code="0"/>
+			<enum name="roaming without loopback" code="1"/>
+			<enum name="roaming with loopback" code="2"/>
+		</avp>
+		<avp name="Neighbour-Node-Address" code="2705" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Relationship-Mode" code="2706" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="trusted" code="0"/>
+			<enum name="non-trusted" code="1"/>
+		</avp>
+		<avp name="Session-Direction" code="2707" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="inbound" code="0"/>
+			<enum name="outbound" code="1"/>
+		</avp>
+		<avp name="From-Address" code="2708" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Access-Transfer-Information" code="2709" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Access-Transfer-Type"/>
+				<gavp name="Access-Network-Information"/>
+				<gavp name="Cellular-Network-Information"/>
+				<gavp name="Inter-UE-Transfer"/>
+				<gavp name="User-Equipment-Info"/>
+				<gavp name="Instance-Id"/>
+				<gavp name="Related-IMS-Charging-Identifier"/>
+				<gavp name="Related-IMS-Charging-Identifier-Node"/>
+				<gavp name="Change-Time"/>
+			</grouped>
+		</avp>
+		<avp name="Access-Transfer-Type" code="2710" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="PS to CS Transfer" code="0"/>
+			<enum name="CS to PS Transfer" code="1"/>
+			<enum name="PS to PS Transfer" code="2"/>
+			<enum name="CS to CS Transfer" code="3"/>
+		</avp>
+		<avp name="Related-IMS-Charging-Identifier" code="2711" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Related-IMS-Charging-Identifier-Node" code="2712" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="IMS-Visited-Network-Identifier" code="2713" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="TWAN-User-Location-Info" code="2714" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SSID"/>
+				<gavp name="BSSID"/>
+			</grouped>
+		</avp>
+		<avp name="BSSID" code="2716" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="TAD-Identifier" code="2717" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="CS" code="0"/>
+			<enum name="PS" code="1"/>
+		</avp>
+		<!--
+		Note: The AVP codes from 2700 to 2799 are reserved for TS 32.299
+		-->
+
+		<!-- 3GPP 29.212 -->
+		<avp name="TDF-Application-Instance-Identifier" code="2802" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="HeNB-Local-IP-Address" code="2804" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="UE-Local-IP-Address" code="2805" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="UDP-Source-Port" code="2806" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="CS-Service-QoS-Request-Identifier" code="2807" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="CS-Service-QoS-Request-Operation" code="2808" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Enumerated"/>
+			<enum name="Deletion" code="0"/>
+			<enum name="Modification" code="1"/>
+		</avp>
+		<avp name="Mute-Notification" code="2809" mandatory="mustnot" protected="may" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Enumerated"/>
+			<enum name="Mute Required" code="0"/>
+		</avp>
+		<avp name="Monitoring-Time" code="2810" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="AN-GW-Status" code="2811" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Enumerated"/>
+			<enum name="AN_GW_FAILED" code="0"/>
+		</avp>
+		<avp name="User-Location-Info-Time" code="2812" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="CS-Service-Resource-Report" code="2813" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<grouped>
+				<gavp name="CS-Service-QoS-Request-Identifier"/>
+				<gavp name="CS-Service-Resource-Result-Operation"/>
+				<gavp name="CS-Service-Resource-Failure-Cause"/>
+			</grouped>
+		</avp>
+		<avp name="CS-Service-Resource-Failure-Cause" code="2814" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Enumerated"/>
+			<enum name="Resource Released" code="0"/>
+		</avp>
+		<avp name="CS-Service-Resource-Result-Operation" code="2815" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Enumerated"/>
+			<enum name="Deletion" code="0"/>
+		</avp>
+		<avp name="Default-QoS-Information" code="2816" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<grouped>
+				<gavp name="QoS-Class-Identifier"/>
+				<gavp name="Max-Requested-Bandwidth-UL"/>
+				<gavp name="Max-Requested-Bandwidth-DL"/>
+				<gavp name="Default-QoS-Name"/>
+			</grouped>
+		</avp>
+		<avp name="Default-QoS-Name" code="2817" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Conditional-APN-Aggregate-Max-Bitrate" code="2818" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<grouped>
+				<gavp name="APN-Aggregate-Max-Bitrate-UL"/>
+				<gavp name="APN-Aggregate-Max-Bitrate-DL"/>
+				<gavp name="IP-CAN-Type"/>
+				<gavp name="RAT-Type"/>
+			</grouped>
+		</avp>
+		<avp name="RAN-NAS-Release-Cause" code="2819" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Presence-Reporting-Area-Elements-List" code="2820" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Presence-Reporting-Area-Identifier" code="2821" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Presence-Reporting-Area-Information" code="2822" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<grouped>
+				<gavp name="Presence-Reporting-Area-Identifier"/>
+				<gavp name="Presence-Reporting-Area-Status"/>
+				<gavp name="Presence-Reporting-Area-Elements-List"/>
+			</grouped>
+		</avp>
+		<avp name="Presence-Reporting-Area-Status" code="2823" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Enumerated"/>
+			<enum name="In area" code="0"/>
+			<enum name="Out of area" code="1"/>
+			<enum name="Inactive" code="2"/>
+		</avp>
+		<avp name="NetLoc-Access-Support" code="2824" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Enumerated"/>
+			<enum name="NETLOC_ACCESS_NOT_SUPPORTED" code="0"/>
+		</avp>
+		<avp name="Fixed-User-Location-Info" code="2825" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<grouped>
+				<gavp name="SSID"/>
+				<gavp name="BSSID"/>
+				<gavp name="Logical-Access-ID"/>
+				<gavp name="Physical-Access-ID"/>
+			</grouped>
+		</avp>
+		<avp name="PCSCF-Restoration-Indication" code="2826" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Enumerated"/>
+			<enum name="PCSCF_RESTORATION" code="0"/>
+		</avp>
+		<avp name="IP-CAN-Session-Charging-Scope" code="2827" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Enumerated"/>
+			<enum name="IP-CAN_SESSION_SCOPE" code="0"/>
+		</avp>
+		<avp name="Monitoring-Flags" code="2828" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Default-Access" code="2829" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="3GPP-GPRS" 		code="0"/>
+			<enum name="DOCSIS" 		code="1"/>
+			<enum name="xDSL" 		code="2"/>
+			<enum name="WiMAX" 		code="3"/>
+			<enum name="3GPP2" 		code="4"/>
+			<enum name="3GPP-EPS" 		code="5"/>
+			<enum name="Non-3GPP-EPS" 	code="6"/>
+		</avp>
+		<avp name="NBIFOM-Mode" code="2830" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="UE_INITIATED" 		code="0"/>
+			<enum name="NETWORK_INITIATED" 		code="1"/>
+		</avp>
+		<avp name="NBIFOM-Support" code="2831" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NBIFOM_NOT_SUPPORTED" 		code="0"/>
+			<enum name="NBIFOM_SUPPORTED" 		code="1"/>
+		</avp>
+		<avp name="RAN-Rule-Support" code="2832" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Access-Availability-Change-Reason" code="2833" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Routing-Rule-Failure-Code" code="2834" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Routing-Rule-Report" code="2835" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<grouped>
+				<gavp name="Routing-Rule-Identifier"/>
+				<gavp name="PCC-Rule-Status"/>
+				<gavp name="Routing-Rule-Failure-Code"/>
+			</grouped>
+		</avp>
+		<avp name="Traffic-Steering-Policy-Identifier-DL" code="2836" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Traffic-Steering-Policy-Identifier-UL" code="2837" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Request-Type" code="2838" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Execution-Time" code="2839" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Conditional-Policy-Information" code="2840" mandatory="must" vendor-bit="must" vendor-id="TGPP" may-encrypt="yes">
+			<grouped>
+				<gavp name="Execution-Time"/>
+				<gavp name="APN-Aggregate-Max-Bitrate-UL"/>
+				<gavp name="APN-Aggregate-Max-Bitrate-DL"/>
+				<gavp name="Conditional-APN-Aggregate-Max-Bitrate"/>
+			</grouped>
+		</avp>
+		<avp name="Resource-Release-Notification" code="2841" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ENABLE_NOTIFICATION" 		code="0"/>
+		</avp>
+		<avp name="Removal-Of-Access" code="2842" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="REMOVAL_OF_ACCESS" 		code="0"/>
+		</avp>
+
+		<avp name="Default-Bearer-Indication" code="2844" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="BIND_TO_DEF_BEARER" 	code="0"/>
+			<enum name="BIND_TO_APPLICABLE_BEARER" 	code="1"/>
+		</avp>
+		<avp name="PRA-Install" code="2845" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Presence-Reporting-Area-Information"/>
+			</grouped>
+		</avp>
+		<avp name="PRA-Remove" code="2846" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Presence-Reporting-Area-Identifier"/>
+			</grouped>
+		</avp>
+		<avp name="3GPP-PS-Data-Off-Status-Gx" code="2847" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ACTIVE" 	code="0"/>
+			<enum name="INACTIVE" 	code="1"/>
+		</avp>
+		<avp name="Extended-APN-AMBR-DL" code="2848" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Extended-APN-AMBR-UL" code="2849" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Extended-GBR-DL" code="2850" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Extended-GBR-UL" code="2851" mandatory="mustnot" may-encrypt="yes" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+
+		<!--
+		Note: The AVP codes from 2829 to 2899 are reserved for TS 29.212
+		-->
+
+		<avp name="Policy-Counter-Identifier" code="2901" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Policy-Counter-Status" code="2902" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Policy-Counter-Status-Report" code="2903" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Policy-Counter-Identifier"/>
+				<gavp name="Policy-Counter-Status"/>
+				<gavp name="Pending-Policy-Counter-Information"/>
+			</grouped>
+		</avp>
+		<avp name="SL-Request-Type" code="2904" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="INITIAL_REQUEST"		code="0"/>
+			<enum name="INTERMEDIATE_REQUEST"	code="1"/>
+		</avp>
+		<avp name="Pending-Policy-Counter-Information" code="2905" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Policy-Counter-Status"/>
+				<gavp name="Pending-Policy-Counter-Change-Time"/>
+			</grouped>
+		</avp>
+		<avp name="Pending-Policy-Counter-Change-Time" code="2906" mandatory="must" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+
+		<avp name="Device-Action" code="3001" mandatory="must" vendor-bit="must" protected="may" vendor-id="TGPP">
+			<grouped>
+				<gavp name="External-Identifier"/>
+				<gavp name="MSISDN"/>
+				<gavp name="SCS-Identity"/>
+				<gavp name="Reference-Number"/>
+				<gavp name="Action-Type"/>
+				<gavp name="Trigger-Data"/>
+				<gavp name="Validity-Time"/>
+			</grouped>
+		</avp>
+		<avp name="Device-Notification" code="3002" mandatory="must" vendor-bit="must" protected="may" vendor-id="TGPP">
+			<grouped>
+				<gavp name="External-Identifier"/>
+				<gavp name="MSISDN"/>
+				<gavp name="SCS-Identity"/>
+				<gavp name="Reference-Number"/>
+				<gavp name="Action-Type"/>
+				<gavp name="Request-Status"/>
+				<gavp name="Delivery-Outcome"/>
+			</grouped>
+		</avp>
+		<avp name="Trigger-Data" code="3003" mandatory="must" vendor-bit="must" protected="may" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Payload"/>
+				<gavp name="Priority-Indication"/>
+				<gavp name="Application-Port-Identifier"/>
+			</grouped>
+		</avp>
+		<avp name="Payload" code="3004" mandatory="must" vendor-bit="must" protected="may" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Action-Type" code="3005" mandatory="must" vendor-bit="must" protected="may" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Device Trigger Request" code="1"/>
+			<enum name="Delivery Report" code="2"/>
+		</avp>
+		<avp name="Priority-Indication" code="3006" mandatory="must" vendor-bit="must" protected="may" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Non-Priority" code="0"/>
+			<enum name="Priority" code="1"/>
+		</avp>
+		<avp name="Reference-Number" code="3007" mandatory="must" vendor-bit="must" protected="may" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Request-Status" code="3008" mandatory="must" vendor-bit="must" protected="may" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SUCCESS" code="0"/>
+			<enum name="TEMPORARYERROR" code="201"/>
+			<enum name="INVPAYLOAD" code="101"/>
+			<enum name="INVEXTID" code="102"/>
+			<enum name="INVSCSID" code="103"/>
+			<enum name="INVPERIOD" code="104"/>
+			<enum name="NOTAUTHORIZED" code="105"/>
+			<enum name="SERVICEUNAVAILABLE" code="106"/>
+			<enum name="PERMANENTERROR" code="107"/>
+			<enum name="QUOTAEXCEEDED" code="108"/>
+			<enum name="RATEEXCEEDED" code="109"/>
+		</avp>
+		<avp name="Delivery-Outcome" code="3009" mandatory="must" vendor-bit="must" protected="may" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="SUCCESS" code="0"/>
+			<enum name="EXPIRED" code="1"/>
+			<enum name="TEMPORARYERROR" code="2"/>
+			<enum name="UNDELIVERABLE" code="3"/>
+		</avp>
+		<avp name="Application-Port-Identifier" code="3010" mandatory="must" vendor-bit="must" protected="may" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Old-Reference-Number" code="3011" mandatory="mustnot" vendor-bit="must" protected="may" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="IP-SM-GW-Number" code="3100" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="IP-SM-GW-Name" code="3101" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="User-Identifier" code="3102" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="User-Name"/>
+				<gavp name="MSISDN"/>
+				<gavp name="External-Identifier"/>
+				<gavp name="LMSI"/>
+				<gavp name="Type-Of-External-Identifier"/>
+			</grouped>
+		</avp>
+		<avp name="S6-Service-ID" code="3103" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="DEVICE_TRIGGER" code="0"/>
+			<enum name="SMS_MO" code="1"/>
+		</avp>
+		<avp name="SCS-Identity" code="3104" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Service-Parameters" code="3105" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="T4-Parameters"/>
+				<gavp name="Application-Port-Identifier"/>
+			</grouped>
+		</avp>
+		<avp name="T4-Parameters" code="3106" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Priority-Indication"/>
+				<gavp name="SM-RP-SMEA"/>
+			</grouped>
+		</avp>
+		<avp name="Service-Data" code="3107" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="T4-Data"/>
+			</grouped>
+		</avp>
+		<avp name="T4-Data" code="3108" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="HSS-Cause"/>
+				<gavp name="Serving-Node"/>
+				<gavp name="Additional-Serving-Node"/>
+			</grouped>
+		</avp>
+		<avp name="HSS-Cause" code="3109" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="SIR-Flags" code="3110" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="External-Identifier" code="3111" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="IP-SM-GW-Realm" code="3112" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="AESE-Communication-Pattern" code="3113" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SCEF-Reference-ID"/>
+				<gavp name="SCEF-ID"/>
+				<gavp name="SCEF-Reference-ID-for-Deletion"/>
+				<gavp name="Communication-Pattern-Set"/>
+			</grouped>
+		</avp>
+		<avp name="Communication-Pattern-Set" code="3114" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Periodic-Communication-Indicator"/>
+				<gavp name="Communication-Duration-Time"/>
+				<gavp name="Periodic-Time"/>
+				<gavp name="Scheduled-Communication-Time"/>
+				<gavp name="Stationary-Indication"/>
+				<gavp name="Reference-ID-Validity-Time"/>
+			</grouped>
+		</avp>
+		<avp name="Periodic-Communication-Indicator" code="3115" mandatory="must" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Integer32"/>
+ 			<enum name="PERIODICALLY" code="0"/>
+ 			<enum name="ON_DEMAND" code="1"/>
+		</avp>
+		<avp name="Communication-Duration-Time" code="3116" mandatory="must" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Periodic-Time" code="3117" mandatory="must" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Scheduled-Communication-Time" code="3118" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Day-Of-Week-Mask"/>
+				<gavp name="Time-Of-Day-Start"/>
+				<gavp name="Time-Of-Day-End"/>
+			</grouped>
+		</avp>
+		<avp name="Stationary-Indication" code="3119" mandatory="must" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Integer32"/>
+			<enum name="STATIONARY_UE" code="0"/>
+			<enum name="MOBILE_UE" code="1"/>
+		</avp>
+		<avp name="AESE-Communication-Pattern-Config-Status" code="3120" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SCEF-Reference-ID"/>
+				<gavp name="SCEF-ID"/>
+				<gavp name="Periodic-Time"/>
+				<gavp name="AESE-Error-Report"/>
+			</grouped>
+		</avp>
+		<avp name="AESE-Error-Report" code="3121" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Service-Result"/>
+			</grouped>
+		</avp>
+		<avp name="Monitoring-Event-Configuration" code="3122" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SCEF-Reference-ID"/>
+				<gavp name="SCEF-ID"/>
+				<gavp name="Monitoring-Type"/>
+				<gavp name="SCEF-Reference-ID-for-Deletion"/>
+				<gavp name="Maximum-Number-of-Reports"/>
+				<gavp name="Monitoring-Duration"/>
+				<gavp name="Charged-Party"/>
+				<gavp name="UE-Reachability-Configuration"/>
+				<gavp name="Location-Information-Configuration"/>
+				<gavp name="Association-Type"/>
+				<gavp name="DL-Buffering-Suggested-Packet-Count"/>
+				<gavp name="PLMN-ID-Requested"/>
+			</grouped>
+		</avp>
+		<!-- Monitoring-Event-Report supports T6a/T6b and S6t, but AVP formats are not the same -->
+		<avp name="Monitoring-Event-Report" code="3123" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SCEF-Reference-ID"/>
+				<gavp name="SCEF-ID"/>
+				<gavp name="SCEF-Reference-ID-for-Deletion"/>
+				<gavp name="Visited-PLMN-Id"/>
+				<gavp name="Roaming-Information"/>
+				<gavp name="IMEI-Change"/>
+				<gavp name="Reachability-Information"/>
+				<gavp name="Maximum-UE-Availability-Time"/>
+				<gavp name="EPS-Location-Information"/>
+				<gavp name="Monitoring-Type"/>
+				<gavp name="Event-Handling"/>
+				<gavp name="Service-Report"/>
+				<gavp name="Loss-Of-Connectivity-Reason"/>
+				<gavp name="Idle-Status-Indication"/>
+				<gavp name="Communication-Failure-Information"/>
+				<gavp name="Number-Of-UE-Per-Location-Report"/>
+				<gavp name="Visited-PLMN-Id"/>
+			</grouped>
+		</avp>
+		<avp name="SCEF-Reference-ID" code="3124" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="SCEF-ID" code="3125" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+		<avp name="SCEF-Reference-ID-for-Deletion" code="3126" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Monitoring-Type" code="3127" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+			<enum name="LOSS_OF_CONNECTIVITY" code="0"/>
+			<enum name="UE_REACHABILITY" code="1"/>
+			<enum name="LOCATION_REPORTING" code="2"/>
+			<enum name="CHANGE_OF_IMSI_IMEI(SV)_ASSOCIATION" code="3"/>
+			<enum name="ROAMING_STATUS" code="4"/>
+			<enum name="COMMUNICATION_FAILURE" code="5"/>
+			<enum name="AVAILABILITY_AFTER_DDN_FAILURE" code="6"/>
+			<enum name="NUMBER_OF_UES_PRESENT_IN_A_GEOGRAPHICAL_AREA" code="7"/>
+			<enum name="UE_REACHABILITY_AND_IDLE_STATUS_INDICATION" code="8"/>
+			<enum name="AVAILABILITY_AFTER_DDN_FAILURE_AND_IDLE_STATUS_INDICATION" code="9"/>
+		</avp>
+		<avp name="Maximum-Number-of-Reports" code="3128" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="UE-Reachability-Configuration" code="3129" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Reachability-Type"/>
+				<gavp name="Maximum-Latency"/>
+				<gavp name="Maximum-Response-Time"/>
+				<gavp name="DL-Buffering-Suggested-Packet-Count"/>
+			</grouped>
+		</avp>
+		<avp name="Monitoring-Duration" code="3130" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Maximum-Detection-Time" code="3131" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Reachability-Type" code="3132" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+ 			<enum name="Reachability for SMS" code="1"/>
+ 			<enum name="Reachability for Data" code="2"/>
+		</avp>
+		<avp name="Maximum-Latency" code="3133" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Maximum-Response-Time" code="3134" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Location-Information-Configuration" code="3135" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="MONTE-Location-Type"/>
+				<gavp name="Accuracy"/>
+				<gavp name="Periodic-Time"/>
+			</grouped>
+		</avp>
+		<avp name="MONTE-Location-Type" code="3136" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+			<enum name="CURRENT_LOCATION" code="0"/>
+			<enum name="LAST_KNOWN_LOCATION" code="1"/>
+		</avp>
+		<avp name="Accuracy" code="3137" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+			<enum name="CGI-ECGI" code="0"/>
+			<enum name="eNB" code="1"/>
+			<enum name="LA-TA-RA" code="2"/>
+			<enum name="PRA" code="3"/>
+			<enum name="PLMN-ID" code="4"/>
+		</avp>
+		<avp name="Association-Type" code="3138" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+			<enum name="IMEI-CHANGE" code="0"/>
+			<enum name="IMEISV-CHANGE" code="1"/>
+		</avp>
+		<avp name="Roaming-Information" code="3139" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+			<enum name="SUBSCRIBER_ROAMING" code="0"/>
+			<enum name="SUBSCRIBER_NOT_ROAMING" code="1"/>
+		</avp>
+		<avp name="Reachability-Information" code="3140" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+			<enum name="REACHABLE_FOR_SMS" code="0"/>
+			<enum name="REACHABLE_FOR_DATA" code="1"/>
+		</avp>
+		<avp name="IMEI-Change" code="3141" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Monitoring-Event-Config-Status" code="3142" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Service-Report"/>
+				<gavp name="SCEF-Reference-ID"/>
+				<gavp name="SCEF-ID"/>
+			</grouped>
+		</avp>
+		<avp name="Supported-Services" code="3143" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Supported-Monitoring-Events"/>
+				<gavp name="Node-Type"/>
+			</grouped>
+		</avp>
+		<avp name="Supported-Monitoring-Events" code="3144" mandatory="must" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned64"/>
+		</avp>
+		<avp name="CIR-Flags" code="3145" mandatory="must" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Service-Result" code="3146" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Vendor-Id"/>
+				<gavp name="Service-Result-Code"/>
+			</grouped>
+		</avp>
+		<avp name="Service-Result-Code" code="3147" mandatory="must" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Reference-ID-Validity-Time" code="3148" mandatory="must" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Event-Handling" code="3149" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+			<enum name="SUSPEND" code="0"/>
+			<enum name="RESUME" code="1"/>
+			<enum name="CANCEL" code="2"/>
+		</avp>
+		<avp name="NIDD-Authorization-Request" code="3150" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Service-Selection"/>
+				<gavp name="Requested-Validity-Time"/>
+			</grouped>
+		</avp>
+		<avp name="NIDD-Authorization-Response" code="3151" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="MSISDN"/>
+				<gavp name="User-Name"/>
+				<gavp name="External-Identifier"/>
+				<gavp name="Granted-Validity-Time"/>
+			</grouped>
+		</avp>
+		<avp name="Service-Report" code="3152" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Service-Result"/>
+				<gavp name="Node-Type"/>
+			</grouped>
+		</avp>
+		<avp name="Node-Type" code="3153" mandatory="must" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+			<enum name="HSS" code="0"/>
+			<enum name="MME" code="1"/>
+			<enum name="SGSN" code="2"/>
+		</avp>
+		<avp name="S6t-HSS-Cause" code="3154" mandatory="must" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Enhanced-Coverage-Restriction" code="3155" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Restricted-PLMN-List"/>
+				<gavp name="Allowed-PLMN-List"/>
+			</grouped>
+		</avp>
+		<avp name="Enhanced-Coverage-Restriction-Data" code="3156" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Enhanced-Coverage-Restriction"/>
+				<gavp name="Visited-PLMN-Id"/>
+			</grouped>
+		</avp>
+		<avp name="Restricted-PLMN-List" code="3157" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Visited-PLMN-Id"/>
+			</grouped>
+		</avp>
+		<avp name="Allowed-PLMN-List" code="3158" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Visited-PLMN-Id"/>
+			</grouped>
+		</avp>
+		<avp name="Requested-Validity-Time" code="3159" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="Granted-Validity-Time" code="3160" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="NIDD-Authorization-Update" code="3161" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="MSISDN"/>
+				<gavp name="User-Name"/>
+				<gavp name="External-Identifier"/>
+				<gavp name="Granted-Validity-Time"/>
+			</grouped>
+		</avp>
+		<avp name="Loss-Of-Connectivity-Reason" code="3162" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+			<enum name="UE_DETACHED_MME" code="0"/>
+			<enum name="UE_DETACHED_SGSN" code="1"/>
+			<enum name="MAX_DETECTION_TIME_EXPIRED_MME" code="2"/>
+			<enum name="MAX_DETECTION_TIME_EXPIRED_SGSN" code="3"/>
+			<enum name="UE_PURGED_MME" code="4"/>
+			<enum name="UE_PURGED_SGSN" code="5"/>
+		</avp>
+		<avp name="Group-Reporting-Guard-Timer" code="3163" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="CIA-Flags" code="3164" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Group-Monitoring-Event-Report" code="3165" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+			<gavp name="SCEF-Reference-ID"/>
+			<gavp name="SCEF-ID"/>
+			<gavp name="Group-Monitoring-Event-Report-Item"/>
+			</grouped>
+		</avp>
+		<avp name="Group-Monitoring-Event-Report-Item" code="3166" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+			<gavp name="User-Identifier"/>
+				<gavp name="Visited-PLMN-Id"/>
+				<gavp name="Roaming-Information"/>
+				<gavp name="Reachability-Information"/>
+				<gavp name="Maximum-UE-Availability-Time"/>
+				<gavp name="EPS-Location-Information"/>
+				<gavp name="Monitoring-Type"/>
+				<gavp name="Service-Report"/>
+				<gavp name="S6t-HSS-Cause"/>
+			</grouped>
+		</avp>
+		<avp name="RIR-Flags" code="3167" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Type-Of-External-Identifier" code="3168" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+			<enum name="EXTERNAL-UE-IDENTIFIER-TYPE" code="0"/>
+			<enum name="EXTERNAL-GROUP-IDENTIFIER-TYPE" code="1"/>
+		</avp>
+		<avp name="APN-Validity-Time" code="3169" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+			<gavp name="Granted-Validity-Time"/>
+				<gavp name="Service-Selection"/>
+			</grouped>
+		</avp>
+		<avp name="Suggested-Network-Configuration" code="3170" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SCEF-Reference-ID"/>
+				<gavp name="SCEF-ID"/>
+				<gavp name="Subscribed-Periodic-RAU-TAU-Timer"/>
+				<gavp name="Active-Time"/>
+				<gavp name="DL-Buffering-Suggested-Packet-Count"/>
+				<gavp name="Group-Reporting-Guard-Timer"/>
+			</grouped>
+		</avp>
+		<avp name="Monitoring-Event-Report-Status" code="3171" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SCEF-Reference-ID"/>
+				<gavp name="SCEF-ID"/>
+				<gavp name="Result-Code"/>
+				<gavp name="Experimental-Result-Code"/>
+			</grouped>
+		</avp>
+		<avp name="PLMN-ID-Requested" code="3172" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="TRUE" code="0"/>
+			<enum name="FALSE" code="1"/>
+		</avp>
+		<avp name="AdditionalIdentifiers" code="3173" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="External-Identifier"/>
+			</grouped>
+		</avp>
+		<avp name="NIR-Flags" code="3174" mandatory="mustnot" may-encrypt="no" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+
+		<!--
+		Note: The AVP codes from 3163 to 3199 are reserved for TS 29.336
+		-->
+
+		<avp name="SM-Delivery-Outcome-T4" code="3200" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="ABSENT_SUBSCRIBER" code="0"/>
+			<enum name="UE_MEMORTY_CAPACITY_EXCEEDED" code="1"/>
+			<enum name="SUCCESSFUL_TRANSFER" code="2"/>
+		</avp>
+		<avp name="Absent-Subscriber-Diagnostic-T4" code="3201" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NO_PAGING_RESPONSE" code="0"/>
+			<enum name="UE_DETACHED" code="1"/>
+			<enum name="UE_DEREGISTERED" code="2"/>
+			<enum name="UE_PURGED" code="3"/>
+			<enum name="ROAMING_RESTRICTION" code="4"/>
+			<enum name="UNIDENTIFIED_SUBSCRIBER" code="5"/>
+		</avp>
+		<avp name="Trigger-Action" code="3202" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="MTC-Error-Diagnostic" code="3203" mandatory="mustnot" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+
+		<!--
+		Note: The AVP codes from 3206 to 3308 are reserved for TS 29.338
+		-->
+
+
+		<avp name="Reason-Header" code="3401" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Instance-Id" code="3402" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Route-Header-Received" code="3403" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Route-Header-Transmitted" code="3404" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="SM-Device-Trigger-Information" code="3405" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="MTC-IWF-Address"/>
+				<gavp name="Reference-Number"/>
+				<gavp name="Serving-Node"/>
+				<gavp name="Validity-Time"/>
+				<gavp name="Priority-Indication"/>
+				<gavp name="Application-Port-Identifier"/>
+			</grouped>
+		</avp>
+		<avp name="MTC-IWF-Address" code="3406" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="SM-Device-Trigger-Indicator" code="3407" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Not DeviceTrigger" code="0"/>
+			<enum name="DeviceTrigger" code="1"/>
+		</avp>
+		<avp name="SM-Sequence-Number" code="3408" mandatory="must" vendor-bit="must" protected="may" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="SMS-Result" code="3409" mandatory="must" vendor-bit="must" protected="may" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="VCS-Information" code="3410" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Bearer-Capability"/>
+				<gavp name="Network-Call-Reference-Number"/>
+				<gavp name="MSC-Address"/>
+				<gavp name="Basic-Service-Code"/>
+				<gavp name="ISUP-Location-Number"/>
+				<gavp name="VLR-Number"/>
+				<gavp name="Forwarding-Pending"/>
+				<gavp name="ISUP-Release-Cause"/>
+				<gavp name="Start-Time"/>
+				<gavp name="Start-of-Charging"/>
+				<gavp name="Stop-Time"/>
+				<gavp name="PS-Free-Format-Data"/>
+			</grouped>
+		</avp>
+		<avp name="Basic-Service-Code" code="3411" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Bearer-Service"/>
+				<gavp name="Teleservice"/>
+			</grouped>
+		</avp>
+		<avp name="Bearer-Capability" code="3412" mandatory="must" vendor-bit="must" protected="may" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Teleservice" code="3413" mandatory="must" vendor-bit="must" protected="may" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="ISUP-Location-Number" code="3414" mandatory="must" vendor-bit="must" protected="may" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Forwarding-Pending" code="3415" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Forwarding not pending" code="0"/>
+			<enum name="Forwarding pending" code="1"/>
+		</avp>
+		<avp name="ISUP-Release-Cause" code="3416" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="ISUP-Cause-Location"/>
+				<gavp name="ISUP-Cause-Value"/>
+				<gavp name="ISUP-Cause-Diagnostics"/>
+			</grouped>
+		</avp>
+		<avp name="MSC-Address" code="3417" mandatory="must" vendor-bit="must" protected="may" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Network-Call-Reference-Number" code="3418" mandatory="must" vendor-bit="must" protected="may" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Start-of-Charging" code="3419" mandatory="must" vendor-bit="must" protected="may" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Time"/>
+		</avp>
+		<avp name="VLR-Number" code="3420" mandatory="must" vendor-bit="must" protected="may" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="CN-Operator-Selection-Entity" code="3421" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="The serving network has been selected by the UE" code="0"/>
+			<enum name="The serving network has been selected by the network" code="1"/>
+		</avp>
+		<avp name="ISUP-Cause-Diagnostics" code="3422" mandatory="must" vendor-bit="must" protected="may" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="ISUP-Cause-Location" code="3423" mandatory="must" vendor-bit="must" protected="may" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="ISUP-Cause-Value" code="3424" mandatory="must" vendor-bit="must" protected="may" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="ePDG-Address" code="3425" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Announcing-UE-HPLMN-Identifier" code="3426" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Announcing-UE-VPLMN-Identifier" code="3427" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Coverage-Status" code="3428" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Out of coverage" code="0"/>
+			<enum name="In coverage" code="1"/>
+		</avp>
+		<avp name="Layer-2-Group-ID" code="3429" mandatory="must" vendor-bit="must" protected="may" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Monitored-PLMN-Identifier" code="3430" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Monitoring-UE-HPLMN-Identifier" code="3431" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Monitoring-UE-Identifier" code="3432" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Monitoring-UE-VPLMN-Identifier" code="3433" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="PC3-Control-Protocol-Cause" code="3434" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="PC3-EPC-Control-Protocol-Cause" code="3435" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Requested-PLMN-Identifier" code="3436" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Requestor-PLMN-Identifier" code="3437" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Role-Of-ProSe-Function" code="3438" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="HPLMN" code="0"/>
+			<enum name="VPLMN" code="0"/>
+			<enum name="Local PLMN" code="0"/>
+		</avp>
+		<avp name="Usage-Information-Report-Sequence-Number" code="3439" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="ProSe-3rd-Party-Application-ID" code="3440" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<!--
+		Note: The AVP codes from 3400 to 3499 are reserved for TS 32.299
+		-->
+
+		<avp name="Enhanced-Diagnostics" code="3901" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<grouped>
+				<gavp name="RAN-NAS-Release-Cause"/>
+			</grouped>
+		</avp>
+		<avp name="Inter-UE-Transfer" code="3902" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Intra-UE transfer" code="0"/>
+			<enum name="Inter-UE transfer" code="1"/>
+		</avp>
+		<avp name="TWAG-Address" code="3903" mandatory="must" may-encrypt="no" protected="may" vendor-bit="must" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="Announcement-Information" code="3904" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+		<grouped>
+			<gavp name="Announcement-Identifier"/>
+			<gavp name="Variable-Part"/>
+			<gavp name="Time-Indicator"/>
+			<gavp name="Quota-Indicator"/>
+			<gavp name="Announcement-Order"/>
+			<gavp name="Play-Alternative"/>
+			<gavp name="Privacy-Indicator"/>
+			<gavp name="Language"/>
+		</grouped>
+		</avp>
+		<avp name="Announcement-Identifier" code="3905" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Announcement-Order" code="3906" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Variable-Part" code="3907" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Variable-Part-Order"/>
+				<gavp name="Variable-Part-Type"/>
+				<gavp name="Variable-Part-Value"/>
+			</grouped>
+		</avp>
+		<avp name="Variable-Part-Order" code="3908" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Variable-Part-Type" code="3909" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+			<enum name="Integer" code="0"/>
+			<enum name="Number" code="1"/>
+			<enum name="Time" code="2"/>
+			<enum name="Date" code="3"/>
+			<enum name="Currency" code="4"/>
+		</avp>
+		<avp name="Variable-Part-Value" code="3910" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Time-Indicator" code="3911" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Quota-Indicator" code="3912" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="QUOTA_IS_NOT_USED_DURING_PLAYBACK" code="0"/>
+			<enum name="QUOTA_IS_USED_DURING_PLAYBACK" code="1"/>
+		</avp>
+		<avp name="Play-Alternative" code="3913" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="served party" code="0"/>
+			<enum name="remote party" code="1"/>
+		</avp>
+		<avp name="Language" code="3914" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Privacy-Indicator" code="3915" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="NOT_PRIVATE" code="0"/>
+			<enum name="PRIVATE" code="1"/>
+		</avp>
+		<avp name="Called-Identity" code="3916" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Called-Identity-Change" code="3917" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Called-Identity"/>
+				<gavp name="Change-Time"/>
+			</grouped>
+		</avp>
+		<avp name="UWAN-User-Location-Info" code="3918" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="UE-Local-IP-Address"/>
+				<gavp name="UDP-Source-Port"/>
+				<gavp name="SSID"/>
+				<gavp name="BSSID"/>
+			</grouped>
+		</avp>
+		<avp name="Monitoring-Event-Configuration-Activity" code="3919" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Monitoring-Event-Report-Data" code="3920" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Event-Timestamp"/>
+				<gavp name="SCEF-Reference-ID"/>
+				<gavp name="SCEF-ID"/>
+				<gavp name="Monitoring-Event-Report-Number"/>
+				<gavp name="Charged-Party"/>
+				<gavp name="Subscription-Id"/>
+				<gavp name="Monitoring-Type"/>
+				<gavp name="Reachability-Information"/>
+				<gavp name="EPS-Location-Information"/>
+				<gavp name="Communication-Failure-Information"/>
+				<gavp name="Number-Of-UE-Per-Location-Report"/>
+			</grouped>
+		</avp>
+		<avp name="Monitoring-Event-Information" code="3921" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Monitoring-Event-Functionality"/>
+				<gavp name="Event-Timestamp"/>
+				<gavp name="SCEF-Reference-ID"/>
+				<gavp name="SCEF-ID"/>
+				<gavp name="Monitoring-Type"/>
+				<gavp name="Maximum-Number-of-Reports"/>
+				<gavp name="Monitoring-Duration"/>
+				<gavp name="Charged-Party"/>
+				<gavp name="Maximum-Detection-Time"/>
+				<gavp name="UE-Reachability-Configuration"/>
+				<gavp name="MONTE-Location-Type"/>
+				<gavp name="Accuracy"/>
+				<gavp name="Number-Of-UE-Per-Location-Configuration"/>
+				<gavp name="Monitoring-Event-Report"/>
+			</grouped>
+		</avp>
+		<avp name="Monitoring-Event-Functionality" code="3922" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Integer32"/>
+		</avp>
+		<avp name="Monitoring-Event-Report-Number" code="3923" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Cellular-Network-Information " code="3924" mandatory="must" vendor-bit="must" may-encrypt="no" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Related-Change-Condition-Information" code="3925" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SGSN-Address"/>
+				<gavp name="Change-Condition"/>
+				<gavp name="3GPP-User-Location-Info"/>
+				<gavp name="3GPP2-BSID"/>
+				<gavp name="UWAN-User-Location-Info"/>
+				<gavp name="Presence-Reporting-Area-Status"/>
+				<gavp name="User-CSG-Information"/>
+				<gavp name="3GPP-RAT-Type"/>
+			</grouped>
+		</avp>
+		<avp name="CP-CIoT-EPS-Optimisation-Indicator" code="3930" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Not Apply" code ="0"/>
+			<enum name="Apply" code="1"/>
+		</avp>
+		<avp name="SGi-PtP-Tunnelling-Method" code="3931" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="UDP_IP_based" code="0"/>
+			<enum name="Others" code="1"/>
+		</avp>
+		<avp name="UNI-PDU-CP-Only-Flag" code="3932" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="UNI-PDU-both-UP-CP" code="0"/>
+			<enum name="UNI-PDU-CP-Only" code="1"/>
+		</avp>
+		<avp name="APN-Rate-Control" code="3933" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<grouped>
+				<gavp name="APN-Rate-Control-Uplink"/>
+				<gavp name="APN-Rate-Control-Downlink"/>
+			</grouped>
+		</avp>
+		<avp name="APN-Rate-Control-Downlink" code="3934" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Rate-Control-Time-Unit"/>
+				<gavp name="Rate-Control-Max-Rate"/>
+				<gavp name="Rate-Control-Max-Message-Size"/>
+			</grouped>
+		</avp>
+		<avp name="APN-Rate-Control-Uplink" code="3935" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Additional-Exception-Reports"/>
+				<gavp name="Rate-Control-Time-Unit"/>
+				<gavp name="Rate-Control-Max-Rate"/>
+				<gavp name="Rate-Control-Max-Message-Size"/>
+			</grouped>
+		</avp>
+		<avp name="Additional-Exception-Reports" code="3936" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Not Allowed" code="0"/>
+			<enum name="Allowed" code="1"/>
+		</avp>
+		<avp name="Rate-Control-Max-Message-Size" code="3937" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Rate-Control-Max-Rate" code="3938" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="Rate-Control-Time-Unit" code="3939" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="Unsigned32"/>
+		</avp>
+		<avp name="SCS-AS-Address" code="3940" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<grouped>
+				<gavp name="SCS-Realm"/>
+				<gavp name="SCS-Address"/>
+			</grouped>
+		</avp>
+		<avp name="SCS-Address" code="3941" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="IPAddress"/>
+		</avp>
+		<avp name="SCS-Realm" code="3942" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="DiameterIdentity"/>
+		</avp>
+
+		<!--
+		Note: The AVP codes from 3900 to 3999 are reserved for TS 32.299
+		-->
+
+		<avp name="eNodeB-ID" code="4008" mandatory="must" vendor-bit="must" protected="may" may-encrypt="yes" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+		<avp name="Extended-eNodeB-ID" code="4013" mandatory="must" vendor-bit="must" protected="may" may-encrypt="yes" vendor-id="TGPP">
+			<type type-name="OctetString"/>
+		</avp>
+
+		<!--
+		Note: The AVP codes from 4000 to 4013 are reserved for TS 29.217
+		-->
+
+		<avp name="Charging-Per-IP-CAN-Session-Indicator" code="4400" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Inactive" code="0"/>
+			<enum name="Active" code="1"/>
+		</avp>
+		<avp name="Access-Network-Info-Change" code="4401" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<grouped>
+				<gavp name="Access-Network-Information"/>
+				<gavp name="Cellular-Network-Information"/>
+				<gavp name="Change-Time"/>
+			</grouped>
+		</avp>
+		<avp name="Discoveree-UE-HPLMN-Identifier" code="4402" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Discoveree-UE-VPLMN-Identifier" code="4403" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Discoverer-UE-HPLMN-Identifier" code="4404" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="Discoverer-UE-VPLMN-Identifier" code="4405" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="UTF8String"/>
+		</avp>
+		<avp name="3GPP-PS-Data-Off-Status" code="4406" mandatory="must" vendor-bit="must" may-encrypt="no" protected="may" vendor-id="TGPP">
+			<type type-name="Enumerated"/>
+			<enum name="Active" code="0"/>
+			<enum name="Inactive" code="1"/>
+		</avp>
+		<!--
+		Note: The AVP codes from 4400 to 4499 are reserved for TS 32.299
+		-->
+	</base>
+
+	<!-- ********************************************************************** -->
+	<!-- ************************* Application IDs **************************** -->
+	<!-- ********************************************************************** -->
+	<application id="0"		name="Diameter Common Messages"		uri="http://tools.ietf.org/html/rfc6733"/>
+	<!-- application 1		is defined in nasreq.xml -->
+	<!-- application 2		is defined in mobileipv4.xml -->
+	<application id="3"		name="Diameter Base Accounting"		uri="http://tools.ietf.org/html/rfc6733"/>
+	<!-- application 4		is defined in chargecontrol.xml -->
+	<!-- application 5		is defined in eap.xml -->
+	<!-- application 6		is defined in sip.xml -->
+	<!-- application 7		is defined in mobileipv6.xml -->
+	<!-- application 8		is defined in mobileipv6.xml -->
+	<application id="9"		name="Diameter QoS application"		uri="http://tools.ietf.org/html/rfc5866"/>
+	<application id="10"		name="Diameter Capabilities Update"	uri="http://tools.ietf.org/html/rfc6737"/>
+	<application id="11"		name="Diameter IKE SK (IKESK)"		uri="http://tools.ietf.org/html/rfc6738"/>
+	<application id="12"		name="Diameter NAT Control Application"	uri="http://tools.ietf.org/html/rfc6736"/>
+	<application id="13"		name="Diameter ERP"			uri="http://tools.ietf.org/html/rfc6942"/>
+
+	<!-- application 16777216	is defined in TGPP.xml -->
+	<!-- application 16777217	is defined in TGPP.xml -->
+	<application id="16777218"	name="3GPP Re/Rf"			uri="http://www.3GPP.org/ftp/Specs/html-info/32296.htm"/>
+	<application id="16777219"	name="3GPP Wx"				uri="http://www.3GPP.org/ftp/Specs/html-info/29234.htm"/>
+	<application id="16777220"	name="3GPP Zn"				uri="http://www.3GPP.org/ftp/Specs/html-info/29109.htm"/>
+	<application id="16777221"	name="3GPP Zh"				uri="http://www.3GPP.org/ftp/Specs/html-info/29109.htm"/>
+	<!-- application 16777222	is defined in TGPP.xml -->
+	<!-- application 16777223	is defined in TGPP.xml -->
+	<application id="16777224"	name="3GPP Gx"				uri="http://www.3gpp.org/ftp/Specs/html-info/29210.htm"/>
+	<application id="16777225"	name="3GPP Gx over Gy"			uri="http://www.3GPP.org/ftp/Specs/html-info/29210.htm"/>
+	<application id="16777226"	name="3GPP MM10"			uri="http://www.3GPP.org/ftp/Specs/html-info/29140.htm"/>
+	<!-- application 16777227	is defined in Ericsson.xml -->
+	<!-- application 16777228	is defined in Ericsson.xml -->
+	<application id="16777229"	name="3GPP Rx Release 6"		uri="http://www.3GPP.org/ftp/Specs/html-info/29211.htm"/>
+	<application id="16777230"	name="3GPP Pr"				uri="http://www.3gpp.org/ftp/Specs/html-info/29234.htm"/>
+	<!-- application 16777231	is defined in etsie2e4.xml -->
+	<!-- application 16777232	is defined in Ericsson.xml -->
+	<!-- application 16777233	is defined in Ericsson.xml -->
+	<!-- application 16777234	is defined in Vodafone.xml -->
+	<application id="16777235"	name="ITU-T Rs"				uri="http://www.itu.int/ITU-T/recommendations/rec.aspx?rec=11971"/>
+	<!-- application 16777236	is defined in TGPP.xml -->
+	<!-- application 16777237	is defined in TGPP2.xml -->
+	<application id="16777238"	name="3GPP Gx"				uri="http://www.3GPP.org/ftp/Specs/html-info/29210.htm"/>
+	<application id="16777239"	name="Juniper Cluster"			uri="none"/>
+	<application id="16777240"	name="Juniper Policy-Control-AAA"	uri="none"/>
+	<application id="16777241"	name="iptego USPI"			uri="none"/>
+	<application id="16777242"	name="Covergence-specific SIP routing"	uri="none"/>
+	<application id="16777243"	name="Policy Processing"		uri="none"/>
+	<application id="16777244"	name="Juniper Policy-Control-JSRC"	uri="none"/>
+	<application id="16777245"	name="ITU-T S-TC1"			uri="http://www.itu.int/ITU-T/recommendations/rec.aspx?rec=9340"/>
+	<!-- application 16777246	is defined in NokiaSolutionsAndNetworks.xml -->
+	<application id="16777247"	name="3GPP2 CAN Access Authentication and Authorization"	uri="http://www.3gpp2.org/Public_html/specs/X.S0054-100-0_v2.0_080909.pdf"/>
+	<application id="16777248"	name="3GPP2 WLAN Interworking Access Authentication and Authorization"	uri="http://www.3gpp2.org/Public_html/specs/X.S0028-200-A_v1.0_080625.pdf"/>
+	<application id="16777249"	name="3GPP2 WLAN Interworking Accounting"	uri="http://www.3gpp2.org/Public_html/specs/X.S0028-200-A_v1.0_080625.pdf"/>
+	<application id="16777250"	name="3GPP STa"				uri="http://www.3gpp.org/ftp/Specs/html-info/29273.htm"/>
+	<application id="16777251"	name="3GPP S6a/S6d"			uri="http://tools.ietf.org/html/rfc5516"/>
+	<application id="16777252"	name="3GPP S13/S13'"			uri="http://tools.ietf.org/html/rfc5516"/>
+	<application id="16777253"	name="ETSI Re"				uri="http://www.etsi.org/deliver/etsi_ts%5C183000_183099%5C183060%5C03.01.01_60%5Cts_183060v030101p.pdf"/>
+	<application id="16777254"	name="ETSI GOCAP"			uri="http://www.etsi.org/deliver/etsi_es%5C283000_283099%5C28303902%5C03.01.01_60%5Ces_28303902v030101p.pdf"/>
+	<application id="16777255"	name="3GPP SLg"				uri="http://www.3gpp.org/ftp/Specs/html-info/29172.htm"/>
+	<application id="16777256"	name="ITU-T Rw"				uri="https://tools.ietf.org/html/rfc5431"/>
+	<application id="16777257"	name="ETSI a4"				uri="http://www.etsi.org/deliver/etsi_ts%5C183000_183099%5C183066%5C02.01.01_60%5Cts_183066v020101p.pdf"/>
+	<application id="16777258"	name="ITU-T Rt"				uri="http://www.itu.int/ITU-T/recommendations/rec.aspx?rec=11450"/>
+	<application id="16777259"	name="CARA"				uri="none"/>
+	<application id="16777260"	name="CAMA"				uri="none"/>
+	<application id="16777261"	name="Femtocell extension to Diameter EAP Application" uri="none"/>
+	<application id="16777262"	name="ITU-T Ru"				uri="none"/>
+	<application id="16777263"	name="ITU-T Ng"				uri="none"/>
+	<application id="16777264"	name="3GPP SWm"				uri="http://www.3gpp.org/ftp/Specs/html-info/29273.htm"/>
+	<application id="16777265"	name="3GPP SWx"				uri="http://www.3gpp.org/ftp/Specs/html-info/29273.htm"/>
+	<application id="16777266"	name="3GPP Gxx"				uri="http://www.3gpp.org/ftp/Specs/html-info/29212.htm"/>
+	<!-- application 16777267	is defined in TGPP.xml -->
+	<application id="16777268"	name="3GPP Zpn"				uri="http://www.3gpp.org/ftp/Specs/html-info/29109.htm"/>
+	<!-- application 16777269	is defined in Ericsson.xml -->
+	<application id="16777270"	name="Juniper-Example"			uri="none"/>
+	<application id="16777271"	name="ITU-T Ri"				uri="http://www.itu.int/ITU-T/recommendations/rec.aspx?rec=9881"/>
+	<application id="16777272"	name="3GPP S6b"				uri="http://www.3gpp.org/ftp/Specs/html-info/29273.htm"/>
+	<application id="16777273"	name="Juniper JGx"			uri="none"/>
+	<application id="16777274"	name="ITU-T Rd"				uri="http://www.itu.int/ITU-T/recommendations/rec.aspx?rec=10224"/>
+	<application id="16777275"	name="ADMI Notification Application"	uri="none"/>
+	<application id="16777276"	name="ADMI Messaging Interface Application"	uri="none"/>
+	<application id="16777277"	name="Peter-Service VSI"		uri="none"/>
+	<application id="16777278"	name="ETSI Rr request model"		uri="http://www.etsi.org/deliver/etsi_ts%5C183000_183099%5C183071%5C03.01.01_60%5Cts_183071v030101p.pdf"/>
+	<application id="16777279"	name="ETSI Rr delegated model"		uri="http://www.etsi.org/deliver/etsi_ts%5C183000_183099%5C183071%5C03.01.01_60%5Cts_183071v030101p.pdf"/>
+			<!--
+			 16777280 WIMAX HRPD Interworking [3GPP2 X.S0058-0 v1.0][Avi_Lior]
+			 16777281 WiMAX Network Access Authentication and Authorization Diameter Application (WNAAADA) [WiMAX Release 1.5][Avi_Lior]
+			 16777282 WiMAX Network Accounting Diameter Application (WNADA) [WiMAX Release 1.5][Avi_Lior]
+			 16777283 WiMAX MIP4 Diameter Application (WM4DA) [WiMAX Release 1.5][Avi_Lior]
+			 16777284 WiMAX MIP6 Diameter Application (WM6DA) [WiMAX Release 1.5][Avi_Lior]
+			 16777285 WiMAX DHCP Diameter Application (WDDA) [WiMAX Release 1.5][Avi_Lior]
+			 16777286 WiMAX-Location-Authentication-Authorization Diameter Application (WLAADA) [WiMAX Release 1.5][Avi_Lior]
+			 16777287 WiMAX-Policy-and-Charging-Control-R3-Policies Diameter Application (WiMAX PCC-R3-P) [WiMAX Release 1.5][Avi_Lior]
+			 16777288 WiMAX-Policy-and-Charging-Control-R3-OFfline-Charging Diameter Application (WiMAX PCC-R3-OFC) [WiMAX Release 1.5][Avi_Lior]
+			 16777289 WiMAX-Policy-and-Charging-Control-R3-Offline-Charging-Prime Diameter Application (WiMAX PCC-R3-OFC-PRIME) [WiMAX Release 1.5][Avi_Lior]
+			 16777290 WiMAX-Policy-and-Charging-Control-R3-Online-Charging Diameter Application (WiMAX PCC-R3-OC) [WiMAX Release 1.5][Avi_Lior]
+			-->
+	<application id="16777291"	name="3GPP SLh"				uri="http://www.3gpp.org/ftp/Specs/html-info/29173.htm"/>
+	<!-- application 16777292	is defined in TGPP.xml -->
+	<application id="16777293"	name="Cloudmark Diameter Interface"	uri="none"/>
+	<application id="16777294"	name="Camiant DRMA"			uri="none"/>
+	<application id="16777295"	name="PiLTE Interworking Diameter Application" uri="http://www.3gpp2.org/Public_html/specs/X.S0057-0%20v3.0%20(clean)%20E-UTRAN-eHRPD%20Interworking.pdf"/>
+	<application id="16777296"	name="Juniper-Sessions-Recovery"	uri="none"/>
+	<application id="16777297"	name="Vedicis LiveProxy"		uri="none"/>
+	<application id="16777298"	name="Pi*3GPP2 Diameter Application"	uri="http://www.3gpp2.org/Public_html/specs/X.S0057-A%20v2.0_20121018.pdf"/>
+	<application id="16777299"	name="Sandvine Rf+"			uri="none"/>
+	<application id="16777300"	name="Subscription Information Application" uri="none"/>
+	<!-- application 16777301	is defined in Ericsson.xml -->
+	<application id="16777302"	name="3GPP Sy"				uri="http://www.3gpp.org/ftp/Specs/html-info/29219.htm"/>
+	<application id="16777303"	name="3GPP Sd"				uri="http://www.3gpp.org/ftp/Specs/html-info/29212.htm"/>
+	<!-- application 16777304	is defined in Ericsson.xml -->
+	<application id="16777305"	name="HP DTD"				uri="none"/>
+	<application id="16777306"	name="ITU-T M9"				uri="http://www.itu.int/ITU-T/recommendations/rec.aspx?rec=11570"/>
+	<application id="16777307"	name="ITU-T M13"			uri="http://www.itu.int/ITU-T/recommendations/rec.aspx?rec=11712"/>
+	<application id="16777308"	name="3GPP S7a"				uri="http://www.3gpp.org/ftp/Specs/html-info/29272.htm"/>
+	<application id="16777309"	name="3GPP Tsp"				uri="http://www.3gpp.org/ftp/Specs/html-info/29368.htm"/>
+	<application id="16777310"	name="3GPP S6m"				uri="http://www.3gpp.org/ftp/Specs/html-info/29336.htm"/>
+	<application id="16777311"	name="3GPP T4"				uri="http://www.3gpp.org/ftp/Specs/html-info/29337.htm"/>
+  <!-- application 16777312 3GPP S6c"is defined in TGPP.xml -->
+	<application id="16777313"	name="3GPP SGd"				uri="http://www.3gpp.org/ftp/Specs/html-info/29338.htm"/>
+	<application id="16777314"	name="Intrado-SLg"			uri="none"/>
+	<!-- application 16777315	is defined in Ericsson.xml -->
+	<application id="16777316"	name="Verizon-Femto-Loc"		uri="none"/>
+	<!-- application 16777317	is defined in NokiaSolutionsAndNetworks.xml -->
+	<application id="16777318"	name="3GPP S15"				uri="http://www.3gpp.org/ftp/Specs/html-info/29212.htm"/>
+	<application id="16777319"	name="3GPP S9a"				uri="http://www.3gpp.org/ftp/Specs/html-info/29215.htm"/>
+	<application id="16777320"	name="3GPP S9a*"			uri="http://www.3gpp.org/ftp/Specs/html-info/29215.htm"/>
+	<application id="16777321"	name="Gateway Location Application"	uri="none"/>
+	<application id="16777322"	name="Verizon Session Recovery"		uri="none"/>
+	<!-- application 16777323	is defined in TGPP2.xml -->
+	<application id="16777324"	name="MAGIC Client Interface Protocol (CIP)" uri="none"/>
+	<application id="16777325"	name="ITU-T Nc"				uri="http://www.itu.int/ITU-T/recommendations/rec.aspx?rec=12217"/>
+	<application id="16777326"	name="ITU-T Ne"				uri="none"/>
+	<!-- application 16777327	is defined in Ericsson.xml -->
+	<!-- application 16777328	is defined in Nokia.xml -->
+	<application id="16777329"	name="Rivada Xd"			uri="none"/>
+	<application id="16777330"	name="Rivada Xm"			uri="none"/>
+	<application id="16777331"	name="Rivada Xh"			uri="none"/>
+	<application id="16777332"	name="Rivada Xf"			uri="none"/>
+	<application id="16777333"	name="Rivada Xf"			uri="none"/>
+	<application id="16777334"	name="Rivada Xp"			uri="none"/>
+	<application id="16777335"	name="3GPP MB2-C"			uri="http://www.3gpp.org/ftp/Specs/html-info/29468.htm"/>
+	<!-- application 16777336 (3GPP PC4a)	is defined in TGPP.xml -->
+	<application id="16777337"	name="3GPP PC2"				uri="http://www.3gpp.org/ftp/Specs/html-info/29343.htm"/>
+	<application id="16777338"	name="Juniper Domain Policy"		uri="none"/>
+	<application id="16777339"	name="Host Observer"			uri="none"/>
+	<application id="16777340"	name="3GPP PC6/PC7"			uri="http://www.3gpp.org/ftp/Specs/html-info/29345.htm"/>
+	<!-- application 16777341	is defined in Nokia.xml -->
+	<application id="16777342"	name="3GPP Np"				uri="http://www.3gpp.org/ftp/Specs/html-info/29217.htm"/>
+	<!-- application 16777346	is defined in TGPP.xml -->
+	<application id="16777999"	name="S6b Application (One-AAA)"	uri="none"/>
+  <!--
+16777341 Nokia Sdr Application [Timo_Perala]
+16777342 3GPP Np [3GPP TS 29.217][Kimmo_Kymalainen]
+16777343 Sandvine Location Relay Service [Inian_Vasanth]
+16777344 Sandvine Fairshare Traffic Management Service [Inian_Vasanth]
+-->
+  	<application id="16777345"	name="3GPP S6t"	uri="http://www.3gpp.org/ftp/Specs/archive/29_series/29.336/29336-e20.zip"/>
+<!--
+16777347 3GPP Ns [3GPP TS 29.153][Kimmo_Kymalainen]
+16777348 3GPP Nt [3GPP TS 29.154][Kimmo_Kymalainen]
+  -->
+	<application id="4294967295"	name="Relay"				uri="http://tools.ietf.org/html/rfc6733"/>
+	<!-- *********************** End Application IDs ************************** -->
+
+
+	<!-- ************************************************************** -->
+	<!-- ************************* Vendors **************************** -->
+	<!-- ************************************************************** -->
+	<vendor vendor-id="None"			code="0"	name="None"/>
+	<vendor vendor-id="Merit"			code="61"	name="Merit Networks"/>
+	<vendor vendor-id="USR"				code="429"	name="US Robotics Corp."/>
+	<vendor vendor-id="Lucent"			code="1751"	name="Lucent Technologies"/>
+	<vendor vendor-id="Deutsche_Telekom_AG"		code="2937"	name="Deutsche Telekom AG"/>
+	<vendor vendor-id="Acision"			code="3830"	name="Acision"/>
+	<vendor vendor-id="SKT"				code="5806"	name="SK Telecom"/>
+	<vendor vendor-id="TGPP"			code="10415"	name="3GPP"/>
+	<vendor vendor-id="ETSI"			code="13019"	name="ETSI"/>
+	<vendor vendor-id="Tango"			code="13421"	name="Tango Telecom Limited"/>
+	<vendor vendor-id="ChinaTelecom"		code="81000"	name="China Telecom"/>
+	<vendor vendor-id="TGPPCX"			code="16777216"	name="3GPP CX/DX"/>
+	<!-- *********************** End Vendors ************************** -->
+
+	&nasreq;
+	&eap;
+	&mobileipv4;
+	&chargecontrol;
+	&sunping;
+	&TGPP;
+	&TGPP2;
+	&sip;
+	&etsie2e4;
+	&Ericsson;
+	&mobileipv6;
+	&Cisco;
+	&Starent;
+	&Vodafone;
+	&AlcatelLucent;
+	&Nokia;
+	&NokiaSolutionsAndNetworks;
+	&HP;
+	&Oracle;
+	&CiscoSystems;
+	&Juniper;
+	&Inovar;
+	&Huawei;
+	&VerizonWireless;
+	&Custom;
+</dictionary>

--- a/codec-diameter-codegen/src/main/resources/diameter/eap.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/eap.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<application id="5" name="EAP Application" uri="http://www.ietf.org/rfc/rfc4072.txt">
+
+	<command name="Diameter-EAP" code="268" vendor-id="None"/>
+
+	<avp name="EAP-Payload" code="462">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="EAP-Reissued-Payload" code="463">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="EAP-Master-Session-Key" code="464">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Accounting-EAP-Auth-Method" code="465">
+		<type type-name="Unsigned64"/>
+	</avp>
+</application>

--- a/codec-diameter-codegen/src/main/resources/diameter/etsie2e4.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/etsie2e4.xml
@@ -1,0 +1,349 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- ETSI ES 283 034 V2.2.0  -->
+<!-- ETSI ES 283 035 V2.5.1 (2008-08) -->
+
+<application id="16777231" name="Diameter e2e4 Application" uri="http://pda.etsi.org">
+
+	<!-- ETSI ES 283 026 V1.6.0 (2008-02) Specifies some experimental resultcodes with vendor id ETSI
+		6.3.2 Experimental-Result-Code AVP values defined in the present
+		document
+	This clause defines the specific values of the Experimental-Result-Code AVP (vendor-id is ETSI):
+
+	XXX prefixed with ETSI to not clash with the IETF one, that causes some filter problem with Wireshark when creating custom columns
+
+	The following tshark parameters ” -Y diameter -z
+	proto,colinfo,diameter.Experimental-Result-Code,diameter.Experimental-Result-Code”
+
+	yields no result where as
+
+	-Y diameter -z proto,colinfo,diameter.Result-Code,diameter.Result-Code
+
+	Does
+
+		<avp name="Experimental-Result-Code" code="298" mandatory="must" protected="mustnot" vendor-bit="must" vendor-id="ETSI" may-encrypt="no" >
+	-->
+
+	<avp name="ETSI-Experimental-Result-Code" code="298" mandatory="must" protected="mustnot" vendor-bit="must" vendor-id="ETSI" may-encrypt="no" >
+		<type type-name="Enumerated"/>
+		<enum name="INSUFFICIENT_RESOURCES"	code="4041"/>
+		<enum name="COMMIT_FAILURE"		code="4043"/>
+		<enum name="REFRESH_FAILURE"		code="4044"/>
+		<enum name="QOS_PROFILE_FAILURE"	code="4045"/>
+		<enum name="ACCESS_PROFILE_FAILURE"	code="4046"/>
+		<enum name="PRIORITY_NOT_GRANTED"	code="4047"/>
+		<enum name="MODIFICATION_FAILURE"	code="5041"/>
+	</avp>
+
+	<!-- ************************* e4 AVPs ************************ -->
+
+	<avp name="Globally-Unique-Address" code="300" mandatory="must" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<grouped>
+			<gavp name="Framed-IP-Address"/>
+			<gavp name="Framed-IPv6-Prefix"/>
+			<gavp name="Address-Realm"/>
+		</grouped>
+	</avp>
+	<avp name="Address-Realm" code="301" mandatory="must" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Logical-Access-ID" code="302" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Initial-Gate-Setting" code="303" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<grouped>
+			<gavp name="NAS-Filter-Rule"/>
+			<gavp name="Maximum-Allowed-Bandwidth-UL"/>
+			<gavp name="Maximum-Allowed-Bandwidth-DL"/>
+		</grouped>
+	</avp>
+	<avp name="QoS-Profile" code="304" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<grouped>
+			<gavp name="Application-Class-ID"/>
+			<gavp name="Media-Type"/>
+			<gavp name="Reservation-Priority"/>
+			<gavp name="Maximum-Allowed-Bandwidth-UL"/>
+			<gavp name="Maximum-Allowed-Bandwidth-DL"/>
+			<gavp name="Transport-Class"/>
+		</grouped>
+	</avp>
+	<avp name="IP-Connectivity-Status" code="305" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="IP-CONNECTIVITY-ON" code="0"/>
+		<enum name="IP-CONNECTIVITY-LOST" code="1"/>
+	</avp>
+	<avp name="Access-Network-Type" code="306" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<grouped>
+			<gavp name="NAS-Port-Type"/>
+			<gavp name="Aggregation-Network-Type"/>
+		</grouped>
+	</avp>
+	<avp name="Aggregation-Network-Type" code="307" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="UNKNOWN" code="0"/>
+		<enum name="ATM" code="1"/>
+		<enum name="ETHERNET" code="2"/>
+	</avp>
+	<avp name="Maximum-Allowed-Bandwidth-UL" code="308" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Maximum-Allowed-Bandwidth-DL" code="309" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<!-- Removed from ETSI ES 283 034 V1.2.0 (2007-05) -->
+	<avp name="Maximum-Priority-DEPRECATED" code="310" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Transport-Class" code="311" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Application-Class-ID" code="312" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Physical-Access-ID" code="313" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Initial-Gate-Setting-ID" code="314" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="QoS-Profile-ID" code="315" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<!-- ************************* e2 AVPs ************************ -->
+
+	<avp name="ETSI-Location-Information" code="350" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<grouped>
+			<gavp name="Line-Identifier"/>
+		</grouped>
+	</avp>
+	<avp name="RACS-Contact-Point" code="351" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="DiameterIdentity"/>
+	</avp>
+	<avp name="Terminal-Type" code="352" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Requested-Information-353" code="353" mandatory="mustnot" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="SUBSCRIBER-ID" code="0"/>
+		<enum name="LOCATION-INFORMATION" code="1"/>
+		<enum name="RACS-CONTACT-POINT" code="2"/>
+		<enum name="ACCESS-NETWORK-TYPE" code="3"/>
+		<enum name="TERMINAL-TYPE" code="4"/>
+		<!-- The following values are reserved for future use and
+		     are out of scope in ETSI ES 283 035 V1.2.1 (2007-06). -->
+		<enum name="Logical-Access-ID" code="5"/>
+		<enum name="Physical-Access-ID" code="6"/>
+		<enum name="ACCESS-NETWORK-TYPE" code="7"/>
+		<enum name="INITIAL-GATE-SETTING" code="8"/>
+		<enum name="QOS-PROFILE" code="9"/>
+		<enum name="IP-CONNECTIVITY-STATUS" code="10"/>
+	</avp>
+	<avp name="ETSI-Event-Type-354" code="354" mandatory="must" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="USER-LOGON" code="0"/>
+		<enum name="LOCATION-INFORMATION-CHANGED" code="1"/>
+		<enum name="RACS-CONTACT-POINT-CHANGED" code="2"/>
+		<enum name="ACCESS-NETWORK-TYPE" code="3"/>
+		<enum name="TERMINAL-TYPE-CHANGED" code="4"/>
+		<enum name="LOGICAL-ACCESS-ID-CHANGED" code="5"/>
+		<enum name="PHYSICAL-ACCESS-ID-CHANGED" code="6"/>
+		<enum name="IP-ADDRESS-CHANGED" code="7"/>
+		<enum name="INITIAL-GATE-SETTING-CHANGED" code="8"/>
+		<enum name="QOS-PROFILE-CHANGED" code="9"/>
+		<enum name="USER-LOGOFF" code="10"/>
+	</avp>
+	<avp name="Civic-Location" code="355" mandatory="must" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Geospatial-Location" code="356" mandatory="must" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+
+	<!--- ETSI ES 283 026 V1.6.0 (2008-02) -->
+	<avp name="Session-Bundle-Id" code="400" mandatory="must" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<!--- ETSI TS 183 066 V2.1.1 (2009-01) -->
+	<avp name="ETSI-Event-Type-420" code="420" mandatory="must" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="UPDATE" code="0"/>
+		<enum name="REMOVE" code="1"/>
+	</avp>
+
+	<!-- ETSI TS 183 017 V1.4.0 (2007-08) -->
+	<avp name="Binding-information" code="450" mandatory="mustnot" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<grouped>
+			<gavp name="Binding-Input-List"/>
+			<gavp name="Binding-Output-List"/>
+		</grouped>
+	</avp>
+	<avp name="Binding-Input-List" code="451" mandatory="mustnot" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<grouped>
+			<gavp name="V6-Transport-Address"/>
+			<gavp name="V4-Transport-Address"/>
+		</grouped>
+	</avp>
+	<avp name="Binding-Output-List" code="452" mandatory="mustnot" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<grouped>
+			<gavp name="V6-Transport-Address"/>
+			<gavp name="V4-Transport-Address"/>
+		</grouped>
+	</avp>
+	<avp name="V6-Transport-Address" code="453" mandatory="mustnot" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<grouped>
+			<gavp name="Framed-IPv6-Prefix"/>
+			<gavp name="Port-Number"/>
+		</grouped>
+	</avp>
+	<avp name="V4-Transport-Address" code="454" mandatory="mustnot" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<grouped>
+			<gavp name="Framed-IP-Address"/>
+			<gavp name="Port-Number"/>
+		</grouped>
+	</avp>
+	<avp name="Port-Number" code="455" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Reservation-Class" code="456" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Requested-Information-457" code="457" mandatory="mustnot" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="LATCH" code="0"/>
+		<enum name="RELATCH" code="1"/>
+	</avp>
+	<avp name="Reservation-Priority" code="458" mandatory="mustnot" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="DEFAULT" code="0"/>
+		<enum name="PRIORITY-ONE" code="1"/>
+		<enum name="PRIORITY-TWO" code="2"/>
+		<enum name="PRIORITY-THREE" code="3"/>
+		<enum name="PRIORITY-FOUR" code="4"/>
+		<enum name="PRIORITY-FIVE" code="5"/>
+		<enum name="PRIORITY-SIX" code="6"/>
+		<enum name="PRIORITY-SEVEN" code="7"/>
+		<enum name="PRIORITY-EIGHT" code="8"/>
+		<enum name="PRIORITY-NINE" code="9"/>
+		<enum name="PRIORITY-TEN" code="10"/>
+		<enum name="PRIORITY-ELEVEN" code="11"/>
+		<enum name="PRIORITY-TWELVE" code="12"/>
+		<enum name="PRIORITY-THIRTEEN" code="13"/>
+		<enum name="PRIORITY-FOURTEEN" code="14"/>
+		<enum name="PRIORITY-FIFTEEN" code="15"/>
+	</avp>
+	<avp name="ETSI-Service-Class" code="459" mandatory="mustnot" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Media-Authorization-Context-Id" code="462" mandatory="must" vendor-bit="must" vendor-id="ETSI" may-encrypt="yes">
+		<type type-name="UTF8String" />
+	</avp>
+
+	<!--- ETSI TS 183 033 V1.2.0 (2007-10) -->
+	<!-- The Line-Identifier AVP has a Vendor-Id header set to ETSI (13019).
+	6.3.34 Line-Identifier AVP
+	The Line-Identifier AVP is of type OctetString. This AVP contains a fixed broadband access line identifier
+	 associated to the user.
+	-->
+	<avp name="Line-Identifier" code="500" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="OctetString"/>
+	</avp>
+	<!-- The following table describes the Diameter AVPs defined for the Cx interface protocol in support of
+		 HTTP Digest, their AVP Code values, types, possible flag values and whether or not the AVP may be
+		 encrypted. The Vendor-Id header of all AVPs defined in the present document shall be set to ETSI (13019). -->
+
+	<avp name="ETSI-SIP-Authenticate" code="501" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<grouped>
+			<gavp name="ETSI-Digest-Realm"/>
+			<gavp name="ETSI-Digest-Nonce"/>
+			<gavp name="ETSI-Digest-Domain"/>
+			<gavp name="ETSI-Digest-Opaque"/>
+			<gavp name="ETSI-Digest-Stale"/>
+			<gavp name="ETSI-Digest-Algorithm"/>
+			<gavp name="ETSI-Digest-QoP"/>
+			<gavp name="ETSI-Digest-HA1"/>
+			<gavp name="ETSI-Digest-Auth-Param"/>
+		</grouped>
+	</avp>
+	<avp name="ETSI-SIP-Authorization" code="502" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<grouped>
+			<gavp name="ETSI-Digest-Username"/>
+			<gavp name="ETSI-Digest-Realm"/>
+			<gavp name="ETSI-Digest-Nonce"/>
+			<gavp name="ETSI-Digest-URI"/>
+			<gavp name="ETSI-Digest-Response"/>
+			<gavp name="ETSI-Digest-Algorithm"/>
+			<gavp name="ETSI-Digest-CNonce"/>
+			<gavp name="ETSI-Digest-Opaque"/>
+			<gavp name="ETSI-Digest-QoP"/>
+			<gavp name="ETSI-Digest-Nonce-Count"/>
+			<gavp name="ETSI-Digest-Method"/>
+			<gavp name="ETSI-Digest-Entity-Body-Hash"/>
+			<gavp name="ETSI-Digest-Auth-Param"/>
+		</grouped>
+	</avp>
+	<avp name="ETSI-SIP-Authentication-Info" code="503" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<grouped>
+			<gavp name="ETSI-Digest-Nextnonce"/>
+			<gavp name="ETSI-Digest-QoP"/>
+			<gavp name="ETSI-Digest-Response-Auth"/>
+			<gavp name="ETSI-Digest-CNonce"/>
+			<gavp name="ETSI-Digest-Nonce-Count"/>
+		</grouped>
+	</avp>
+	<avp name="ETSI-Digest-Realm" code="504" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-Nonce" code="505" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-Domain" code="506" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-Opaque" code="507" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-Stale" code="508" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-Algorithm" code="509" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-QoP" code="510" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-HA1" code="511" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-Auth-Param" code="512" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-Username" code="513" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-URI" code="514" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-Response" code="515" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-CNonce" code="516" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-Nonce-Count" code="517" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-Method" code="518" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-Entity-Body-Hash" code="519" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-Nextnonce" code="520" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="ETSI-Digest-Response-Auth" code="521" mandatory="may" vendor-bit="must" vendor-id="ETSI" may-encrypt="no">
+		<type type-name="UTF8String"/>
+	</avp>
+</application>

--- a/codec-diameter-codegen/src/main/resources/diameter/mobileipv4.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/mobileipv4.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<application id="2" name="Mobile IPv4 Application" uri="http://tools.ietf.org/html/rfc4004">
+
+	<!-- Mobile-IPv4 Application -->
+	<command name="AA-Mobile-Node" code="260" vendor-id="None"/>
+	<command name="Home-Agent-MIP" code="262" vendor-id="None"/>
+
+	<!-- ************************** Mobile-IPv4 AVPS ********************* -->
+	<avp name="MIP-FA-to-HA-SPI" code="318" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="MIP-FA-to-MN-SPI" code="319" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="MIP-Reg-Request" code="320" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MIP-Reg-Reply" code="321" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MIP-MN-AAA-Auth" code="322" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<grouped>
+			<gavp name="MIP-MN-AAA-SPI"/>
+			<gavp name="MIP-Auth-Input-Data-Length"/>
+			<gavp name="MIP-Authenticator-Length"/>
+			<gavp name="MIP-Authenticator-Offset"/>
+		</grouped>
+	</avp>
+	<avp name="MIP-HA-to-FA-SPI" code="323" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<!-- 324 Unassigned -->
+	<avp name="MIP-MN-to-FA-MSA" code="325" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<grouped>
+			<gavp name="MIP-MN-AAA-SPI"/>
+			<gavp name="MIP-Algorithm-Type"/>
+			<gavp name="MIP-Nonce"/>
+		</grouped>
+	</avp>
+	<avp name="MIP-FA-to-MN-MSA" code="326" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<grouped>
+			<gavp name="MIP-MN-AAA-SPI"/>
+			<gavp name="MIP-Algorithm-Type"/>
+			<gavp name="MIP-Session-Key"/>
+		</grouped>
+	</avp>
+
+	<!-- 327 Unassigned -->
+	<avp name="MIP-FA-to-HA-MSA" code="328" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<grouped>
+			<gavp name="MIP-FA-to-HA-SPI"/>
+			<gavp name="MIP-Algorithm-Type"/>
+			<gavp name="MIP-Session-Key"/>
+		</grouped>
+	</avp>
+	<avp name="MIP-HA-to-FA-MSA" code="329" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<grouped>
+			<gavp name="MIP-HA-to-FA-SPI"/>
+			<gavp name="MIP-Algorithm-Type"/>
+			<gavp name="MIP-Session-Key"/>
+		</grouped>
+	</avp>
+
+	<!-- 330 Unassigned -->
+
+	<avp name="MIP-MN-to-HA-MSA" code="331" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<grouped>
+			<gavp name="MIP-MN-HA-SPI"/>
+			<gavp name="MIP-Algorithm-Type"/>
+			<gavp name="MIP-Session-Key"/>
+			<gavp name="MIP-Nonce"/>
+		</grouped>
+	</avp>
+	<avp name="MIP-HA-to-MN-MSA" code="332" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<grouped>
+			<gavp name="MIP-Algorithm-Type"/>
+			<gavp name="MIP-Replay-Mode"/>
+			<gavp name="MIP-Session-Key"/>
+		</grouped>
+	</avp>
+	<avp name="MIP-Mobile-Node-Address" code="333" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="IPAddress"/>
+	</avp>
+	<avp name="MIP-Home-Agent-Address" code="334" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="IPAddress"/>
+	</avp>
+	<avp name="MIP-Nonce" code="335" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MIP-Candidate-Home-Agent-Host" code="336" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="no">
+		<type type-name="DiameterIdentity"/>
+	</avp>
+	<avp name="MIP-Feature-Vector" code="337" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="Mobile-Node-Home-Address-Requested" code="1"/>
+		<enum name="Home-Address-Allocatable-Only-in-Home-Realm" code="2"/>
+		<enum name="Home-Agent-Requested" code="4"/>
+		<enum name="Foreign-Home-Agent-Available" code="8"/>
+		<enum name="MN-HA-Key-Request" code="16"/>
+		<enum name="MN-FA-Key-Request" code="32"/>
+		<enum name="FA-HA-Key-Request" code="64"/>
+		<enum name="Home-Agent-In-Foreign-Network" code="128"/>
+		<enum name="Co-Located-Mobile-Node" code="256"/>
+	</avp>
+	<avp name="MIP-Auth-Input-Data-Length" code="338" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="MIP-Authenticator-Length" code="339" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="MIP-Authenticator-Offset" code="340" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="MIP-MN-AAA-SPI" code="341" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="MIP-Filter-Rule" code="342" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="IPFilterRule"/>
+	</avp>
+	<avp name="MIP-Session-Key" code="343" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MIP-FA-Challenge" code="344" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MIP-Algorithm-Type" code="345" mandatory="must" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="HMAC-SHA-1" code="2"/>
+	</avp>
+	<avp name="MIP-Replay-Mode" code="346" mandatory="must" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="None" code="1"/>
+		<enum name="Timestamps" code="2"/>
+		<enum name="Nonces" code="3"/>
+	</avp>
+	<avp name="MIP-Originating-Foreign-AAA" code="347" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<grouped>
+			<gavp name="Origin-Realm"/>
+			<gavp name="Origin-Host"/>
+		</grouped>
+	</avp>
+	<avp name="MIP-Home-Agent-Host" code="348" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="no">
+		<grouped>
+			<gavp name="Destination-Realm"/>
+			<gavp name="Destination-Host"/>
+		</grouped>
+	</avp>
+	<!--
+	349-362 Unassigned
+	in dictionary.xml
+	363	Accounting-Input-Octets			[RFC4005][RFC4004]
+	364	Accounting-Output-Octets		[RFC4005][RFC4004]
+	365	Accounting-Input-Packets		[RFC4005][RFC4004]
+	366	Accounting-Output-Packets		[RFC4005][RFC4004]
+	in SIP.xml
+	-->
+	<avp name="MIP-MSA-Lifetime" code="367" mandatory="must" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+
+	<!-- ************************ END Mobile-IPv4 AVPS ******************* -->
+</application>

--- a/codec-diameter-codegen/src/main/resources/diameter/mobileipv6.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/mobileipv6.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<application id="7" name="Diameter Mobile IPv6 IKE   (MIP6I)" uri="http://tools.ietf.org/html/rfc5778"/>
+<application id="8" name="Diameter Mobile IPv6 Auth  (MIP6A)" uri="http://tools.ietf.org/html/rfc5778">
+
+	<!-- Mobile-IPv6 Application -->
+	<command name="MIP6-Request/Answer" code="325" vendor-id="None"/>
+
+	<!-- ************************** Mobile-IPv6 AVPS ********************* -->
+
+	<!-- RFC5447 -->
+
+	<avp name="MIP6-Agent-Info" code="486" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<grouped>
+			<gavp name="MIP-Home-Agent-Address"/>
+			<gavp name="MIP-Home-Agent-Host"/>
+			<gavp name="MIP6-Home-Link-Prefix"/>
+		</grouped>
+	</avp>
+
+	<!-- RFC5778 -->
+
+	<avp name="MIP-Careof-Address" code="487" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="IPAddress"/>
+	</avp>
+	<avp name="MIP-Authenticator" code="488" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MIP-MAC-Mobility-Data" code="489" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MIP-Timestamp" code="490" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="MIP-MN-HA-SPI" code="491" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="MIP-MN-HA-MSA" code="492" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<grouped>
+			<gavp name="MIP-Session-Key"/>
+			<gavp name="MIP-MSA-Lifetime"/>
+			<gavp name="MIP-MN-HA-SPI"/>
+			<gavp name="MIP-Algorithm-Type"/>
+			<gavp name="MIP-Replay-Mode"/>
+		</grouped>
+	</avp>
+	<avp name="Service-Selection" code="493" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="MIP6-Auth-Mode" code="494" mandatory="must" protected="may" vendor-bit="mustnot" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="Reserved" code="0"/>
+		<enum name="IP6_AUTH_MN_AAA" code="1"/>
+	</avp>
+
+	<!-- RFC5779 -->
+
+	<avp name="PMIP6-DHCP-Server-Address" code="504">
+		<type type-name="IPAddress"/>
+	</avp>
+	<avp name="PMIP6-IPv4-Home-Address" code="505">
+		<type type-name="IPAddress"/>
+	</avp>
+	<avp name="Mobile-Node-Identifier" code="506">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="Service-Configuration" code="507">
+		<grouped>
+			<gavp name="MIP6-Agent-Info"/>
+			<gavp name="Service-Selection"/>
+		</grouped>
+	</avp>
+
+	<!-- ************************ END Mobile-IPv6 AVPS ******************* -->
+</application>

--- a/codec-diameter-codegen/src/main/resources/diameter/nasreq.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/nasreq.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<application id="1" name="NASREQ Application" uri="http://www.ietf.org/rfc/rfc4005.txt">
+
+	<command name="AA" code="265" vendor-id="None"/>
+
+	<avp name="Accounting-Input-Octets" code="363" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="Accounting-Output-Octets" code="364" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="Accounting-Input-Packets" code="365" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned64"/>
+	</avp>
+	<avp name="Accounting-Output-Packets" code="366" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned64"/>
+	</avp>
+
+	<!--
+	368 - 393 is in sip.xml
+	368 SIP-Accounting-Information [RFC4740]
+	369 SIP-Accounting-Server-URI [RFC4740]
+	370 SIP-Credit-Control-Server-URI [RFC4740]
+	371 SIP-Server-URI [RFC4740]
+	372 SIP-Server-Capabilities [RFC4740]
+	373 SIP-Mandatory-Capability [RFC4740]
+	374 SIP-Optional-Capability [RFC4740]
+	375 SIP-Server-Assignment-Type [RFC4740]
+	376 SIP-Auth-Data-Item [RFC4740]
+	377 SIP-Authentication-Scheme [RFC4740]
+	378 SIP-Item-Number [RFC4740]
+	379 SIP-Authenticate [RFC4740]
+	380 SIP-Authorization [RFC4740]
+	381 SIP-Authentication-Info [RFC4740]
+	382 SIP-Number-Auth-Items [RFC4740]
+	383 SIP-Deregistration-Reason [RFC4740]
+	384 SIP-Reason-Code [RFC4740]
+	385 SIP-Reason-Info [RFC4740]
+	386 SIP-Visited-Network-Id [RFC4740]
+	387 SIP-User-Authorization-Type [RFC4740]
+	388 SIP-Supported-User-Data-Type [RFC4740]
+	389 SIP-User-Data [RFC4740]
+	390 SIP-User-Data-Type [RFC4740]
+	391 SIP-User-Data-Contents [RFC4740]
+	392 SIP-User-Data-Already-Available [RFC4740]
+	393 SIP-Method [RFC4740]
+	394-399 Unassigned
+	-->
+
+	<avp name="NAS-Filter-Rule" code="400" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="IPFilterRule"/>
+	</avp>
+	<avp name="Tunneling" code="401" mandatory="must" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Tunnel-Type"/>
+			<gavp name="Tunnel-Medium-Type"/>
+			<gavp name="Tunnel-Client-Endpoint"/>
+			<gavp name="Tunnel-Server-Endpoint"/>
+			<gavp name="Tunnel-Preference"/>
+			<gavp name="Tunnel-Client-Auth-Id"/>
+			<gavp name="Tunnel-Server-Auth-Id"/>
+			<gavp name="Tunnel-Assignment-Id"/>
+			<gavp name="Tunnel-Password"/>
+			<gavp name="Tunnel-Private-Group-Id"/>
+		</grouped>
+	</avp>
+	<avp name="CHAP-Auth" code="402" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="CHAP-Algorithm"/>
+			<gavp name="CHAP-Ident"/>
+			<gavp name="CHAP-Response"/>
+		</grouped>
+	</avp>
+	<avp name="CHAP-Algorithm" code="403" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="CHAP with MD5" code="5"/>
+	</avp>
+	<avp name="CHAP-Ident" code="404" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="CHAP-Response" code="405" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="Accounting-Auth-Method" code="406" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="PAP" code="1"/>
+		<enum name="CHAP" code="2"/>
+		<enum name="MS-CHAP-1" code="3"/>
+		<enum name="MS-CHAP-2" code="4"/>
+		<enum name="EAP" code="5"/>
+		<enum name="Undefined" code="6"/>
+		<enum name="None" code="7"/>
+	</avp>
+	<avp name="QoS-Filter-Rule" code="407">
+		<type type-name="QoSFilterRule"/>
+	</avp>
+	<avp name="Origin-AAA-Protocol" code="408" mandatory="must" may-encrypt="yes" protected="may" vendor-bit="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="RADIUS" code="1"/>
+	</avp>
+</application>

--- a/codec-diameter-codegen/src/main/resources/diameter/sip.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/sip.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<application id="6" name="Diameter Session Initiation Protocol (SIP) Application" uri="http://tools.ietf.org/html/rfc4740">
+
+	<command name="User-Authorization" code="283" vendor-id="None"/>
+	<command name="Server-Assignment" code="284" vendor-id="None"/>
+	<command name="Location-Info" code="285" vendor-id="None"/>
+	<command name="Multimedia-Auth" code="286" vendor-id="None"/>
+	<command name="Registration-Termination" code="287" vendor-id="None"/>
+	<command name="Push-Profile" code="288" vendor-id="None"/>
+
+	<!-- ************************* SIP AVPs ************************ -->
+	<!-- This list is not complete yet -->
+	<avp name="SIP-Accounting-Information" code="368" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="SIP-Accounting-Server-URI"/>
+			<gavp name="SIP-Credit-Control-Server-URI"/>
+		</grouped>
+	</avp>
+	<avp name="SIP-Accounting-Server-URI" code="369" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="DiameterURI"/>
+	</avp>
+	<avp name="SIP-Credit-Control-Server-URI" code="370" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="DiameterURI"/>
+	</avp>
+	<avp name="SIP-Server-URI" code="371" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="SIP-Server-Capabilities" code="372" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="SIP-Mandatory-Capability"/>
+			<gavp name="SIP-Optional-Capability"/>
+			<gavp name="SIP-Server-URI"/>
+		</grouped>
+	</avp>
+	<avp name="SIP-Mandatory-Capability" code="373" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="SIP-Optional-Capability" code="374" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="SIP-Server-Assignment-Type" code="375" mandatory="must" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="NO_ASSIGNMENT" code="0"/>
+		<enum name="REGISTRATION" code="1"/>
+		<enum name="RE_REGISTRATION" code="2"/>
+		<enum name="UNREGISTERED_USER" code="3"/>
+		<enum name="TIMEOUT_DEREGISTRATION" code="4"/>
+		<enum name="USER_DEREGISTRATION" code="5"/>
+		<enum name="TIMEOUT_DEREGISTRATION_STORE_SERVER_NAME" code="6"/>
+		<enum name="USER_DEREGISTRATION_STORE_SERVER_NAME" code="7"/>
+		<enum name="ADMINISTRATIVE_DEREGISTRATION" code="8"/>
+		<enum name="AUTHENTICATION_FAILURE" code="9"/>
+		<enum name="AUTHENTICATION_TIMEOUT" code="10"/>
+		<enum name="DEREGISTRATION_TOO_MUCH_DATA" code="11"/>
+	</avp>
+	<avp name="SIP-Auth-Data-Item" code="376" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="SIP-Authentication-Scheme"/>
+			<gavp name="SIP-Item-Number"/>
+			<gavp name="SIP-Authenticate"/>
+			<gavp name="SIP-Authorization"/>
+			<gavp name="SIP-Authentication-Info"/>
+		</grouped>
+	</avp>
+	<avp name="SIP-Authentication-Scheme" code="377" mandatory="must" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="DIGEST" code="0"/>
+	</avp>
+	<avp name="SIP-Item-Number" code="378" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="SIP-Authenticate" code="379" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Digest-Realm"/>
+			<gavp name="Digest-Nonce"/>
+			<gavp name="Digest-Domain"/>
+			<gavp name="Digest-Opaque"/>
+			<gavp name="Digest-Stale"/>
+			<gavp name="Digest-Algorithm"/>
+			<gavp name="Digest-Qop"/>
+			<gavp name="Digest-HA1"/>
+			<gavp name="Digest-Auth-Param"/>
+		</grouped>
+	</avp>
+	<avp name="SIP-Authorization" code="380" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Digest-Username"/>
+			<gavp name="Digest-Realm"/>
+			<gavp name="Digest-Nonce"/>
+			<gavp name="Digest-URI"/>
+			<gavp name="Digest-Response"/>
+			<gavp name="Digest-Algorithm"/>
+			<gavp name="Digest-CNonce"/>
+			<gavp name="Digest-Opaque"/>
+			<gavp name="Digest-Qop"/>
+			<gavp name="Digest-Nonce-Count"/>
+			<gavp name="Digest-Method"/>
+			<gavp name="Digest-Entity-Body-Hash"/>
+			<gavp name="Digest-Auth-Param"/>
+		</grouped>
+	</avp>
+	<avp name="SIP-Authentication-Info" code="381" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="Digest-Nextnonce"/>
+			<gavp name="Digest-Qop"/>
+			<gavp name="Digest-Response-Auth"/>
+			<gavp name="Digest-CNonce"/>
+			<gavp name="Digest-Nonce-Count"/>
+		</grouped>
+	</avp>
+	<avp name="SIP-Number-Auth-Items" code="382" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="SIP-Deregistration-Reason" code="383" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="SIP-Reason-Code"/>
+			<gavp name="SIP-Reason-Info"/>
+		</grouped>
+	</avp>
+	<avp name="SIP-Reason-Code" code="384" mandatory="must" may-encrypt="yes">
+		<type type-name="Enumerated"/>
+		<enum name="PERMANENT_TERMINATION" code="0"/>
+		<enum name="NEW_SIP_SERVER_ASSIGNED" code="1"/>
+		<enum name="SIP_SERVER_CHANGE" code="2"/>
+		<enum name="REMOVE_SIP_SERVER" code="3"/>
+	</avp>
+	<avp name="SIP-Reason-Info" code="385" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="SIP-Visited-Network-Id" code="386" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="SIP-User-Authorization-Type" code="387" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="REGISTRATION" code="0"/>
+		<enum name="DEREGISTRATION" code="1"/>
+		<enum name="REGISTRATION_AND_CAPABILITIES" code="2"/>
+	</avp>
+	<avp name="SIP-Supported-User-Data-Type" code="388" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="SIP-User-Data" code="389" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<grouped>
+			<gavp name="SIP-User-Data-Type"/>
+			<gavp name="SIP-User-Data-Contents"/>
+		</grouped>
+	</avp>
+	<avp name="SIP-User-Data-Type" code="390" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+	<avp name="SIP-User-Data-Contents" code="391" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="OctetString"/>
+	</avp>
+	<avp name="SIP-User-Data-Already-Available" code="392" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="Enumerated"/>
+		<enum name="USER_DATA_NOT_AVAILABLE" code="0"/>
+		<enum name="USER_DATA_ALREADY_AVAILABLE" code="1"/>
+	</avp>
+	<avp name="SIP-Method" code="393" mandatory="may" may-encrypt="no" protected="may" vendor-bit="mustnot">
+		<type type-name="UTF8String"/>
+	</avp>
+
+</application>

--- a/codec-diameter-codegen/src/main/resources/diameter/sunping.xml
+++ b/codec-diameter-codegen/src/main/resources/diameter/sunping.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<vendor vendor-id="Sun"				code="42"	name="Sun Microsystems, Inc."/>
+
+<application id="555" name="Sun Ping Application" uri="ftp://ftp.ietf.org/internet-drafts/draft-calhoun-diameter-sun-ping-02.txt">
+	<command name="Ping" code="511" vendor-id="Sun"/>
+
+	<avp name="Ping-Timestamp-Secs" code="1" vendor-id="Sun" mandatory="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Ping-Timestamp-Usecs" code="2" vendor-id="Sun" mandatory="mustnot" vendor-bit="must">
+		<type type-name="Unsigned32"/>
+	</avp>
+	<avp name="Ping-Timestamp" code="3" vendor-id="Sun" mandatory="mustnot" vendor-bit="must">
+		<grouped>
+			<gavp name="Ping-Timestamp-Secs"/>
+			<gavp name="Ping-Timestamp-Usecs"/>
+		</grouped>
+	</avp>
+</application>

--- a/codec-diameter-codegen/src/test/java/io/snice/codecs/codegen/diameter/config/CodeConfigTest.java
+++ b/codec-diameter-codegen/src/test/java/io/snice/codecs/codegen/diameter/config/CodeConfigTest.java
@@ -3,18 +3,13 @@ package io.snice.codecs.codegen.diameter.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.snice.codecs.codegen.diameter.CodeGenTestBase;
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.util.Optional;
 
 import static java.util.Optional.empty;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 public class CodeConfigTest {
@@ -23,7 +18,7 @@ public class CodeConfigTest {
     public void testLoadConfig() throws Exception {
         final var conf = loadConfig("config_test_001.yml");
         assertThat(conf.getSourceRootDir(), is(empty()));
-        assertThat(conf.getWiresharkDictionaryRoot(), is(empty()));
+        // assertThat(conf.getWiresharkDictionaryRoot(), is(empty()));
         assertThat(conf.getCmdPackageConfig(), is(empty()));
         assertThat(conf.getAppPackageConfig(), is(empty()));
 
@@ -40,15 +35,12 @@ public class CodeConfigTest {
     }
 
     @Test
-    public void testCopyConfig() throws Exception{
+    public void testCopyConfig() throws Exception {
         final var path = Path.of(".");
-        final var wireshark = Path.of(".");
         final var conf = loadConfig("config_test_001.yml").copy()
                 .withSourceRoot(path)
-                .withWiresharkDictionaryDir(wireshark)
                 .build();
         assertThat(conf.getSourceRootDir().get(), is(path));
-        assertThat(conf.getWiresharkDictionaryRoot().get(), is(wireshark));
     }
 
     private void assertIncluded(final CodeConfig2.GenerationConfig conf, final String... included) {
@@ -75,7 +67,7 @@ public class CodeConfigTest {
         }
     }
 
-    private CodeConfig2 loadConfig(String resource) throws Exception {
+    private CodeConfig2 loadConfig(final String resource) throws Exception {
         final InputStream stream = CodeGenTestBase.class.getResourceAsStream(resource);
         final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
         return mapper.readValue(stream, CodeConfig2.class);


### PR DESCRIPTION
Turns out that asking other to checkout wireshark to get this to build,
or rather the snice-codecs to use the diameter-codegen plugin, which
would then refer to the wireshark directory to find these files, is a
bit cumbersom and annoying. Therefore, opted to include those xml files
within the jar itself so everything is self contained.