### PR TITLE
Code generation for GTPv1 Type Value and Type Length Value Information Elements

### DIFF
--- a/codec-codegen-common/src/main/java/io/snice/codecs/codegen/ClassNameConverter.java
+++ b/codec-codegen-common/src/main/java/io/snice/codecs/codegen/ClassNameConverter.java
@@ -1,8 +1,19 @@
 package io.snice.codecs.codegen;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 /**
  * Simple interface that takes the name of a diameter element, such as an AVP, a command or application,
  * and converts the name, which usually comes the dictionary xml files, into a Java class name.
+ * <p>
+ * Note: this class is mainly focusing on the patterns of names that appear in the various 3GPP specs for
+ * Diameter and GTP. As such, it is not a perfect, nor meant to me, converter for all possible use cases.
+ * It's the bare minimum for it to be useful without having to manually convert the names in those specs.
  */
 public interface ClassNameConverter {
 
@@ -12,27 +23,96 @@ public interface ClassNameConverter {
 
     String convert(String name);
 
+    /**
+     * Oh java, why can't you allow to return more than one value!
+     *
+     * Anyway, will convert the given class name into a proper java one
+     * but if there is anything within parentheses, it will be preserved
+     * as an "abbreviation" and returned as the second element in the given list.
+     *
+     * E.g. "International Mobile Subscriber Identity (IMSI)"  has abbreviation specified (IMSI)
+     * which will be returned as the second element.
+     *
+     * @param name
+     * @return a list of either a single value, in which case the given name didn't have an "abbreviation"
+     *         and a list of two values, if the given name did have an abbreviation in it.
+     */
+    List<String> convertPreserveAbbreviation(String name);
+
+    /**
+     * Converts the name to a proper enum name (all caps and snake cased) and honors
+     * any abbreviations. E.g., in the 3GPP specs, it typically lists IMSI as such:
+     * "International Mobile Subscriber Identity (IMSI)" and since the abbreviation IMSI
+     * is common, we prefer to use the abbreviation as opposed to the "long" name. I.e., instead of
+     * ending up with "INTERNATIONAL_MOBILE_SUBSCRIBER_IDENTITY" it favors the abbreviation IMSI.
+     *
+     * @param name
+     * @return
+     */
+    String convertToEnum(String name);
+
+    /**
+     * Default rule is simply of course camel case, no '-' and also, I don't like the
+     * class name that has abbreviations and those are kept in upper case. E.g. the AVP
+     * "Outgoing-Trunk-Group-ID" may be named OutgoingTrunkGroupID but this one will convert it
+     * to OutgoingTrunkGroupId, note how the last ID is "Id", i.e. capital 'i' but lowercase 'd'.
+     * <p>
+     * Furthermore, occasionally, the definitions have abbreviated versions of the name within parentheses, e.g.
+     * "International Mobile Subscriber Identity (IMSI)" and in those cases, we will remove anything within
+     * those parentheses. That word will be saved to the abbreviation
+     */
     class DefaultClassNameConverter implements ClassNameConverter {
 
-        /**
-         * Default rule is simply of course camel case, no '-' and also, I don't like the
-         * class name that has abbreviations and those are kept in upper case. E.g. the AVP
-         * "Outgoing-Trunk-Group-ID" may be named OutgoingTrunkGroupID but this one will convert it
-         * to OutgoingTrunkGroupId, note how the last ID is "Id", i.e. capital 'i' but lowercase 'd'.
-         *
-         * @param name
-         * @return
-         */
+        private final Map<String, String> exceptions = new HashMap<>();
+
+        private DefaultClassNameConverter() {
+
+            // a bunch of exceptions and some patterns that I felt is just easier to override
+            exceptions.put("Recovery (Restart Counter)".toLowerCase(), "RECOVERY");
+            exceptions.put("Rat Type".toLowerCase(), "RAT");
+            exceptions.put("PDN Type".toLowerCase(), "PDN");
+
+            exceptions.put("MM Context (GSM Key and Triplets)".toLowerCase(), "MM_CONTEXT_GSM_KEY_TRIPLETS");
+            exceptions.put("MM Context (GSM Key and Triplets)".toLowerCase(), "MM_CONTEXT_GSM_KEY_TRIPLETS");
+            exceptions.put("MM Context (UMTS Key, Used Cipher and Quintuplets)".toLowerCase(), "MM_CONTEXT_UMTS_KEY_USED_CIPHER_QUINTUPLETS");
+            exceptions.put("MM Context (GSM Key,Used Cipher and Quintuplets)".toLowerCase(), "MM_CONTEXT_GSM_KEY_USED_CIPHER_QUINTUPLETS");
+            exceptions.put("MM Context (UMTS Key and Quintuplets)".toLowerCase(), "MM_CONTEXT_UMTS_KEY_QUINTUPLETS");
+            exceptions.put("MM Context (EPS Security Context,Quadruplets and Quintuplets)".toLowerCase(), "MM_CONTEXT_EPS_SECURITY_CONTEXT_QUADRUPLETS_QUINTUPLETS");
+            exceptions.put("MM Context (UMTS Key, Quadruplets and Quintuplets)".toLowerCase(), "MM_CONTEXT_UMTS_KEY_QUADRUPLETS_QUINTUPLETS");
+            exceptions.put("Special IE type for IE Type Extension".toLowerCase(), "EXTENSION");
+            exceptions.put("Extended Protocol Configuration Options (ePCO)".toLowerCase(), "EPCO");
+            exceptions.put("F-Container".toLowerCase(), "F_CONTAINER");
+            exceptions.put("F-Cause".toLowerCase(), "F_CAUSE");
+            exceptions.put("H(e)NB Information Reporting".toLowerCase(), "HENB_INFORMATION_REPORTING");
+        }
+
+        private Optional<String> hasManualOverride(final String name) {
+            return Optional.ofNullable(exceptions.get(name.toLowerCase()));
+        }
+
         @Override
-        public String convert(final String name) {
-            final String origName = name.toLowerCase();
+        public List<String> convertPreserveAbbreviation(final String name) {
+
+            final var exception = hasManualOverride(name);
+            if (exception.isPresent()) {
+                return List.of(exception.get());
+            }
+
+            // personal style. I prefer to type out 2G3G instead of 2G_3G
+            // and the QoS stuff was an easy ugly fix to just have it stay "together"
+            final String origName = name.replaceAll("2G/3G", "2G3G")
+                    .replaceAll("QoS", "Qos");
             final char[] className = new char[origName.length()];
             int index = 0;
+
+            // first character is always upper case.
             boolean toUpperCase = true;
+
+            boolean inAbbreviation = false;
+            String abbreviation = "";
 
             for (int i = 0; i < origName.length(); ++i) {
                 final char ch = origName.charAt(i);
-
                 // ensure that the first character isn't an illegal java classname one.
                 // if it is, translate if if we have a good translation and if not, complain.
                 // If you feel that you have a good translation, just add code here.
@@ -49,19 +129,102 @@ public interface ClassNameConverter {
                     continue;
                 }
 
-                // next should be upper case.
-                if (ch == '-' || ch == '_') {
+
+                // next should be upper case and the current character will be skipped.
+                if (ch == '-' || ch == '_' || ch == '/' || Character.isWhitespace(ch)) {
                     toUpperCase = true;
+                    if (inAbbreviation) {
+                        abbreviation += "_";
+                    }
+                    continue;
+                } else if (ch == '(') {
+                    if (!abbreviation.isEmpty()) {
+                        throw new IllegalArgumentException("Detected two so-called abbreviations within " +
+                                "the given name. I can only handle a single one");
+                    }
+
+                    inAbbreviation = true;
+                    toUpperCase = false;
+                    continue;
+                } else if (ch == ')') {
+                    inAbbreviation = false;
                     continue;
                 }
 
-                className[index++] = toUpperCase ? Character.toUpperCase(ch) : ch;
+                if (inAbbreviation) {
+                    abbreviation += ch;
+                } else {
+                    className[index++] = toUpperCase ? Character.toUpperCase(ch) : Character.toLowerCase(ch);
+                }
                 toUpperCase = false;
             }
 
             final char[] result = new char[index];
             System.arraycopy(className, 0, result, 0, index);
-            return new String(result);
+            final var javaClassName = new String(result);
+            if (abbreviation.isEmpty()) {
+                return List.of(patch(javaClassName));
+            }
+
+            final var finalClassName = patch(javaClassName);
+
+            // this is a bit dumb but it works. Perhaps I'll fix it at some point
+            final var finalAbbreviation = enumToClassName(convertToEnum(patch(abbreviation)));
+            return List.of(finalClassName, finalAbbreviation);
+        }
+
+        /**
+         * Convert a proper enum name to a class name.
+         *
+         * @param enumName
+         * @return
+         */
+        private String enumToClassName(final String enumName) {
+            return Arrays.stream(enumName.toLowerCase().split("_"))
+                    .map(s -> Character.toUpperCase(s.charAt(0)) + s.substring(1))
+                    .collect(Collectors.joining());
+        }
+
+        /**
+         * Some abbreviations we just want a certain way and since it is not like the
+         * names in the various 3GPP specs follow a well-defined ABNF and therefore, hard to
+         * write generic rules for everything. So, just patch it...
+         *
+         * @param name
+         * @return
+         */
+        private String patch(final String name) {
+            return name.replaceAll("FTEID", "F_TEID")
+                    .replaceAll("PTMSI", "P_TMSI");
+        }
+
+
+        @Override
+        public String convertToEnum(final String name) {
+            final var names = convertPreserveAbbreviation(name);
+            if (names.size() == 1) {
+                return patch(toEnumName(names.get(0)));
+            }
+            return patch(toEnumName(names.get(1)));
+        }
+
+        private String toEnumName(final String name) {
+            final var sb = new StringBuilder();
+            for (int i = 0; i < name.length() - 1; ++i) {
+                final var ch = name.charAt(i);
+                final var peek = name.charAt(i + 1);
+                sb.append(Character.toUpperCase(ch));
+                if (Character.isLowerCase(ch) && Character.isUpperCase(peek)) {
+                    sb.append("_");
+                }
+            }
+            sb.append(Character.toUpperCase(name.charAt(name.length() - 1)));
+            return sb.toString();
+        }
+
+        @Override
+        public String convert(final String name) {
+            return convertPreserveAbbreviation(name).get(0);
         }
     }
 

--- a/codec-codegen-common/src/test/java/io/snice/codecs/codegen/ClassNameConverterTest.java
+++ b/codec-codegen-common/src/test/java/io/snice/codecs/codegen/ClassNameConverterTest.java
@@ -1,0 +1,369 @@
+package io.snice.codecs.codegen;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class ClassNameConverterTest {
+
+    private ClassNameConverter converter;
+
+    @Before
+    public void setUp() {
+        converter = ClassNameConverter.defaultConverter();
+    }
+
+    /**
+     * There are a few exceptions with the GTPv2 Information Elements.
+     */
+    @Test
+    public void testConvertToEnumGtpv2() {
+        ensureEnumConversion("P_TMSI", "P-TMSI");
+
+        ensureEnumConversion("RESERVED", "Reserved");
+        ensureEnumConversion("IMSI", "International Mobile Subscriber Identity (IMSI)");
+        ensureEnumConversion("CAUSE", "Cause");
+
+        // another exception
+        ensureEnumConversion("RECOVERY", "Recovery (Restart Counter)");
+        ensureEnumConversion("STN_SR", "STN-SR");
+        ensureEnumConversion("APN", "Access Point Name (APN)");
+        ensureEnumConversion("AMBR", "Aggregate Maximum Bit Rate (AMBR)");
+        ensureEnumConversion("EBI", "EPS Bearer ID (EBI)");
+        ensureEnumConversion("IP_ADDRESS", "IP Address");
+        ensureEnumConversion("MEI", "Mobile Equipment Identity (MEI)");
+        ensureEnumConversion("MSISDN", "MSISDN");
+        ensureEnumConversion("INDICATION", "Indication");
+        ensureEnumConversion("PCO", "Protocol Configuration Options (PCO)");
+        ensureEnumConversion("PAA", "PDN Address Allocation (PAA)");
+        ensureEnumConversion("BEARER_QOS", "Bearer LevelQuality of Service (Bearer QoS)");
+        ensureEnumConversion("FLOW_QOS", "FlowQuality of Service (Flow QoS)");
+        ensureEnumConversion("RAT", "RAT Type");
+        ensureEnumConversion("SERVING_NETWORK", "Serving Network");
+        ensureEnumConversion("BEARER_TFT", "EPS Bearer LevelTraffic Flow Template (Bearer TFT)");
+        ensureEnumConversion("TAD", "Traffic Aggregation Description (TAD)");
+        ensureEnumConversion("ULI", "User Location Information (ULI)");
+
+        ensureEnumConversion("F_TEID", "Fully Qualified Tunnel Endpoint Identifier (F-TEID)");
+
+        ensureEnumConversion("TMSI", "TMSI");
+        ensureEnumConversion("GLOBAL_CN_ID", "Global CN-Id");
+        ensureEnumConversion("S103PDF", "S103 PDN Data Forwarding Info (S103PDF)");
+        ensureEnumConversion("S1UDF", "S1-U Data Forwarding Info (S1UDF)");
+        ensureEnumConversion("DELAY_VALUE", "Delay Value");
+        ensureEnumConversion("BEARER_CONTEXT", "Bearer Context");
+        ensureEnumConversion("CHARGING_ID", "Charging ID");
+        ensureEnumConversion("CHARGING_CHARACTERISTICS", "Charging Characteristics");
+        ensureEnumConversion("TRACE_INFORMATION", "Trace Information");
+        ensureEnumConversion("BEARER_FLAGS", "Bearer Flags");
+        ensureEnumConversion("PDN", "PDN Type");
+        ensureEnumConversion("PROCEDURE_TRANSACTION_ID", "Procedure Transaction ID");
+
+        // These are all exceptions to the normal conversion rule.
+        ensureEnumConversion("MM_CONTEXT_GSM_KEY_TRIPLETS", "MM Context (GSM Key and Triplets)");
+        ensureEnumConversion("MM_CONTEXT_GSM_KEY_TRIPLETS", "MM Context (GSM Key and Triplets)");
+        ensureEnumConversion("MM_CONTEXT_UMTS_KEY_USED_CIPHER_QUINTUPLETS", "MM Context (UMTS Key, Used Cipher and Quintuplets)");
+        ensureEnumConversion("MM_CONTEXT_GSM_KEY_USED_CIPHER_QUINTUPLETS", "MM Context (GSM Key,Used Cipher and Quintuplets)");
+        ensureEnumConversion("MM_CONTEXT_UMTS_KEY_QUINTUPLETS", "MM Context (UMTS Key and Quintuplets)");
+        ensureEnumConversion("MM_CONTEXT_EPS_SECURITY_CONTEXT_QUADRUPLETS_QUINTUPLETS", "MM Context (EPS Security Context,Quadruplets and Quintuplets)");
+        ensureEnumConversion("MM_CONTEXT_UMTS_KEY_QUADRUPLETS_QUINTUPLETS", "MM Context (UMTS Key, Quadruplets and Quintuplets)");
+
+
+        ensureEnumConversion("PDN_CONNECTION", "PDN Connection");
+        ensureEnumConversion("PDU_NUMBERS", "PDU Numbers");
+        ensureEnumConversion("P_TMSI", "P-TMSI");
+        ensureEnumConversion("P_TMSI_SIGNATURE", "P-TMSI Signature");
+
+        ensureEnumConversion("HOP_COUNTER", "Hop Counter");
+        ensureEnumConversion("UE_TIME_ZONE", "UE Time Zone");
+        ensureEnumConversion("TRACE_REFERENCE", "Trace Reference");
+        ensureEnumConversion("COMPLETE_REQUEST_MESSAGE", "Complete Request Message");
+        ensureEnumConversion("GUTI", "GUTI");
+        ensureEnumConversion("F_CONTAINER", "F-Container");
+        ensureEnumConversion("F_CAUSE", "F-Cause");
+        ensureEnumConversion("PLMN_ID", "PLMN ID");
+        ensureEnumConversion("TARGET_IDENTIFICATION", "Target Identification");
+        ensureEnumConversion("PACKET_FLOW_ID", "Packet Flow ID");
+        ensureEnumConversion("RAB_CONTEXT", "RAB Context");
+        ensureEnumConversion("SOURCE_RNC_PDCP_CONTEXT_INFO", "Source RNC PDCP Context Info");
+        ensureEnumConversion("PORT_NUMBER", "Port Number");
+        ensureEnumConversion("APN_RESTRICTION", "APN Restriction");
+        ensureEnumConversion("SELECTION_MODE", "Selection Mode");
+        ensureEnumConversion("SOURCE_IDENTIFICATION", "Source Identification");
+        ensureEnumConversion("CHANGE_REPORTING_ACTION", "Change Reporting Action");
+        ensureEnumConversion("FQ_CSID", "Fully Qualified PDN Connection Set Identifier (FQ-CSID)");
+        ensureEnumConversion("CHANNEL_NEEDED", "Channel needed");
+        ensureEnumConversion("EMLPP_PRIORITY", "eMLPP Priority");
+        ensureEnumConversion("NODE_TYPE", "Node Type");
+        ensureEnumConversion("FQDN", "Fully Qualified Domain Name (FQDN)");
+        ensureEnumConversion("TI", "Transaction Identifier (TI)");
+        ensureEnumConversion("MBMS_SESSION_DURATION", "MBMS Session Duration");
+        ensureEnumConversion("MBMS_SERVICE_AREA", "MBMS Service Area");
+        ensureEnumConversion("MBMS_SESSION_IDENTIFIER", "MBMS Session Identifier");
+        ensureEnumConversion("MBMS_FLOW_IDENTIFIER", "MBMS Flow Identifier");
+        ensureEnumConversion("MBMS_IP_MULTICAST_DISTRIBUTION", "MBMS IP Multicast Distribution");
+        ensureEnumConversion("MBMS_DISTRIBUTION_ACKNOWLEDGE", "MBMS Distribution Acknowledge");
+        ensureEnumConversion("RFSP_INDEX", "RFSP Index");
+        ensureEnumConversion("UCI", "User CSG Information (UCI)");
+        ensureEnumConversion("CSG_INFORMATION_REPORTING_ACTION", "CSG Information Reporting Action");
+        ensureEnumConversion("CSG_ID", "CSG ID");
+        ensureEnumConversion("CMI", "CSG Membership Indication (CMI)");
+        ensureEnumConversion("SERVICE_INDICATOR", "Service indicator");
+        ensureEnumConversion("DETACH_TYPE", "Detach Type");
+        ensureEnumConversion("LDN", "Local Distiguished Name (LDN)");
+        ensureEnumConversion("NODE_FEATURES", "Node Features");
+        ensureEnumConversion("MBMS_TIME_TO_DATA_TRANSFER", "MBMS Time to Data Transfer");
+        ensureEnumConversion("THROTTLING", "Throttling");
+        ensureEnumConversion("ARP", "Allocation/Retention Priority (ARP)");
+        ensureEnumConversion("EPC_TIMER", "EPC Timer");
+        ensureEnumConversion("SIGNALLING_PRIORITY_INDICATION", "Signalling Priority Indication");
+        ensureEnumConversion("TMGI", "Temporary Mobile Group Identity (TMGI)");
+        ensureEnumConversion("ADDITIONAL_MM_CONTEXT_FOR_SRVCC", "Additional MM context for SRVCC");
+        ensureEnumConversion("ADDITIONAL_FLAGS_FOR_SRVCC", "Additional flags for SRVCC");
+        ensureEnumConversion("MDT_CONFIGURATION", "MDT Configuration");
+        ensureEnumConversion("APCO", "Additional Protocol Configuration Options (APCO)");
+        ensureEnumConversion("ABSOLUTE_TIME_OF_MBMS_DATA_TRANSFER", "Absolute Time of MBMS Data Transfer");
+        ensureEnumConversion("HENB_INFORMATION_REPORTING", "H(e)NB Information Reporting");
+        ensureEnumConversion("IP4CP", "IPv4 Configuration Parameters (IP4CP)");
+        ensureEnumConversion("CHANGE_TO_REPORT_FLAGS", "Change to Report Flags");
+        ensureEnumConversion("ACTION_INDICATION", "Action Indication");
+        ensureEnumConversion("TWAN_IDENTIFIER", "TWAN Identifier");
+        ensureEnumConversion("ULI_TIMESTAMP", "ULI Timestamp");
+        ensureEnumConversion("MBMS_FLAGS", "MBMS Flags");
+        ensureEnumConversion("RAN_NAS_CAUSE", "RAN/NAS Cause");
+        ensureEnumConversion("CN_OPERATOR_SELECTION_ENTITY", "CN Operator Selection Entity");
+        ensureEnumConversion("TRUSTED_WLAN_MODE_INDICATION", "Trusted WLAN Mode Indication");
+        ensureEnumConversion("NODE_NUMBER", "Node Number");
+        ensureEnumConversion("NODE_IDENTIFIER", "Node Identifier");
+        ensureEnumConversion("PRESENCE_REPORTING_AREA_ACTION", "Presence Reporting Area Action");
+        ensureEnumConversion("PRESENCE_REPORTING_AREA_INFORMATION", "Presence Reporting Area Information");
+        ensureEnumConversion("TWAN_IDENTIFIER_TIMESTAMP", "TWAN Identifier Timestamp");
+        ensureEnumConversion("OVERLOAD_CONTROL_INFORMATION", "Overload Control Information");
+        ensureEnumConversion("LOAD_CONTROL_INFORMATION", "Load Control Information");
+        ensureEnumConversion("METRIC", "Metric");
+        ensureEnumConversion("SEQUENCE_NUMBER", "Sequence Number");
+        ensureEnumConversion("APN_AND_RELATIVE_CAPACITY", "APN and Relative Capacity");
+        ensureEnumConversion("WLAN_OFFLOADABILITY_INDICATION", "WLAN Offloadability Indication");
+        ensureEnumConversion("PAGING_AND_SERVICE_INFORMATION", "Paging and Service Information");
+        ensureEnumConversion("INTEGER_NUMBER", "Integer Number");
+        ensureEnumConversion("MILLISECOND_TIME_STAMP", "Millisecond Time Stamp");
+        ensureEnumConversion("MONITORING_EVENT_INFORMATION", "Monitoring Event Information");
+        ensureEnumConversion("ECGI_LIST", "ECGI List");
+        ensureEnumConversion("REMOTE_UE_CONTEXT", "Remote UE Context");
+        ensureEnumConversion("REMOTE_USER_ID", "Remote User ID");
+        ensureEnumConversion("REMOTE_UE_IP_INFORMATION", "Remote UE IP information");
+        ensureEnumConversion("CIOT_OPTIMIZATIONS_SUPPORT_INDICATION", "CIoT Optimizations Support Indication");
+        ensureEnumConversion("SCEF_PDN_CONNECTION", "SCEF PDN Connection");
+        ensureEnumConversion("HEADER_COMPRESSION_CONFIGURATION", "Header Compression Configuration");
+        ensureEnumConversion("EPCO", "Extended Protocol Configuration Options (ePCO)");
+        ensureEnumConversion("SERVING_PLMN_RATE_CONTROL", "Serving PLMN Rate Control");
+        ensureEnumConversion("COUNTER", "Counter");
+        ensureEnumConversion("MAPPED_UE_USAGE_TYPE", "Mapped UE Usage Type");
+        ensureEnumConversion("SECONDARY_RAT_USAGE_DATA_REPORT", "Secondary RAT Usage Data Report");
+        ensureEnumConversion("UP_FUNCTION_SELECTION_INDICATION_FLAGS", "UP Function Selection Indication Flags");
+        ensureEnumConversion("MAXIMUM_PACKET_LOSS_RATE", "Maximum Packet Loss Rate");
+        ensureEnumConversion("APN_RATE_CONTROL_STATUS", "APN Rate Control Status");
+        ensureEnumConversion("EXTENDED_TRACE_INFORMATION", "Extended Trace Information");
+        ensureEnumConversion("MONITORING_EVENT_EXTENSION_INFORMATION", "Monitoring Event Extension Information");
+        ensureEnumConversion("EXTENSION", "Special IE type for IE Type Extension");
+        ensureEnumConversion("PRIVATE_EXTENSION", "Private Extension");
+    }
+
+    /**
+     * These are all the generated GTPv1 Information Elements and they have been manually
+     * checked to ensure the names are what we want. If you change the converter and break any of
+     * these tests, that also means that the actual name of the enum will change when the new code is
+     * generated, which would be a breaking change and as such, any code using it would have to be updated.
+     */
+    @Test
+    public void testConvertToEnumGtpv1() {
+        ensureEnumConversion("CAUSE", "Cause");
+
+        // Note how the conversion favors "abbreviations" where, in this case, instead of naming the
+        // enum "INTERNATIONAL_MOBILE_SUBSCRIBER_IDENTITY" it favors the abbreviation IMSI
+        ensureEnumConversion("IMSI", "International Mobile Subscriber Identity (IMSI)");
+        ensureEnumConversion("RAI", "Routeing Area Identity (RAI)");
+        ensureEnumConversion("TLLI", "Temporary Logical Link Identity (TLLI)");
+        ensureEnumConversion("P_TMSI", "Packet TMSI (P-TMSI)");
+        ensureEnumConversion("REORDERING_REQUIRED", "Reordering Required");
+        ensureEnumConversion("AUTHENTICATION_TRIPLET", "Authentication Triplet");
+        ensureEnumConversion("MAP_CAUSE", "MAP Cause");
+        ensureEnumConversion("P_TMSI_SIGNATURE", "P-TMSI Signature");
+        ensureEnumConversion("MS_VALIDATED", "MS Validated");
+        ensureEnumConversion("RECOVERY", "Recovery");
+        ensureEnumConversion("SELECTION_MODE", "Selection Mode");
+        ensureEnumConversion("TUNNEL_ENDPOINT_IDENTIFIER_DATA_I", "Tunnel Endpoint Identifier Data I");
+        ensureEnumConversion("TUNNEL_ENDPOINT_IDENTIFIER_CONTROL_PLANE", "Tunnel Endpoint Identifier Control Plane");
+        ensureEnumConversion("TUNNEL_ENDPOINT_IDENTIFIER_DATA_II", "Tunnel Endpoint Identifier Data II");
+        ensureEnumConversion("TEARDOWN_IND", "Teardown Ind");
+        ensureEnumConversion("NSAPI", "NSAPI");
+        ensureEnumConversion("RANAP_CAUSE", "RANAP Cause");
+        ensureEnumConversion("RAB_CONTEXT", "RAB Context");
+        ensureEnumConversion("RADIO_PRIORITY_SMS", "Radio Priority SMS");
+        ensureEnumConversion("RADIO_PRIORITY", "Radio Priority");
+        ensureEnumConversion("PACKET_FLOW_ID", "Packet Flow Id");
+        ensureEnumConversion("CHARGING_CHARACTERISTICS", "Charging Characteristics");
+        ensureEnumConversion("TRACE_REFERENCE", "Trace reference");
+        ensureEnumConversion("TRACE_TYPE", "Trace type");
+        ensureEnumConversion("MS_NOT_REACHABLE_REASON", "MS Not Reachable Reason");
+        ensureEnumConversion("CHARGING_ID", "Charging ID");
+        ensureEnumConversion("END_USER_ADDRESS", "End User Address");
+        ensureEnumConversion("MM_CONTEXT", "MM Context");
+        ensureEnumConversion("PDP_CONTEXT", "PDP Context");
+        ensureEnumConversion("ACCESS_POINT_NAME", "Access Point Name");
+        ensureEnumConversion("PROTOCOL_CONFIGURATION_OPTIONS", "Protocol Configuration Options");
+        ensureEnumConversion("GSN_ADDRESS", "GSN Address");
+        ensureEnumConversion("MSISDN", "MS International PSTN/ISDN Number (MSISDN)");
+        ensureEnumConversion("QUALITY_OF_SERVICE_PROFILE", "Quality of Service Profile");
+        ensureEnumConversion("AUTHENTICATION_QUINTUPLET", "Authentication Quintuplet");
+        ensureEnumConversion("TRAFFIC_FLOW_TEMPLATE", "Traffic Flow Template");
+        ensureEnumConversion("TARGET_IDENTIFICATION", "Target Identification");
+        ensureEnumConversion("UTRAN_TRANSPARENT_CONTAINER", "UTRAN Transparent Container");
+        ensureEnumConversion("RAB_SETUP_INFORMATION", "RAB Setup Information");
+        ensureEnumConversion("EXTENSION_HEADER_TYPE_LIST", "Extension Header type List");
+        ensureEnumConversion("TRIGGER_ID", "Trigger Id");
+        ensureEnumConversion("OMC_IDENTITY", "OMC Identity");
+        ensureEnumConversion("RAN_TRANSPARENT_CONTAINER", "RAN Transparent Container");
+        ensureEnumConversion("PDP_CONTEXT_PRIORITIZATION", "PDP Context Prioritization");
+        ensureEnumConversion("ADDITIONAL_RAB_SETUP_INFORMATION", "Additional RAB Setup Information");
+        ensureEnumConversion("SGSN_NUMBER", "SGSN Number");
+        ensureEnumConversion("COMMON_FLAGS", "Common Flags");
+        ensureEnumConversion("APN_RESTRICTION", "APN Restriction");
+        ensureEnumConversion("RADIO_PRIORITY_LCS", "Radio Priority LCS");
+        ensureEnumConversion("RAT", "RAT type");
+        ensureEnumConversion("USER_LOCATION_INFORMATION", "User Location Information");
+        ensureEnumConversion("MS_TIME_ZONE", "MS Time Zone");
+        ensureEnumConversion("SV", "IMEI(SV)");
+        ensureEnumConversion("CAMEL_CHARGING_INFORMATION_CONTAINER", "CAMEL Charging Information Container");
+        ensureEnumConversion("MBMS_UE_CONTEXT", "MBMS UE Context");
+        ensureEnumConversion("TMGI", "Temporary Mobile Group Identity (TMGI)");
+        ensureEnumConversion("RIM_ROUTING_ADDRESS", "RIM Routing Address");
+        ensureEnumConversion("MBMS_PROTOCOL_CONFIGURATION_OPTIONS", "MBMS Protocol Configuration Options");
+        ensureEnumConversion("MBMS_SERVICE_AREA", "MBMS Service Area");
+        ensureEnumConversion("SOURCE_RNC_PDCP_CONTEXT_INFO", "Source RNC PDCP context info");
+        ensureEnumConversion("ADDITIONAL_TRACE_INFO", "Additional Trace Info");
+        ensureEnumConversion("HOP_COUNTER", "Hop Counter");
+        ensureEnumConversion("SELECTED_PLMN_ID", "Selected PLMN ID");
+        ensureEnumConversion("MBMS_SESSION_IDENTIFIER", "MBMS Session Identifier");
+        ensureEnumConversion("MBMS2G3G_INDICATOR", "MBMS 2G/3G Indicator");
+        ensureEnumConversion("ENHANCED_NSAPI", "Enhanced NSAPI");
+        ensureEnumConversion("MBMS_SESSION_DURATION", "MBMS Session Duration");
+        ensureEnumConversion("ADDITIONAL_MBMS_TRACE_INFO", "Additional MBMS Trace Info");
+        ensureEnumConversion("MBMS_SESSION_REPETITION_NUMBER", "MBMS Session Repetition Number");
+        ensureEnumConversion("MBMS_TIME_TO_DATA_TRANSFER", "MBMS Time To Data Transfer");
+        ensureEnumConversion("BSS_CONTAINER", "BSS Container");
+        ensureEnumConversion("CELL_IDENTIFICATION", "Cell Identification");
+        ensureEnumConversion("PDU_NUMBERS", "PDU Numbers");
+        ensureEnumConversion("BSSGP_CAUSE", "BSSGP Cause");
+        ensureEnumConversion("REQUIRED_MBMS_BEARER_CAPABILITIES", "Required MBMS bearer capabilities");
+        ensureEnumConversion("RIM_ROUTING_ADDRESS_DISCRIMINATOR", "RIM Routing Address Discriminator");
+        ensureEnumConversion("LIST_OF_SET_UP_PFCS", "List of set-up PFCs");
+        ensureEnumConversion("PS_HANDOVER_XID_PARAMETERS", "PS Handover XID Parameters");
+        ensureEnumConversion("MS_INFO_CHANGE_REPORTING_ACTION", "MS Info Change Reporting Action");
+        ensureEnumConversion("DIRECT_TUNNEL_FLAGS", "Direct Tunnel Flags");
+        ensureEnumConversion("CORRELATION_ID", "Correlation-ID");
+        ensureEnumConversion("BEARER_CONTROL_MODE", "Bearer Control Mode");
+        ensureEnumConversion("MBMS_FLOW_IDENTIFIER", "MBMS Flow Identifier");
+        ensureEnumConversion("MBMS_IP_MULTICAST_DISTRIBUTION", "MBMS IP Multicast Distribution");
+        ensureEnumConversion("MBMS_DISTRIBUTION_ACKNOWLEDGEMENT", "MBMS Distribution Acknowledgement");
+        ensureEnumConversion("RELIABLE_INTER_RAT_HANDOVER_INFO", "Reliable INTER RAT HANDOVER INFO ");
+        ensureEnumConversion("RFSP_INDEX", "RFSP Index");
+        ensureEnumConversion("FQDN", "Fully Qualified Domain Name (FQDN)");
+        ensureEnumConversion("EVOLVED_ALLOCATION_RETENTION_PRIORITY_I", "Evolved Allocation/Retention Priority I");
+        ensureEnumConversion("EVOLVED_ALLOCATION_RETENTION_PRIORITY_II", "Evolved Allocation/Retention Priority II");
+        ensureEnumConversion("EXTENDED_COMMON_FLAGS", "Extended Common Flags");
+        ensureEnumConversion("UCI", "User CSG Information (UCI)");
+        ensureEnumConversion("CSG_INFORMATION_REPORTING_ACTION", "CSG Information Reporting Action");
+        ensureEnumConversion("CSG_ID", "CSG ID");
+        ensureEnumConversion("CMI", "CSG Membership Indication (CMI)");
+        ensureEnumConversion("AMBR", "Aggregate Maximum Bit Rate (AMBR)");
+        ensureEnumConversion("UE_NETWORK_CAPABILITY", "UE Network Capability");
+        ensureEnumConversion("UE_AMBR", "UE-AMBR");
+        ensureEnumConversion("APN_AMBR_WITH_NSAPI", "APN-AMBR with NSAPI");
+        ensureEnumConversion("GGSN_BACK_OFF_TIME", "GGSN Back-Off Time");
+        ensureEnumConversion("SIGNALLING_PRIORITY_INDICATION", "Signalling Priority Indication");
+        ensureEnumConversion("SIGNALLING_PRIORITY_INDICATION_WITH_NSAPI", "Signalling Priority Indication with NSAPI");
+        ensureEnumConversion("HIGHER_BITRATES_THAN16MBPS_FLAG", "Higher bitrates than 16 Mbps flag");
+        ensureEnumConversion("ADDITIONAL_MM_CONTEXT_FOR_SRVCC", "Additional MM context for SRVCC");
+        ensureEnumConversion("ADDITIONAL_FLAGS_FOR_SRVCC", "Additional flags for SRVCC");
+        ensureEnumConversion("STN_SR", "STN-SR");
+        ensureEnumConversion("CMSISDN", "C-MSISDN");
+        ensureEnumConversion("EXTENDED_RANAP_CAUSE", "Extended RANAP Cause");
+        ensureEnumConversion("ENODEB_ID", "eNodeB ID");
+        ensureEnumConversion("SELECTION_MODE_WITH_NSAPI", "Selection Mode with NSAPI");
+        ensureEnumConversion("ULI_TIMESTAMP", "ULI Timestamp");
+        ensureEnumConversion("LHN_ID", "Local Home Network ID (LHN-ID) with NSAPI");
+        ensureEnumConversion("CN_OPERATOR_SELECTION_ENTITY", "CN Operator Selection Entity ");
+        ensureEnumConversion("UE_USAGE_TYPE", "UE Usage type");
+        ensureEnumConversion("EXTENDED_COMMON_FLAGS_II", "Extended Common Flags II");
+        ensureEnumConversion("NODE_IDENTIFIER", "Node Identifier ");
+        ensureEnumConversion("CIOT_OPTIMIZATIONS_SUPPORT_INDICATION", "CIoT Optimizations Support Indication");
+        ensureEnumConversion("SCEF_PDN_CONNECTION", "SCEF PDN Connection");
+        ensureEnumConversion("IOV_UPDATES_COUNTER", "IOV_updates counter");
+        ensureEnumConversion("MAPPED_UE_USAGE_TYPE", "Mapped UE Usage type");
+        ensureEnumConversion("UP_FUNCTION_SELECTION_INDICATION_FLAGS", "UP Function Selection Indication Flags");
+        ensureEnumConversion("EXTENSION", "Special IE type for IE type Extension");
+        ensureEnumConversion("CHARGING_GATEWAY_ADDRESS", "Charging Gateway Address");
+        ensureEnumConversion("PRIVATE_EXTENSION", "Private Extension");
+
+    }
+
+    @Test
+    public void testConvertToEnum() {
+        ensureEnumConversion("CAUSE", "Cause");
+        ensureEnumConversion("CAUSE", "cause");
+        ensureEnumConversion("HELLO_WORLD", "Hello-World");
+        ensureEnumConversion("HELLO_WORLD", "Hello World");
+        ensureEnumConversion("HELLO_WORLD", "Hello_World");
+        ensureEnumConversion("HELLO_WORLD", "Hello_world");
+        ensureEnumConversion("HELLOWORLD", "Helloworld");
+
+    }
+
+    @Test
+    public void testRegularClassName() {
+        ensureConversion("Tgpp2QosInformation", "3GPP2-QoS-Information", null);
+        ensureConversion("InternationalMobileSubscriberIdentity", "International Mobile Subscriber Identity (IMSI)", "Imsi");
+        ensureConversion("ChargingGatewayAddress", "Charging Gateway Address", null);
+        ensureConversion("OutgoingTrunkGroupId", "Outgoing-Trunk-Group-ID", null);
+
+        // many spaces...
+        ensureConversion("ChargingGatewayAddress", "    Charging     Gateway Address     ", null);
+        // tabs...
+        ensureConversion("ChargingGatewayAddress", "Charging    Gateway Address             ", null);
+
+        // don't know why this would ever be specified this way but if it does, the current strategy is still
+        // to detect and remove it from the "main" name and return it as an abbreviation.
+        ensureConversion("AbbreviationInTheMiddle", "Abbreviation (MIDDLE) In The Middle", "Middle");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testTwoAbbreviations() {
+        converter.convert("Two Abbreviations (ONE) (TWO)");
+    }
+
+
+    private void ensureEnumConversion(final String expected, final String name) {
+        final var actual = converter.convertToEnum(name);
+        assertThat(actual, is(expected));
+    }
+
+    private void ensureConversion(final String expected, final String name, final String abbreviation) {
+        final var result = converter.convertPreserveAbbreviation(name);
+        assertThat(result.get(0), is(expected));
+
+        // also verify that the method that doesn't preserve the abbreviation does the right thing
+        assertThat(converter.convert(name), is(expected));
+
+
+        if (abbreviation == null) {
+            assertThat(result.size(), is(1));
+        } else {
+            assertThat(result.get(1), is(abbreviation));
+        }
+    }
+
+
+}

--- a/codec-diameter-codegen/src/test/java/io/snice/codecs/codegen/diameter/config/ClassNameConverterTest.java
+++ b/codec-diameter-codegen/src/test/java/io/snice/codecs/codegen/diameter/config/ClassNameConverterTest.java
@@ -6,7 +6,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 public class ClassNameConverterTest extends CodeGenTestBase {

--- a/codec-gtp-codegen/pom.xml
+++ b/codec-gtp-codegen/pom.xml
@@ -23,6 +23,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.snice.codecs</groupId>
+            <artifactId>codec-gtp-base</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.snice</groupId>
             <artifactId>snice-buffers</artifactId>
         </dependency>

--- a/codec-gtp-codegen/src/main/java/io/snice/codecs/codegen/gtp/Gtpv1InfoElementMetaData.java
+++ b/codec-gtp-codegen/src/main/java/io/snice/codecs/codegen/gtp/Gtpv1InfoElementMetaData.java
@@ -1,0 +1,124 @@
+package io.snice.codecs.codegen.gtp;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.snice.codecs.codec.gtp.v1.common.Format;
+import io.snice.codecs.codegen.ClassNameConverter;
+
+import java.util.Optional;
+
+/**
+ * This will read a yml file that has been produced from the Information Elements in TS 29.060. See
+ * the scripts folder for more information of how to read those files.
+ */
+// @JsonNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+public class Gtpv1InfoElementMetaData {
+
+    @JsonProperty
+    private Format format;
+
+    @JsonProperty
+    private String informationElement;
+
+    @JsonProperty
+    private String lengthType;
+
+    @JsonProperty
+    private int numberOfFixedOctets;
+
+    @JsonProperty
+    private String reference;
+
+    /**
+     * The type is the given type number in the specification.
+     */
+    @JsonProperty
+    private int type;
+
+    /**
+     * If not specified, we will use the "raw type" as the underlying implementation.
+     */
+    @JsonProperty
+    private final Optional<String> typeImpl = Optional.empty();
+
+    /**
+     * Whether or not this type can be represented, or parsed from, as an integer. Mainly used
+     * for code generation.
+     */
+    @JsonProperty
+    private boolean isIntType = false;
+
+    public boolean isIntType() {
+        return isIntType;
+    }
+
+    public void setIntType(final boolean intType) {
+        isIntType = intType;
+    }
+
+    /**
+     * This is converting the Information Element name, as listed in the specification, to a proper
+     * java enum name.
+     *
+     * @return
+     */
+    public String getEnumName() {
+        return ClassNameConverter.defaultConverter().convertToEnum(getInformationElement());
+    }
+
+    public String getFriendlyName() {
+        return getInformationElement();
+    }
+
+    public int getType() {
+        return type;
+    }
+
+    public Format getFormat() {
+        return format;
+    }
+
+    public void setFormat(final Format format) {
+        this.format = format;
+    }
+
+    public String getInformationElement() {
+        return informationElement;
+    }
+
+    public void setInformationElement(final String informationElement) {
+        this.informationElement = informationElement;
+    }
+
+    public String getLengthType() {
+        return lengthType;
+    }
+
+    public void setLengthType(final String lengthType) {
+        this.lengthType = lengthType;
+    }
+
+    public int getNumberOfFixedOctets() {
+        return numberOfFixedOctets;
+    }
+
+    public void setNumberOfFixedOctets(final int numberOfFixedOctets) {
+        this.numberOfFixedOctets = numberOfFixedOctets;
+    }
+
+    public String getReference() {
+        return reference;
+    }
+
+    public void setReference(final String reference) {
+        this.reference = reference;
+    }
+
+    public void setType(final int type) {
+        this.type = type;
+    }
+
+    public Optional<String> getTypeImpl() {
+        return typeImpl;
+    }
+
+}

--- a/codec-gtp-codegen/src/main/java/io/snice/codecs/codegen/gtp/Gtpv2InfoElementMetaData.java
+++ b/codec-gtp-codegen/src/main/java/io/snice/codecs/codegen/gtp/Gtpv2InfoElementMetaData.java
@@ -15,6 +15,12 @@ public class Gtpv2InfoElementMetaData {
     @JsonProperty
     private String comment;
 
+    /**
+     * Note that this enum value as found in the yml file is no longer really used.
+     * The actual name of the resulting Enum is derived from the friendly name.
+     *
+     * TODO: remove this one and remove it from the yaml file.
+     */
     @JsonProperty("enum")
     private String enumValue;
 
@@ -38,7 +44,7 @@ public class Gtpv2InfoElementMetaData {
     }
 
     public String getEnumValue() {
-        return enumValue;
+        return getName();
     }
 
     public boolean isExtendable() {
@@ -58,7 +64,8 @@ public class Gtpv2InfoElementMetaData {
     }
 
     public String getName() {
-        return ClassNameConverter.defaultConverter().convert(enumValue);
+        // return ClassNameConverter.defaultConverter().convert(enumValue);
+        return ClassNameConverter.defaultConverter().convertToEnum(friendlyName);
     }
 
     public Optional<String> getTypeImpl() {
@@ -68,7 +75,8 @@ public class Gtpv2InfoElementMetaData {
     public Map<String, Object> toAttributes() {
         final Map<String, Object> attributes = new HashMap<>();
         attributes.put("comment", comment);
-        attributes.put("enum", enumValue);
+        // attributes.put("enum", enumValue);
+        attributes.put("enum", getName());
         attributes.put("enum_byte", getType());
         attributes.put("extendable", extendable);
         attributes.put("friendly_name", friendlyName);

--- a/codec-gtp-codegen/src/main/java/io/snice/codecs/codegen/gtp/templates/Gtpv1InformationElementsTemplate.java
+++ b/codec-gtp-codegen/src/main/java/io/snice/codecs/codegen/gtp/templates/Gtpv1InformationElementsTemplate.java
@@ -1,0 +1,32 @@
+package io.snice.codecs.codegen.gtp.templates;
+
+import io.snice.codecs.codegen.gtp.CodeGen;
+import io.snice.codecs.codegen.gtp.Gtpv1InfoElementMetaData;
+import io.snice.codecs.codegen.gtp.Gtpv1MessageTypeMetaData;
+import liqp.Template;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class Gtpv1InformationElementsTemplate {
+
+    private final Template template;
+
+    public static Gtpv1InformationElementsTemplate load() throws Exception {
+        return new Gtpv1InformationElementsTemplate(CodeGen.loadTemplate("templates/gtpv1_information_elements.liquid"));
+    }
+
+    private Gtpv1InformationElementsTemplate(final Template template) {
+        this.template = template;
+    }
+
+    public String render(final List<Gtpv1InfoElementMetaData> ies) {
+        final var attributes = new HashMap<String, Object>();
+        final var elements = new ArrayList<>();
+        ies.forEach(elements::add);
+        attributes.put("elements", elements);
+        return template.render(attributes);
+    }
+
+}

--- a/codec-gtp-codegen/src/main/java/io/snice/codecs/codegen/gtp/templates/TlvFramerTemplate.java
+++ b/codec-gtp-codegen/src/main/java/io/snice/codecs/codegen/gtp/templates/TlvFramerTemplate.java
@@ -1,0 +1,43 @@
+package io.snice.codecs.codegen.gtp.templates;
+
+import io.snice.codecs.codec.gtp.v1.common.Format;
+import io.snice.codecs.codegen.ClassNameConverter;
+import io.snice.codecs.codegen.gtp.CodeGen;
+import io.snice.codecs.codegen.gtp.Gtpv1InfoElementMetaData;
+import liqp.Template;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TlvFramerTemplate {
+
+    private final Template template;
+
+    public static TlvFramerTemplate load() throws Exception {
+        return new TlvFramerTemplate(CodeGen.loadTemplate("templates/gtpv1_tlv_framer.liquid"));
+    }
+
+    private TlvFramerTemplate(final Template template) {
+        this.template = template;
+    }
+
+    public String render(final ClassNameConverter converter, final String packageName, final List<Gtpv1InfoElementMetaData> tvs) {
+        final var attributes = new HashMap<String, Object>();
+        final var elements = new ArrayList<>();
+        attributes.put("elements", elements);
+        attributes.put("package", packageName);
+
+        tvs.stream().filter(tv -> tv.getFormat() == Format.TLV).forEach(tv -> {
+            final Map<String, Object> tvAttributes = new HashMap<>();
+            final var names = converter.convertPreserveAbbreviation(tv.getFriendlyName());
+            final var className = names.size() == 1 ? names.get(0) : names.get(1);
+            tvAttributes.put("name", className);
+            elements.add(tvAttributes);
+        });
+
+        return template.render(attributes);
+    }
+
+}

--- a/codec-gtp-codegen/src/main/java/io/snice/codecs/codegen/gtp/templates/TlvTemplate.java
+++ b/codec-gtp-codegen/src/main/java/io/snice/codecs/codegen/gtp/templates/TlvTemplate.java
@@ -1,0 +1,61 @@
+package io.snice.codecs.codegen.gtp.templates;
+
+import io.snice.codecs.codegen.ClassNameConverter;
+import io.snice.codecs.codegen.gtp.CodeGen;
+import io.snice.codecs.codegen.gtp.Gtpv1InfoElementMetaData;
+import liqp.Template;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TlvTemplate {
+
+    private final Template template;
+
+    public static TlvTemplate load() throws Exception {
+        return new TlvTemplate(CodeGen.loadTemplate("templates/gtpv1_tlv.liquid"));
+    }
+
+    private TlvTemplate(final Template template) {
+        this.template = template;
+    }
+
+    public RenderResult render(final ClassNameConverter converter, final String javaPackageName, final Gtpv1InfoElementMetaData ie) {
+        final var attributes = new HashMap<String, Object>();
+        final Map<String, Object> javaAttributes = new HashMap<>();
+        final Map<String, Object> tlivAttributes = new HashMap<>();
+        attributes.put("java", javaAttributes);
+        javaAttributes.put("package", javaPackageName);
+        javaAttributes.put("tv", tlivAttributes);
+        final var names = converter.convertPreserveAbbreviation(ie.getFriendlyName());
+        final var className = names.size() == 1 ? names.get(0) : names.get(1);
+        tlivAttributes.put("name", className);
+        tlivAttributes.put("enum", ie.getEnumName());
+        tlivAttributes.put("enum_value", ie.getType());
+        tlivAttributes.put("type", ie.getTypeImpl().orElse("RawType"));
+        tlivAttributes.put("is_of_int_type", ie.isIntType());
+
+        final String rendered = template.render(attributes);
+        return new RenderResult(rendered, className);
+    }
+
+    public static class RenderResult {
+
+        private final String result;
+        private final String javaClassName;
+
+        private RenderResult(final String result, final String javaClassName) {
+            this.result = result;
+            this.javaClassName = javaClassName;
+        }
+
+        public String getResult() {
+            return result;
+        }
+
+        public String getJavaClassName() {
+            return javaClassName;
+        }
+    }
+
+}

--- a/codec-gtp-codegen/src/main/java/io/snice/codecs/codegen/gtp/templates/TvFramerTemplate.java
+++ b/codec-gtp-codegen/src/main/java/io/snice/codecs/codegen/gtp/templates/TvFramerTemplate.java
@@ -1,0 +1,43 @@
+package io.snice.codecs.codegen.gtp.templates;
+
+import io.snice.codecs.codec.gtp.v1.common.Format;
+import io.snice.codecs.codegen.ClassNameConverter;
+import io.snice.codecs.codegen.gtp.CodeGen;
+import io.snice.codecs.codegen.gtp.Gtpv1InfoElementMetaData;
+import liqp.Template;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TvFramerTemplate {
+
+    private final Template template;
+
+    public static TvFramerTemplate load() throws Exception {
+        return new TvFramerTemplate(CodeGen.loadTemplate("templates/gtpv1_tv_framer.liquid"));
+    }
+
+    private TvFramerTemplate(final Template template) {
+        this.template = template;
+    }
+
+    public String render(final ClassNameConverter converter, final String packageName, final List<Gtpv1InfoElementMetaData> tvs) {
+        final var attributes = new HashMap<String, Object>();
+        final var elements = new ArrayList<>();
+        attributes.put("elements", elements);
+        attributes.put("package", packageName);
+
+        tvs.stream().filter(tv -> tv.getFormat() == Format.TV).forEach(tv -> {
+            final Map<String, Object> tvAttributes = new HashMap<>();
+            final var names = converter.convertPreserveAbbreviation(tv.getFriendlyName());
+            final var className = names.size() == 1 ? names.get(0) : names.get(1);
+            tvAttributes.put("name", className);
+            elements.add(tvAttributes);
+        });
+
+        return template.render(attributes);
+    }
+
+}

--- a/codec-gtp-codegen/src/main/java/io/snice/codecs/codegen/gtp/templates/TvTemplate.java
+++ b/codec-gtp-codegen/src/main/java/io/snice/codecs/codegen/gtp/templates/TvTemplate.java
@@ -1,0 +1,61 @@
+package io.snice.codecs.codegen.gtp.templates;
+
+import io.snice.codecs.codegen.ClassNameConverter;
+import io.snice.codecs.codegen.gtp.CodeGen;
+import io.snice.codecs.codegen.gtp.Gtpv1InfoElementMetaData;
+import liqp.Template;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class TvTemplate {
+
+    private final Template template;
+
+    public static TvTemplate load() throws Exception {
+        return new TvTemplate(CodeGen.loadTemplate("templates/gtpv1_tv.liquid"));
+    }
+
+    private TvTemplate(final Template template) {
+        this.template = template;
+    }
+
+    public RenderResult render(final ClassNameConverter converter, final String javaPackageName, final Gtpv1InfoElementMetaData ie) {
+        final var attributes = new HashMap<String, Object>();
+        final Map<String, Object> javaAttributes = new HashMap<>();
+        final Map<String, Object> tlivAttributes = new HashMap<>();
+        attributes.put("java", javaAttributes);
+        javaAttributes.put("package", javaPackageName);
+        javaAttributes.put("tv", tlivAttributes);
+        final var names = converter.convertPreserveAbbreviation(ie.getFriendlyName());
+        final var className = names.size() == 1 ? names.get(0) : names.get(1);
+        tlivAttributes.put("name", className);
+        tlivAttributes.put("enum", ie.getEnumName());
+        tlivAttributes.put("enum_value", ie.getType());
+        tlivAttributes.put("type", ie.getTypeImpl().orElse("RawType"));
+        tlivAttributes.put("is_of_int_type", ie.isIntType());
+
+        final String rendered = template.render(attributes);
+        return new RenderResult(rendered, className);
+    }
+
+    public static class RenderResult {
+
+        private final String result;
+        private final String javaClassName;
+
+        private RenderResult(final String result, final String javaClassName) {
+            this.result = result;
+            this.javaClassName = javaClassName;
+        }
+
+        public String getResult() {
+            return result;
+        }
+
+        public String getJavaClassName() {
+            return javaClassName;
+        }
+    }
+
+}

--- a/codec-gtp-codegen/src/main/resources/specifications/gtpv1_information_elements.yml
+++ b/codec-gtp-codegen/src/main/resources/specifications/gtpv1_information_elements.yml
@@ -1,751 +1,756 @@
-- Format: TV
-  InformationElement: Cause
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.1
-  Type: 1
-- Format: TV
-  InformationElement: International Mobile Subscriber Identity (IMSI)
-  LengthType: Fixed
-  NumberOfFixedOctets: 8
-  Reference: 7.7.2
-  Type: 2
-- Format: TV
-  InformationElement: Routeing Area Identity (RAI)
-  LengthType: Fixed
-  NumberOfFixedOctets: 6
-  Reference: 7.7.3
-  Type: 3
-- Format: TV
-  InformationElement: Temporary Logical Link Identity (TLLI)
-  LengthType: Fixed
-  NumberOfFixedOctets: 4
-  Reference: 7.7.4
-  Type: 4
-- Format: TV
-  InformationElement: Packet TMSI (P-TMSI)
-  LengthType: Fixed
-  NumberOfFixedOctets: 4
-  Reference: 7.7.5
-  Type: 5
-- Format: TV
-  InformationElement: Reordering Required
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.6
-  Type: 8
-- Format: TV
-  InformationElement: Authentication Triplet
-  LengthType: Fixed
-  NumberOfFixedOctets: 28
-  Reference: 7.7.7
-  Type: 9
-- Format: TV
-  InformationElement: MAP Cause
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.8
-  Type: 11
-- Format: TV
-  InformationElement: P-TMSI Signature
-  LengthType: Fixed
-  NumberOfFixedOctets: 3
-  Reference: 7.7.9
-  Type: 12
-- Format: TV
-  InformationElement: MS Validated
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.10
-  Type: 13
-- Format: TV
-  InformationElement: Recovery
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.11
-  Type: 14
-- Format: TV
-  InformationElement: Selection Mode
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.12
-  Type: 15
-- Format: TV
-  InformationElement: Tunnel Endpoint Identifier Data I
-  LengthType: Fixed
-  NumberOfFixedOctets: 4
-  Reference: 7.7.13
-  Type: 16
-- Format: TV
-  InformationElement: Tunnel Endpoint Identifier Control Plane
-  LengthType: Fixed
-  NumberOfFixedOctets: 4
-  Reference: 7.7.14
-  Type: 17
-- Format: TV
-  InformationElement: Tunnel Endpoint Identifier Data II
-  LengthType: Fixed
-  NumberOfFixedOctets: 5
-  Reference: 7.7.15
-  Type: 18
-- Format: TV
-  InformationElement: Teardown Ind
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.16
-  Type: 19
-- Format: TV
-  InformationElement: NSAPI
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.17
-  Type: 20
-- Format: TV
-  InformationElement: RANAP Cause
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.18
-  Type: 21
-- Format: TV
-  InformationElement: RAB Context
-  LengthType: Fixed
-  NumberOfFixedOctets: 9
-  Reference: 7.7.19
-  Type: 22
-- Format: TV
-  InformationElement: Radio Priority SMS
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.20
-  Type: 23
-- Format: TV
-  InformationElement: Radio Priority
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.21
-  Type: 24
-- Format: TV
-  InformationElement: Packet Flow Id
-  LengthType: Fixed
-  NumberOfFixedOctets: 2
-  Reference: 7.7.22
-  Type: 25
-- Format: TV
-  InformationElement: Charging Characteristics
-  LengthType: Fixed
-  NumberOfFixedOctets: 2
-  Reference: 7.7.23
-  Type: 26
-- Format: TV
-  InformationElement: Trace Reference
-  LengthType: Fixed
-  NumberOfFixedOctets: 2
-  Reference: 7.7.24
-  Type: 27
-- Format: TV
-  InformationElement: Trace Type
-  LengthType: Fixed
-  NumberOfFixedOctets: 2
-  Reference: 7.7.25
-  Type: 28
-- Format: TV
-  InformationElement: MS Not Reachable Reason
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.25A
-  Type: 29
-- Format: TV
-  InformationElement: Charging ID
-  LengthType: Fixed
-  NumberOfFixedOctets: 4
-  Reference: 7.7.26
-  Type: 127
-- Format: TLV
-  InformationElement: End User Address
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.27
-  Type: 128
-- Format: TLV
-  InformationElement: MM Context
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.28
-  Type: 129
-- Format: TLV
-  InformationElement: PDP Context
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.29
-  Type: 130
-- Format: TLV
-  InformationElement: Access Point Name
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.30
-  Type: 131
-- Format: TLV
-  InformationElement: Protocol Configuration Options
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.31
-  Type: 132
-- Format: TLV
-  InformationElement: GSN Address
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.32
-  Type: 133
-- Format: TLV
-  InformationElement: MS International PSTN/ISDN Number (MSISDN)
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.33
-  Type: 134
-- Format: TLV
-  InformationElement: Quality of Service Profile
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.34
-  Type: 135
-- Format: TLV
-  InformationElement: Authentication Quintuplet
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.35
-  Type: 136
-- Format: TLV
-  InformationElement: Traffic Flow Template
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.36
-  Type: 137
-- Format: TLV
-  InformationElement: Target Identification
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.37
-  Type: 138
-- Format: TLV
-  InformationElement: UTRAN Transparent Container
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.38
-  Type: 139
-- Format: TLV
-  InformationElement: RAB Setup Information
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.39
-  Type: 140
-- Format: TLV
-  InformationElement: Extension Header Type List
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.40
-  Type: 141
-- Format: TLV
-  InformationElement: Trigger Id
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.41
-  Type: 142
-- Format: TLV
-  InformationElement: OMC Identity
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.42
-  Type: 143
-- Format: TLV
-  InformationElement: RAN Transparent Container
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.43
-  Type: 144
-- Format: TLV
-  InformationElement: PDP Context Prioritization
-  LengthType: Fixed
-  NumberOfFixedOctets: 0
-  Reference: 7.7.45
-  Type: 145
-- Format: TLV
-  InformationElement: Additional RAB Setup Information
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.45A
-  Type: 146
-- Format: TLV
-  InformationElement: SGSN Number
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.47
-  Type: 147
-- Format: TLV
-  InformationElement: Common Flags
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.48
-  Type: 148
-- Format: TLV
-  InformationElement: APN Restriction
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.49
-  Type: 149
-- Format: TLV
-  InformationElement: Radio Priority LCS
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.25B
-  Type: 150
-- Format: TLV
-  InformationElement: RAT Type
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.50
-  Type: 151
-- Format: TLV
-  InformationElement: User Location Information
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.51
-  Type: 152
-- Format: TLV
-  InformationElement: MS Time Zone
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.52
-  Type: 153
-- Format: TLV
-  InformationElement: IMEI(SV)
-  LengthType: Fixed
-  NumberOfFixedOctets: 8
-  Reference: 7.7.53
-  Type: 154
-- Format: TLV
-  InformationElement: CAMEL Charging Information Container
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.54
-  Type: 155
-- Format: TLV
-  InformationElement: MBMS UE Context
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.55
-  Type: 156
-- Format: TLV
-  InformationElement: Temporary Mobile Group Identity (TMGI)
-  LengthType: Fixed
-  NumberOfFixedOctets: 6
-  Reference: 7.7.56
-  Type: 157
-- Format: TLV
-  InformationElement: RIM Routing Address
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.57
-  Type: 158
-- Format: TLV
-  InformationElement: MBMS Protocol Configuration Options
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.58
-  Type: 159
-- Format: TLV
-  InformationElement: MBMS Service Area
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.60
-  Type: 160
-- Format: TLV
-  InformationElement: Source RNC PDCP context info
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.61
-  Type: 161
-- Format: TLV
-  InformationElement: Additional Trace Info
-  LengthType: Fixed
-  NumberOfFixedOctets: 9
-  Reference: 7.7.62
-  Type: 162
-- Format: TLV
-  InformationElement: Hop Counter
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.63
-  Type: 163
-- Format: TLV
-  InformationElement: Selected PLMN ID
-  LengthType: Fixed
-  NumberOfFixedOctets: 3
-  Reference: 7.7.64
-  Type: 164
-- Format: TLV
-  InformationElement: MBMS Session Identifier
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.65
-  Type: 165
-- Format: TLV
-  InformationElement: MBMS 2G/3G Indicator
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.66
-  Type: 166
-- Format: TLV
-  InformationElement: Enhanced NSAPI
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.67
-  Type: 167
-- Format: TLV
-  InformationElement: MBMS Session Duration
-  LengthType: Fixed
-  NumberOfFixedOctets: 3
-  Reference: 7.7.59
-  Type: 168
-- Format: TLV
-  InformationElement: Additional MBMS Trace Info
-  LengthType: Fixed
-  NumberOfFixedOctets: 8
-  Reference: 7.7.68
-  Type: 169
-- Format: TLV
-  InformationElement: MBMS Session Repetition Number
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.69
-  Type: 170
-- Format: TLV
-  InformationElement: MBMS Time To Data Transfer
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.70
-  Type: 171
-- Format: TLV
-  InformationElement: BSS Container
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.72
-  Type: 173
-- Format: TLV
-  InformationElement: Cell Identification
-  LengthType: Fixed
-  NumberOfFixedOctets: 17
-  Reference: 7.7.73
-  Type: 174
-- Format: TLV
-  InformationElement: PDU Numbers
-  LengthType: Fixed
-  NumberOfFixedOctets: 9
-  Reference: 7.7.74
-  Type: 175
-- Format: TLV
-  InformationElement: BSSGP Cause
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.75
-  Type: 176
-- Format: TLV
-  InformationElement: Required MBMS bearer capabilities
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.76
-  Type: 177
-- Format: TLV
-  InformationElement: RIM Routing Address Discriminator
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.77
-  Type: 178
-- Format: TLV
-  InformationElement: List of set-up PFCs
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.78
-  Type: 179
-- Format: TLV
-  InformationElement: PS Handover XID Parameters
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.79
-  Type: 180
-- Format: TLV
-  InformationElement: MS Info Change Reporting Action
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.80
-  Type: 181
-- Format: TLV
-  InformationElement: Direct Tunnel Flags
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.81
-  Type: 182
-- Format: TLV
-  InformationElement: Correlation-ID
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.82
-  Type: 183
-- Format: TLV
-  InformationElement: Bearer Control Mode
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.83
-  Type: 184
-- Format: TLV
-  InformationElement: MBMS Flow Identifier
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.84
-  Type: 185
-- Format: TLV
-  InformationElement: MBMS IP Multicast Distribution
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.85
-  Type: 186
-- Format: TLV
-  InformationElement: MBMS Distribution Acknowledgement
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.86
-  Type: 187
-- Format: TLV
-  InformationElement: 'Reliable INTER RAT HANDOVER INFO '
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.87
-  Type: 188
-- Format: TLV
-  InformationElement: RFSP Index
-  LengthType: Fixed
-  NumberOfFixedOctets: 2
-  Reference: 7.7.88
-  Type: 189
-- Format: TLV
-  InformationElement: Fully Qualified Domain Name (FQDN)
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.90
-  Type: 190
-- Format: TLV
-  InformationElement: Evolved Allocation/Retention Priority I
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.91
-  Type: 191
-- Format: TLV
-  InformationElement: Evolved Allocation/Retention Priority II
-  LengthType: Fixed
-  NumberOfFixedOctets: 2
-  Reference: 7.7.92
-  Type: 192
-- Format: TLV
-  InformationElement: Extended Common Flags
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.93
-  Type: 193
-- Format: TLV
-  InformationElement: User CSG Information (UCI)
-  LengthType: Fixed
-  NumberOfFixedOctets: 8
-  Reference: 7.7.94
-  Type: 194
-- Format: TLV
-  InformationElement: CSG Information Reporting Action
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.95
-  Type: 195
-- Format: TLV
-  InformationElement: CSG ID
-  LengthType: Fixed
-  NumberOfFixedOctets: 4
-  Reference: 7.7.96
-  Type: 196
-- Format: TLV
-  InformationElement: CSG Membership Indication (CMI)
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.97
-  Type: 197
-- Format: TLV
-  InformationElement: Aggregate Maximum Bit Rate (AMBR)
-  LengthType: Fixed
-  NumberOfFixedOctets: 8
-  Reference: 7.7.98
-  Type: 198
-- Format: TLV
-  InformationElement: UE Network Capability
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.99
-  Type: 199
-- Format: TLV
-  InformationElement: UE-AMBR
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.100
-  Type: 200
-- Format: TLV
-  InformationElement: APN-AMBR with NSAPI
-  LengthType: Fixed
-  NumberOfFixedOctets: 9
-  Reference: 7.7.101
-  Type: 201
-- Format: TLV
-  InformationElement: GGSN Back-Off Time
-  LengthType: Extendable
-  NumberOfFixedOctets: 1
-  Reference: 7.7.102
-  Type: 202
-- Format: TLV
-  InformationElement: Signalling Priority Indication
-  LengthType: Extendable
-  NumberOfFixedOctets: 1
-  Reference: 7.7.103
-  Type: 203
-- Format: TLV
-  InformationElement: Signalling Priority Indication with NSAPI
-  LengthType: Extendable
-  NumberOfFixedOctets: 2
-  Reference: 7.7.104
-  Type: 204
-- Format: TLV
-  InformationElement: Higher bitrates than 16 Mbps flag
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.105
-  Type: 205
-- Format: TLV
-  InformationElement: Additional MM context for SRVCC
-  LengthType: Extendable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.107
-  Type: 207
-- Format: TLV
-  InformationElement: Additional flags for SRVCC
-  LengthType: Extendable
-  NumberOfFixedOctets: 1
-  Reference: 7.7.108
-  Type: 208
-- Format: TLV
-  InformationElement: STN-SR
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.109
-  Type: 209
-- Format: TLV
-  InformationElement: C-MSISDN
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.110
-  Type: 210
-- Format: TLV
-  InformationElement: Extended RANAP Cause
-  LengthType: Extendable
-  NumberOfFixedOctets: 2
-  Reference: 7.7.111
-  Type: 211
-- Format: TLV
-  InformationElement: eNodeB ID
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.112
-  Type: 212
-- Format: TLV
-  InformationElement: Selection Mode with NSAPI
-  LengthType: Fixed
-  NumberOfFixedOctets: 2
-  Reference: 7.7.113
-  Type: 213
-- Format: TLV
-  InformationElement: ULI Timestamp
-  LengthType: Extendable
-  NumberOfFixedOctets: 4
-  Reference: 7.7.114
-  Type: 214
-- Format: TLV
-  InformationElement: Local Home Network ID (LHN-ID) with NSAPI
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.115
-  Type: 215
-- Format: TLV
-  InformationElement: 'CN Operator Selection Entity '
-  LengthType: Extendable
-  NumberOfFixedOctets: 1
-  Reference: 7.7.116
-  Type: 216
-- Format: TLV
-  InformationElement: UE Usage Type
-  LengthType: Variable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.117
-  Type: 217
-- Format: TLV
-  InformationElement: Extended Common Flags II
-  LengthType: Extendable
-  NumberOfFixedOctets: 1
-  Reference: 7.7.118
-  Type: 218
-- Format: TLV
-  InformationElement: 'Node Identifier '
-  LengthType: 'Variable '
-  NumberOfFixedOctets: -1
-  Reference: 7.7.119
-  Type: 219
-- Format: TLV
-  InformationElement: CIoT Optimizations Support Indication
-  LengthType: Extendable
-  NumberOfFixedOctets: 1
-  Reference: 7.7.120
-  Type: 220
-- Format: TLV
-  InformationElement: SCEF PDN Connection
-  LengthType: Extendable
-  NumberOfFixedOctets: -1
-  Reference: 7.7.121
-  Type: 221
-- Format: TLV
-  InformationElement: IOV_updates counter
-  LengthType: Fixed
-  NumberOfFixedOctets: 1
-  Reference: 7.7.122
-  Type: 222
-- Format: TLV
-  InformationElement: Mapped UE Usage Type
-  LengthType: Extendable
-  NumberOfFixedOctets: 2
-  Reference: 7.7.123
-  Type: 223
-- Format: TLV
-  InformationElement: UP Function Selection Indication Flags
-  LengthType: Extendable
-  NumberOfFixedOctets: 1
-  Reference: 7.7.124
-  Type: 224
-- Format: TLV
-  InformationElement: Special IE type for IE Type Extension
-  LengthType: Not Applicable
-  NumberOfFixedOctets: -1
-  Reference: See NOTE3
-  Type: 238
-- Format: TLV
-  InformationElement: Charging Gateway Address
-  LengthType: ''
-  NumberOfFixedOctets: -1
-  Reference: 7.7.44
-  Type: 251
-- Format: TLV
-  InformationElement: Private Extension
-  LengthType: ''
-  NumberOfFixedOctets: -1
-  Reference: 7.7.46
-  Type: 255
+- format: TV
+  informationElement: Cause
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.1
+  type: 1
+- format: TV
+  informationElement: International Mobile Subscriber Identity (IMSI)
+  lengthType: Fixed
+  numberOfFixedOctets: 8
+  reference: 7.7.2
+  type: 2
+- format: TV
+  informationElement: Routeing Area Identity (RAI)
+  lengthType: Fixed
+  numberOfFixedOctets: 6
+  reference: 7.7.3
+  type: 3
+- format: TV
+  informationElement: Temporary Logical Link Identity (TLLI)
+  lengthType: Fixed
+  numberOfFixedOctets: 4
+  reference: 7.7.4
+  type: 4
+- format: TV
+  informationElement: Packet TMSI (P-TMSI)
+  lengthType: Fixed
+  numberOfFixedOctets: 4
+  reference: 7.7.5
+  type: 5
+- format: TV
+  informationElement: Reordering Required
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.6
+  type: 8
+- format: TV
+  informationElement: Authentication Triplet
+  lengthType: Fixed
+  numberOfFixedOctets: 28
+  reference: 7.7.7
+  type: 9
+- format: TV
+  informationElement: MAP Cause
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.8
+  type: 11
+- format: TV
+  informationElement: P-TMSI Signature
+  lengthType: Fixed
+  numberOfFixedOctets: 3
+  reference: 7.7.9
+  type: 12
+- format: TV
+  informationElement: MS Validated
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.10
+  type: 13
+- format: TV
+  informationElement: Recovery
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.11
+  type: 14
+  typeImpl: CounterType
+  # Indicate whether or not this TV can be represented as an integer
+  # and if so, the generated TV should have a ofValue(int value) creator
+  # method generated.
+  isIntType: true
+- format: TV
+  informationElement: Selection Mode
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.12
+  type: 15
+- format: TV
+  informationElement: Tunnel Endpoint Identifier Data I
+  lengthType: Fixed
+  numberOfFixedOctets: 4
+  reference: 7.7.13
+  type: 16
+- format: TV
+  informationElement: Tunnel Endpoint Identifier Control Plane
+  lengthType: Fixed
+  numberOfFixedOctets: 4
+  reference: 7.7.14
+  type: 17
+- format: TV
+  informationElement: Tunnel Endpoint Identifier Data II
+  lengthType: Fixed
+  numberOfFixedOctets: 5
+  reference: 7.7.15
+  type: 18
+- format: TV
+  informationElement: Teardown Ind
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.16
+  type: 19
+- format: TV
+  informationElement: NSAPI
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.17
+  type: 20
+- format: TV
+  informationElement: RANAP Cause
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.18
+  type: 21
+- format: TV
+  informationElement: RAB Context
+  lengthType: Fixed
+  numberOfFixedOctets: 9
+  reference: 7.7.19
+  type: 22
+- format: TV
+  informationElement: Radio Priority SMS
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.20
+  type: 23
+- format: TV
+  informationElement: Radio Priority
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.21
+  type: 24
+- format: TV
+  informationElement: Packet Flow Id
+  lengthType: Fixed
+  numberOfFixedOctets: 2
+  reference: 7.7.22
+  type: 25
+- format: TV
+  informationElement: Charging Characteristics
+  lengthType: Fixed
+  numberOfFixedOctets: 2
+  reference: 7.7.23
+  type: 26
+- format: TV
+  informationElement: Trace reference
+  lengthType: Fixed
+  numberOfFixedOctets: 2
+  reference: 7.7.24
+  type: 27
+- format: TV
+  informationElement: Trace type
+  lengthType: Fixed
+  numberOfFixedOctets: 2
+  reference: 7.7.25
+  type: 28
+- format: TV
+  informationElement: MS Not Reachable Reason
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.25A
+  type: 29
+- format: TV
+  informationElement: Charging ID
+  lengthType: Fixed
+  numberOfFixedOctets: 4
+  reference: 7.7.26
+  type: 127
+- format: TLV
+  informationElement: End User Address
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.27
+  type: 128
+- format: TLV
+  informationElement: MM Context
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.28
+  type: 129
+- format: TLV
+  informationElement: PDP Context
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.29
+  type: 130
+- format: TLV
+  informationElement: Access Point Name
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.30
+  type: 131
+- format: TLV
+  informationElement: Protocol Configuration Options
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.31
+  type: 132
+- format: TLV
+  informationElement: GSN Address
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.32
+  type: 133
+- format: TLV
+  informationElement: MS International PSTN/ISDN Number (MSISDN)
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.33
+  type: 134
+- format: TLV
+  informationElement: Quality of Service Profile
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.34
+  type: 135
+- format: TLV
+  informationElement: Authentication Quintuplet
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.35
+  type: 136
+- format: TLV
+  informationElement: Traffic Flow Template
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.36
+  type: 137
+- format: TLV
+  informationElement: Target Identification
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.37
+  type: 138
+- format: TLV
+  informationElement: UTRAN Transparent Container
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.38
+  type: 139
+- format: TLV
+  informationElement: RAB Setup Information
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.39
+  type: 140
+- format: TLV
+  informationElement: Extension Header type List
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.40
+  type: 141
+- format: TLV
+  informationElement: Trigger Id
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.41
+  type: 142
+- format: TLV
+  informationElement: OMC Identity
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.42
+  type: 143
+- format: TLV
+  informationElement: RAN Transparent Container
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.43
+  type: 144
+- format: TLV
+  informationElement: PDP Context Prioritization
+  lengthType: Fixed
+  numberOfFixedOctets: 0
+  reference: 7.7.45
+  type: 145
+- format: TLV
+  informationElement: Additional RAB Setup Information
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.45A
+  type: 146
+- format: TLV
+  informationElement: SGSN Number
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.47
+  type: 147
+- format: TLV
+  informationElement: Common Flags
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.48
+  type: 148
+- format: TLV
+  informationElement: APN Restriction
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.49
+  type: 149
+- format: TLV
+  informationElement: Radio Priority LCS
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.25B
+  type: 150
+- format: TLV
+  informationElement: RAT type
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.50
+  type: 151
+- format: TLV
+  informationElement: User Location Information
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.51
+  type: 152
+- format: TLV
+  informationElement: MS Time Zone
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.52
+  type: 153
+- format: TLV
+  informationElement: IMEI(SV)
+  lengthType: Fixed
+  numberOfFixedOctets: 8
+  reference: 7.7.53
+  type: 154
+- format: TLV
+  informationElement: CAMEL Charging Information Container
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.54
+  type: 155
+- format: TLV
+  informationElement: MBMS UE Context
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.55
+  type: 156
+- format: TLV
+  informationElement: Temporary Mobile Group Identity (TMGI)
+  lengthType: Fixed
+  numberOfFixedOctets: 6
+  reference: 7.7.56
+  type: 157
+- format: TLV
+  informationElement: RIM Routing Address
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.57
+  type: 158
+- format: TLV
+  informationElement: MBMS Protocol Configuration Options
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.58
+  type: 159
+- format: TLV
+  informationElement: MBMS Service Area
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.60
+  type: 160
+- format: TLV
+  informationElement: Source RNC PDCP context info
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.61
+  type: 161
+- format: TLV
+  informationElement: Additional Trace Info
+  lengthType: Fixed
+  numberOfFixedOctets: 9
+  reference: 7.7.62
+  type: 162
+- format: TLV
+  informationElement: Hop Counter
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.63
+  type: 163
+- format: TLV
+  informationElement: Selected PLMN ID
+  lengthType: Fixed
+  numberOfFixedOctets: 3
+  reference: 7.7.64
+  type: 164
+- format: TLV
+  informationElement: MBMS Session Identifier
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.65
+  type: 165
+- format: TLV
+  informationElement: MBMS 2G/3G Indicator
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.66
+  type: 166
+- format: TLV
+  informationElement: Enhanced NSAPI
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.67
+  type: 167
+- format: TLV
+  informationElement: MBMS Session Duration
+  lengthType: Fixed
+  numberOfFixedOctets: 3
+  reference: 7.7.59
+  type: 168
+- format: TLV
+  informationElement: Additional MBMS Trace Info
+  lengthType: Fixed
+  numberOfFixedOctets: 8
+  reference: 7.7.68
+  type: 169
+- format: TLV
+  informationElement: MBMS Session Repetition Number
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.69
+  type: 170
+- format: TLV
+  informationElement: MBMS Time To Data Transfer
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.70
+  type: 171
+- format: TLV
+  informationElement: BSS Container
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.72
+  type: 173
+- format: TLV
+  informationElement: Cell Identification
+  lengthType: Fixed
+  numberOfFixedOctets: 17
+  reference: 7.7.73
+  type: 174
+- format: TLV
+  informationElement: PDU Numbers
+  lengthType: Fixed
+  numberOfFixedOctets: 9
+  reference: 7.7.74
+  type: 175
+- format: TLV
+  informationElement: BSSGP Cause
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.75
+  type: 176
+- format: TLV
+  informationElement: Required MBMS bearer capabilities
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.76
+  type: 177
+- format: TLV
+  informationElement: RIM Routing Address Discriminator
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.77
+  type: 178
+- format: TLV
+  informationElement: List of set-up PFCs
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.78
+  type: 179
+- format: TLV
+  informationElement: PS Handover XID Parameters
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.79
+  type: 180
+- format: TLV
+  informationElement: MS Info Change Reporting Action
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.80
+  type: 181
+- format: TLV
+  informationElement: Direct Tunnel Flags
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.81
+  type: 182
+- format: TLV
+  informationElement: Correlation-ID
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.82
+  type: 183
+- format: TLV
+  informationElement: Bearer Control Mode
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.83
+  type: 184
+- format: TLV
+  informationElement: MBMS Flow Identifier
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.84
+  type: 185
+- format: TLV
+  informationElement: MBMS IP Multicast Distribution
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.85
+  type: 186
+- format: TLV
+  informationElement: MBMS Distribution Acknowledgement
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.86
+  type: 187
+- format: TLV
+  informationElement: 'Reliable INTER RAT HANDOVER INFO '
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.87
+  type: 188
+- format: TLV
+  informationElement: RFSP Index
+  lengthType: Fixed
+  numberOfFixedOctets: 2
+  reference: 7.7.88
+  type: 189
+- format: TLV
+  informationElement: Fully Qualified Domain Name (FQDN)
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.90
+  type: 190
+- format: TLV
+  informationElement: Evolved Allocation/Retention Priority I
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.91
+  type: 191
+- format: TLV
+  informationElement: Evolved Allocation/Retention Priority II
+  lengthType: Fixed
+  numberOfFixedOctets: 2
+  reference: 7.7.92
+  type: 192
+- format: TLV
+  informationElement: Extended Common Flags
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.93
+  type: 193
+- format: TLV
+  informationElement: User CSG Information (UCI)
+  lengthType: Fixed
+  numberOfFixedOctets: 8
+  reference: 7.7.94
+  type: 194
+- format: TLV
+  informationElement: CSG Information Reporting Action
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.95
+  type: 195
+- format: TLV
+  informationElement: CSG ID
+  lengthType: Fixed
+  numberOfFixedOctets: 4
+  reference: 7.7.96
+  type: 196
+- format: TLV
+  informationElement: CSG Membership Indication (CMI)
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.97
+  type: 197
+- format: TLV
+  informationElement: Aggregate Maximum Bit Rate (AMBR)
+  lengthType: Fixed
+  numberOfFixedOctets: 8
+  reference: 7.7.98
+  type: 198
+- format: TLV
+  informationElement: UE Network Capability
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.99
+  type: 199
+- format: TLV
+  informationElement: UE-AMBR
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.100
+  type: 200
+- format: TLV
+  informationElement: APN-AMBR with NSAPI
+  lengthType: Fixed
+  numberOfFixedOctets: 9
+  reference: 7.7.101
+  type: 201
+- format: TLV
+  informationElement: GGSN Back-Off Time
+  lengthType: Extendable
+  numberOfFixedOctets: 1
+  reference: 7.7.102
+  type: 202
+- format: TLV
+  informationElement: Signalling Priority Indication
+  lengthType: Extendable
+  numberOfFixedOctets: 1
+  reference: 7.7.103
+  type: 203
+- format: TLV
+  informationElement: Signalling Priority Indication with NSAPI
+  lengthType: Extendable
+  numberOfFixedOctets: 2
+  reference: 7.7.104
+  type: 204
+- format: TLV
+  informationElement: Higher bitrates than 16 Mbps flag
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.105
+  type: 205
+- format: TLV
+  informationElement: Additional MM context for SRVCC
+  lengthType: Extendable
+  numberOfFixedOctets: -1
+  reference: 7.7.107
+  type: 207
+- format: TLV
+  informationElement: Additional flags for SRVCC
+  lengthType: Extendable
+  numberOfFixedOctets: 1
+  reference: 7.7.108
+  type: 208
+- format: TLV
+  informationElement: STN-SR
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.109
+  type: 209
+- format: TLV
+  informationElement: C-MSISDN
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.110
+  type: 210
+- format: TLV
+  informationElement: Extended RANAP Cause
+  lengthType: Extendable
+  numberOfFixedOctets: 2
+  reference: 7.7.111
+  type: 211
+- format: TLV
+  informationElement: eNodeB ID
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.112
+  type: 212
+- format: TLV
+  informationElement: Selection Mode with NSAPI
+  lengthType: Fixed
+  numberOfFixedOctets: 2
+  reference: 7.7.113
+  type: 213
+- format: TLV
+  informationElement: ULI Timestamp
+  lengthType: Extendable
+  numberOfFixedOctets: 4
+  reference: 7.7.114
+  type: 214
+- format: TLV
+  informationElement: Local Home Network ID (LHN-ID) with NSAPI
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.115
+  type: 215
+- format: TLV
+  informationElement: 'CN Operator Selection Entity '
+  lengthType: Extendable
+  numberOfFixedOctets: 1
+  reference: 7.7.116
+  type: 216
+- format: TLV
+  informationElement: UE Usage type
+  lengthType: Variable
+  numberOfFixedOctets: -1
+  reference: 7.7.117
+  type: 217
+- format: TLV
+  informationElement: Extended Common Flags II
+  lengthType: Extendable
+  numberOfFixedOctets: 1
+  reference: 7.7.118
+  type: 218
+- format: TLV
+  informationElement: 'Node Identifier '
+  lengthType: 'Variable '
+  numberOfFixedOctets: -1
+  reference: 7.7.119
+  type: 219
+- format: TLV
+  informationElement: CIoT Optimizations Support Indication
+  lengthType: Extendable
+  numberOfFixedOctets: 1
+  reference: 7.7.120
+  type: 220
+- format: TLV
+  informationElement: SCEF PDN Connection
+  lengthType: Extendable
+  numberOfFixedOctets: -1
+  reference: 7.7.121
+  type: 221
+- format: TLV
+  informationElement: IOV_updates counter
+  lengthType: Fixed
+  numberOfFixedOctets: 1
+  reference: 7.7.122
+  type: 222
+- format: TLV
+  informationElement: Mapped UE Usage type
+  lengthType: Extendable
+  numberOfFixedOctets: 2
+  reference: 7.7.123
+  type: 223
+- format: TLV
+  informationElement: UP Function Selection Indication Flags
+  lengthType: Extendable
+  numberOfFixedOctets: 1
+  reference: 7.7.124
+  type: 224
+- format: TLV
+  informationElement: Special IE type for IE type Extension
+  lengthType: Not Applicable
+  numberOfFixedOctets: -1
+  reference: See NOTE3
+  type: 238
+- format: TLV
+  informationElement: Charging Gateway Address
+  lengthType: ''
+  numberOfFixedOctets: -1
+  reference: 7.7.44
+  type: 251
+- format: TLV
+  informationElement: Private Extension
+  lengthType: ''
+  numberOfFixedOctets: -1
+  reference: 7.7.46
+  type: 255
 

--- a/codec-gtp-codegen/src/main/resources/templates/gtpv1_information_elements.liquid
+++ b/codec-gtp-codegen/src/main/resources/templates/gtpv1_information_elements.liquid
@@ -1,0 +1,54 @@
+package io.snice.codecs.codec.gtp.gtpc.v1;
+
+import io.snice.codecs.codec.gtp.v1.common.Format;
+
+import static io.snice.codecs.codec.gtp.v1.common.Format.TLV;
+import static io.snice.codecs.codec.gtp.v1.common.Format.TV;
+
+/**
+ * This file has been auto generated. Do not manually edit.
+ * Please see the readme file in the codegen directory
+ * for how to update and generate this file.
+ *
+ * @author jonas@jonasborjesson.com
+ */
+public enum Gtp1InfoElement {
+
+  {%- for element in elements %}
+    {{element['enumName']}}({{element['type']}}, {{element['format']}}, "{{element['friendlyName']}}", {{element['numberOfFixedOctets']}}){%- if element['type'] != 255 -%},{% else %};{%- endif -%}
+  {% endfor %}
+
+    private final int typeAsDecimal;
+    private final byte type;
+    private final int octets;
+    private final String friendlyName;
+    private final Format format;
+
+    Gtp1InfoElement(final int type, final Format format, final String friendlyName, final int octets) {
+        this.typeAsDecimal = type;
+        this.type = (byte) type;
+        this.format = format;
+        this.friendlyName = friendlyName;
+        this.octets = octets;
+    }
+
+    public int getTypeAsDecimal() {
+        return typeAsDecimal;
+    }
+
+    public byte getType() {
+        return type;
+    }
+
+    public int getOctets() {
+        return octets;
+    }
+
+    public Format getFormat() {
+        return format;
+    }
+
+    public String getFriendlyName() {
+        return friendlyName;
+    }
+}

--- a/codec-gtp-codegen/src/main/resources/templates/gtpv1_tlv.liquid
+++ b/codec-gtp-codegen/src/main/resources/templates/gtpv1_tlv.liquid
@@ -1,0 +1,110 @@
+package {{java.package}};
+
+import io.snice.buffer.Buffer;
+import io.snice.buffer.Buffers;
+import io.snice.buffer.WritableBuffer;
+import io.snice.codecs.codec.gtp.gtpc.v2.tliv.TypeLengthInstanceValue;
+import io.snice.codecs.codec.gtp.gtpc.v2.tliv.impl.BaseTliv;
+import io.snice.codecs.codec.gtp.gtpc.v2.tliv.impl.RawTypeLengthInstanceValue;
+import io.snice.codecs.codec.gtp.gtpc.v2.type.CounterType;
+import io.snice.codecs.codec.gtp.gtpc.v2.Gtp2InfoElement;
+import io.snice.codecs.codec.gtp.gtpc.v1.Gtp1InfoElement;
+import io.snice.codecs.codec.gtp.gtpc.v2.type.CounterType;
+import io.snice.codecs.codec.gtp.gtpc.v2.type.RawType;
+
+import static io.snice.preconditions.PreConditions.assertArgument;
+import static io.snice.preconditions.PreConditions.assertNotNull;
+
+/**
+ * This file has been auto generated. Do not manually edit.
+ * Please see the readme file in the codegen directory
+ * for how to update and generate this file.
+ *
+ * @author jonas@jonasborjesson.com
+ */
+public interface {{java.tv.name}} extends TypeLengthValue<{{java.tv.type}}> {
+
+    Gtp1InfoElement TYPE = Gtp1InfoElement.{{java.tv.enum}};
+
+    /**
+     * The raw byte value of the Info Element. Useful when writing switch statements
+     * since those needs a constant value.
+     */
+    byte TYPE_VALUE = (byte){{java.tv.enum_value}};
+
+    int LENGTH = TYPE.getOctets();
+
+    static {{java.tv.name}} frame(final Buffer buffer) {
+        return frame(RawTypeLengthValue.frame(buffer));
+    }
+
+    static {{java.tv.name}} frame(final RawTypeLengthValue raw) {
+        assertNotNull(raw);
+        assertArgument(raw.getType() == TYPE_VALUE, "The given raw TV is not a " + TYPE);
+
+        {%- if java.tv.type == "RawType" %}
+        final var value = raw.getValue();
+        {% else %}
+        final var value = {{java.tv.type}}.parse(raw.getValue().getBuffer());
+        {% endif %}
+        return new Default{{java.tv.name}}(value, raw);
+    }
+
+    static {{java.tv.name}} ofValue(final Buffer buffer) {
+        final var value = {{java.tv.type}}.ofValue(buffer);
+        return ofValue(value);
+    }
+
+    static {{java.tv.name}} ofValue(final String buffer) {
+        final var value = {{java.tv.type}}.ofValue(buffer);
+        return ofValue(value);
+    }
+
+    static {{java.tv.name}} ofValue(final {{java.tv.type}} value) {
+        return ofValue(value);
+    }
+
+   {%- if java.tv.is_of_int_type  %}
+    static {{java.tv.name}} ofValue(final int value) {
+        final var buffer = WritableBuffer.of(1 + LENGTH).fastForwardWriterIndex();
+        buffer.setByte(0, TYPE_VALUE);
+        switch (LENGTH) {
+            case 1:
+                buffer.setByte(1, (byte)value);
+                break;
+            case 2:
+                buffer.setUnsignedShort(1, value);
+                break;
+            case 3:
+                buffer.setThreeOctetInt(1, value);
+                break;
+            case 4:
+                buffer.setInt(1, value);
+                break;
+            default:
+                // TODO: should we perhaps just put the int at the very end?
+                //      Not sure this case actually exists so until we find a TV that
+                //      does this then let's play it safe and error out.
+                throw new IllegalArgumentException("Unable to set an integer for a " +
+                        "Type Value information element that is " + LENGTH + " long");
+
+        }
+
+        final var raw = RawTypeLengthValue.frame(buffer.build());
+        final var typeValue = {{java.tv.type}}.parse(raw.getValue().getBuffer());
+        return new DefaultRecovery(typeValue, raw);
+    }
+    {% endif %}
+
+    @Override
+    default {{java.tv.name}} ensure() {
+        return this;
+    }
+
+    class Default{{java.tv.name}} extends BaseTypeLengthValue<{{java.tv.type}}> implements {{java.tv.name}} {
+        private Default{{java.tv.name}}(final {{java.tv.type}} value, final RawTypeLengthValue raw) {
+            super(TYPE_VALUE, value, raw);
+        }
+    }
+}
+

--- a/codec-gtp-codegen/src/main/resources/templates/gtpv1_tlv_framer.liquid
+++ b/codec-gtp-codegen/src/main/resources/templates/gtpv1_tlv_framer.liquid
@@ -1,0 +1,40 @@
+package {{package}};
+
+import io.snice.buffer.Buffer;
+import io.snice.codecs.codec.gtp.GtpParseException;
+import io.snice.codecs.codec.gtp.gtpc.v2.type.GtpType;
+import io.snice.codecs.codec.gtp.gtpc.v2.tliv.impl.RawTypeLengthInstanceValue;
+
+/**
+ * This file has been auto generated. Do not manually edit.
+ * Please see the readme file in the codegen directory
+ * for how to update and generate this file.
+ *
+ * @author jonas@jonasborjesson.com
+ */
+public class TypeLengthValueFramer {
+
+    public static TypeLengthValue<? extends GtpType> frame(final Buffer buffer) {
+        final var b = buffer.getByte(0);
+        switch (b) {
+  {%- for element in elements %}
+            case ({{element.name}}.TYPE_VALUE):
+                return {{element.name}}.frame(buffer);
+  {%- endfor %}
+            default:
+                throw new GtpParseException("Unknown GTPv1 Type Length Value");
+        }
+    }
+
+    static TypeLengthValue<? extends GtpType> frame(final RawTypeLengthValue raw) {
+        switch (raw.getType()) {
+  {%- for element in elements %}
+            case ({{element.name}}.TYPE_VALUE):
+                return {{element.name}}.frame(raw);
+  {%- endfor %}
+            default:
+                throw new GtpParseException("Unknown GTPv1 Type Length Value");
+        }
+    }
+
+}

--- a/codec-gtp-codegen/src/main/resources/templates/gtpv1_tv.liquid
+++ b/codec-gtp-codegen/src/main/resources/templates/gtpv1_tv.liquid
@@ -1,0 +1,110 @@
+package {{java.package}};
+
+import io.snice.buffer.Buffer;
+import io.snice.buffer.Buffers;
+import io.snice.buffer.WritableBuffer;
+import io.snice.codecs.codec.gtp.gtpc.v2.tliv.TypeLengthInstanceValue;
+import io.snice.codecs.codec.gtp.gtpc.v2.tliv.impl.BaseTliv;
+import io.snice.codecs.codec.gtp.gtpc.v2.tliv.impl.RawTypeLengthInstanceValue;
+import io.snice.codecs.codec.gtp.gtpc.v2.type.CounterType;
+import io.snice.codecs.codec.gtp.gtpc.v2.Gtp2InfoElement;
+import io.snice.codecs.codec.gtp.gtpc.v1.Gtp1InfoElement;
+import io.snice.codecs.codec.gtp.gtpc.v2.type.CounterType;
+import io.snice.codecs.codec.gtp.gtpc.v2.type.RawType;
+
+import static io.snice.preconditions.PreConditions.assertArgument;
+import static io.snice.preconditions.PreConditions.assertNotNull;
+
+/**
+ * This file has been auto generated. Do not manually edit.
+ * Please see the readme file in the codegen directory
+ * for how to update and generate this file.
+ *
+ * @author jonas@jonasborjesson.com
+ */
+public interface {{java.tv.name}} extends TypeValue<{{java.tv.type}}> {
+
+    Gtp1InfoElement TYPE = Gtp1InfoElement.{{java.tv.enum}};
+
+    /**
+     * The raw byte value of the Info Element. Useful when writing switch statements
+     * since those needs a constant value.
+     */
+    byte TYPE_VALUE = (byte){{java.tv.enum_value}};
+
+    int LENGTH = TYPE.getOctets();
+
+    static {{java.tv.name}} frame(final Buffer buffer) {
+        return frame(RawTypeValue.frame(buffer));
+    }
+
+    static {{java.tv.name}} frame(final RawTypeValue raw) {
+        assertNotNull(raw);
+        assertArgument(raw.getType() == TYPE_VALUE, "The given raw TV is not a " + TYPE);
+
+        {%- if java.tv.type == "RawType" %}
+        final var value = raw.getValue();
+        {% else %}
+        final var value = {{java.tv.type}}.parse(raw.getValue().getBuffer());
+        {% endif %}
+        return new Default{{java.tv.name}}(value, raw);
+    }
+
+    static {{java.tv.name}} ofValue(final Buffer buffer) {
+        final var value = {{java.tv.type}}.ofValue(buffer);
+        return ofValue(value);
+    }
+
+    static {{java.tv.name}} ofValue(final String buffer) {
+        final var value = {{java.tv.type}}.ofValue(buffer);
+        return ofValue(value);
+    }
+
+    static {{java.tv.name}} ofValue(final {{java.tv.type}} value) {
+        return ofValue(value);
+    }
+
+   {%- if java.tv.is_of_int_type  %}
+    static {{java.tv.name}} ofValue(final int value) {
+        final var buffer = WritableBuffer.of(1 + LENGTH).fastForwardWriterIndex();
+        buffer.setByte(0, TYPE_VALUE);
+        switch (LENGTH) {
+            case 1:
+                buffer.setByte(1, (byte)value);
+                break;
+            case 2:
+                buffer.setUnsignedShort(1, value);
+                break;
+            case 3:
+                buffer.setThreeOctetInt(1, value);
+                break;
+            case 4:
+                buffer.setInt(1, value);
+                break;
+            default:
+                // TODO: should we perhaps just put the int at the very end?
+                //      Not sure this case actually exists so until we find a TV that
+                //      does this then let's play it safe and error out.
+                throw new IllegalArgumentException("Unable to set an integer for a " +
+                        "Type Value information element that is " + LENGTH + " long");
+
+        }
+
+        final var raw = RawTypeValue.frame(buffer.build());
+        final var typeValue = {{java.tv.type}}.parse(raw.getValue().getBuffer());
+        return new DefaultRecovery(typeValue, raw);
+    }
+    {% endif %}
+
+    @Override
+    default {{java.tv.name}} ensure() {
+        return this;
+    }
+
+    class Default{{java.tv.name}} extends BaseTypeValue<{{java.tv.type}}> implements {{java.tv.name}} {
+        private Default{{java.tv.name}}(final {{java.tv.type}} value, final RawTypeValue raw) {
+            super(TYPE_VALUE, value, raw);
+        }
+    }
+}
+

--- a/codec-gtp-codegen/src/main/resources/templates/gtpv1_tv_framer.liquid
+++ b/codec-gtp-codegen/src/main/resources/templates/gtpv1_tv_framer.liquid
@@ -1,0 +1,50 @@
+package {{package}};
+
+import io.snice.buffer.Buffer;
+import io.snice.codecs.codec.gtp.GtpParseException;
+import io.snice.codecs.codec.gtp.gtpc.v2.type.GtpType;
+import io.snice.codecs.codec.gtp.gtpc.v2.tliv.impl.RawTypeLengthInstanceValue;
+
+/**
+ * This file has been auto generated. Do not manually edit.
+ * Please see the readme file in the codegen directory
+ * for how to update and generate this file.
+ *
+ * @author jonas@jonasborjesson.com
+ */
+public class TypeValueFramer {
+
+    public static TypeValue<? extends GtpType> frame(final Buffer buffer) {
+        final var b = buffer.getByte(0);
+        switch (b) {
+  {%- for element in elements %}
+            case ({{element.name}}.TYPE_VALUE):
+                return {{element.name}}.frame(buffer);
+  {%- endfor %}
+            default:
+                throw new GtpParseException("Unknown GTPv1 Type Value");
+        }
+    }
+
+    static TypeValue<? extends GtpType> frame(final RawTypeValue raw) {
+        switch (raw.getType()) {
+  {%- for element in elements %}
+            case ({{element.name}}.TYPE_VALUE):
+                return {{element.name}}.frame(raw);
+  {%- endfor %}
+            default:
+                throw new GtpParseException("Unknown GTPv1 Type Length value");
+        }
+    }
+
+    public static int getLength(final byte type) {
+        switch (type) {
+  {%- for element in elements %}
+            case ({{element.name}}.TYPE_VALUE):
+                return {{element.name}}.LENGTH;
+  {%- endfor %}
+            default:
+                throw new GtpParseException("Unknown GTPv1 Type Length value");
+        }
+    }
+}

--- a/codec-gtp-codegen/src/test/java/io/snice/codecs/codegen/CodeGenTest.java
+++ b/codec-gtp-codegen/src/test/java/io/snice/codecs/codegen/CodeGenTest.java
@@ -6,7 +6,7 @@ import io.snice.codecs.codegen.gtp.Gtpv2MessageTypeMetaData;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class CodeGenTest {
 

--- a/codec-gtp-codegen/src/test/java/io/snice/codecs/codegen/gtp/templates/Gtpv1InformationElementsTest.java
+++ b/codec-gtp-codegen/src/test/java/io/snice/codecs/codegen/gtp/templates/Gtpv1InformationElementsTest.java
@@ -1,0 +1,45 @@
+package io.snice.codecs.codegen.gtp.templates;
+
+import io.snice.codecs.codec.gtp.v1.common.Format;
+import io.snice.codecs.codegen.gtp.CodeGen;
+import io.snice.codecs.codegen.gtp.Gtpv1InfoElementMetaData;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class Gtpv1InformationElementsTest {
+
+    @Test
+    public void testLoadMetaData() throws Exception {
+        final var ies = CodeGen.loadGtpv1InfoElementMetaData();
+        assertIE(ies, 1, Format.TV, 1, "CAUSE");
+        assertIE(ies, 128, Format.TLV, -1, "END_USER_ADDRESS");
+        assertIE(ies, 134, Format.TLV, -1, "MSISDN");
+
+        final var i = ies.stream().filter(ie -> ie.getFriendlyName().contains("International")).findFirst().get();
+        System.err.println(i.getEnumName());
+    }
+
+    @Test
+    public void testRendering() throws Exception {
+        final var template = Gtpv1InformationElementsTemplate.load();
+        final var ies = CodeGen.loadGtpv1InfoElementMetaData();
+        final var rendered = template.render(ies);
+        System.out.println(rendered);
+    }
+
+    private void assertIE(final List<Gtpv1InfoElementMetaData> ies, final int type,
+                          final Format expectedFormat, final int expectedOctets,
+                          final String expectedEnumName) {
+        final var ie = ies.stream().filter(i -> i.getType() == type)
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Unit Test Error. Cant find IE of type " + type));
+
+        assertThat(ie.getFormat(), is(expectedFormat));
+        assertThat(ie.getNumberOfFixedOctets(), is(expectedOctets));
+        assertThat(ie.getEnumName(), is(expectedEnumName));
+    }
+}

--- a/codec-gtp-codegen/src/test/java/io/snice/codecs/codegen/gtp/templates/Gtpv1MessageTypeTemplateTest.java
+++ b/codec-gtp-codegen/src/test/java/io/snice/codecs/codegen/gtp/templates/Gtpv1MessageTypeTemplateTest.java
@@ -4,7 +4,7 @@ import io.snice.codecs.codegen.gtp.CodeGen;
 import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class Gtpv1MessageTypeTemplateTest {
 

--- a/codec-gtp-codegen/src/test/java/io/snice/codecs/codegen/gtp/templates/InfoElementTemplateTest.java
+++ b/codec-gtp-codegen/src/test/java/io/snice/codecs/codegen/gtp/templates/InfoElementTemplateTest.java
@@ -1,20 +1,66 @@
 package io.snice.codecs.codegen.gtp.templates;
 
+import io.snice.codecs.codegen.ClassNameConverter;
 import io.snice.codecs.codegen.gtp.CodeGen;
-import org.hamcrest.CoreMatchers;
+import io.snice.codecs.codegen.gtp.Gtpv1InfoElementMetaData;
+import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertThat;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 
 public class InfoElementTemplateTest {
 
+    private ClassNameConverter classNameConverter;
+    private TvTemplate tvTemplate;
+    private List<Gtpv1InfoElementMetaData> tvs;
+
+    @Before
+    public void setUp() throws Exception {
+        classNameConverter = ClassNameConverter.defaultConverter();
+        tvTemplate = TvTemplate.load();
+        tvs = CodeGen.loadGtpv1InfoElementMetaData();
+    }
+
+    private void testPackageName() {
+        tvs.forEach(tv -> {
+            final var result = tvTemplate.render(classNameConverter, "unit.test.fake.package.name", tv);
+            assertThat(result.getResult().split("\n")[0].contains("package unit.test.fake.package.name;"), is(true));
+        });
+    }
+
     @Test
     public void testLoadTemplate() throws Exception {
-        final var template = InfoElementTemplate.load();
-        final var ies = CodeGen.loadInfoElementMetaData();
-        final String rendered = template.render(ies);
-        System.out.println(rendered);
-        assertThat(rendered.length() > 0, CoreMatchers.is(true));
+        ensureInterfaceName(1, "Cause");
+        final var recovery = tvTemplate.render(classNameConverter, "unit.test.fake.package.name", get(tvs, 14));
+        assertThat(recovery.getResult().contains("public interface Recovery"), is(true));
+
+        // recovery is really just an int (or actually byte) and as such, it should have a static ofValue method to create
+        // it from.
+        assertThat(recovery.getResult().contains("static Recovery ofValue(final int value)"), is(true));
+
+        final var tlli = tvTemplate.render(classNameConverter, "unit.test.fake.package.name", get(tvs, 4));
+        System.out.println(tlli.getResult());
+        assertThat(tlli.getJavaClassName(), is("Tlli"));
+
+        final var imsi = tvTemplate.render(classNameConverter, "unit.test.fake.package.name", get(tvs, 2));
+        System.out.println(imsi.getResult());
+        assertThat(tlli.getJavaClassName(), is("Tlli"));
+    }
+
+    private void ensureInterfaceName(final int tvType, final String expectedName) {
+        final var tv = tvTemplate.render(classNameConverter, "unit.test.fake.package.name", get(tvs, tvType));
+        assertThat(tv.getJavaClassName(), is(expectedName));
+    }
+
+    private Gtpv1InfoElementMetaData get(final List<Gtpv1InfoElementMetaData> list, final int type) {
+        return list.stream()
+                .filter(tv -> tv.getType() == type)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unit test error. Unable to find the TV of type " + type));
     }
 
 }

--- a/codec-gtp-codegen/src/test/java/io/snice/codecs/codegen/gtp/templates/TlvFramerTemplateTest.java
+++ b/codec-gtp-codegen/src/test/java/io/snice/codecs/codegen/gtp/templates/TlvFramerTemplateTest.java
@@ -1,0 +1,40 @@
+package io.snice.codecs.codegen.gtp.templates;
+
+import io.snice.codecs.codec.gtp.v1.common.Format;
+import io.snice.codecs.codegen.ClassNameConverter;
+import io.snice.codecs.codegen.gtp.CodeGen;
+import io.snice.codecs.codegen.gtp.Gtpv1InfoElementMetaData;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TlvFramerTemplateTest {
+
+    private ClassNameConverter classNameConverter;
+    private TlvFramerTemplate tvTemplate;
+    private List<Gtpv1InfoElementMetaData> tvs;
+
+    @Before
+    public void setUp() throws Exception {
+        classNameConverter = ClassNameConverter.defaultConverter();
+        tvTemplate = TlvFramerTemplate.load();
+        tvs = CodeGen.loadGtpv1InfoElementMetaData();
+    }
+
+    @Test
+    public void testGenerateFramer() {
+        final var result = tvTemplate.render(classNameConverter, "hello.world", tvs);
+        assertThat(result.contains("package hello.world;"), is(true));
+        final var countTypeValueElements = tvs.stream().filter(tv -> tv.getFormat() == Format.TLV).count();
+        final var countCaseStatements = Arrays.stream(result.split("\n")).filter(line -> line.contains("case (")).count();
+
+        // two as many because we generate two different switch statements
+        assertThat(countCaseStatements, is(countTypeValueElements * 2L));
+    }
+
+}

--- a/codec-gtp-codegen/src/test/java/io/snice/codecs/codegen/gtp/templates/TvFramerTemplateTest.java
+++ b/codec-gtp-codegen/src/test/java/io/snice/codecs/codegen/gtp/templates/TvFramerTemplateTest.java
@@ -1,0 +1,40 @@
+package io.snice.codecs.codegen.gtp.templates;
+
+import io.snice.codecs.codec.gtp.v1.common.Format;
+import io.snice.codecs.codegen.ClassNameConverter;
+import io.snice.codecs.codegen.gtp.CodeGen;
+import io.snice.codecs.codegen.gtp.Gtpv1InfoElementMetaData;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class TvFramerTemplateTest {
+
+    private ClassNameConverter classNameConverter;
+    private TvFramerTemplate tvTemplate;
+    private List<Gtpv1InfoElementMetaData> tvs;
+
+    @Before
+    public void setUp() throws Exception {
+        classNameConverter = ClassNameConverter.defaultConverter();
+        tvTemplate = TvFramerTemplate.load();
+        tvs = CodeGen.loadGtpv1InfoElementMetaData();
+    }
+
+    @Test
+    public void testGenerateFramer() {
+        final var result = tvTemplate.render(classNameConverter, "hello.world", tvs);
+        assertThat(result.contains("package hello.world;"), is(true));
+        final var countTypeValueElements = tvs.stream().filter(tv -> tv.getFormat() == Format.TV).count();
+        final var countCaseStatements = Arrays.stream(result.split("\n")).filter(line -> line.contains("case (")).count();
+
+        // thrice as many because we generate three different switch statements
+        assertThat(countCaseStatements, is(countTypeValueElements * 3L));
+    }
+
+}

--- a/codec-gtp-codegen/src/test/java/io/snice/codecs/codegen/gtp/templates/TvTemplateTest.java
+++ b/codec-gtp-codegen/src/test/java/io/snice/codecs/codegen/gtp/templates/TvTemplateTest.java
@@ -7,14 +7,13 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 
-public class TlivTemplateTest {
+public class TvTemplateTest {
 
     @Test
     public void testLoadTemplate() throws Exception {
         final var template = TlivTemplate.load();
         final var ies = CodeGen.loadInfoElementMetaData();
         final String rendered = template.render(ClassNameConverter.defaultConverter(), ies.get(1));
-        System.out.println(rendered);
         assertThat(rendered.length() > 0, CoreMatchers.is(true));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
 
     <modules>
         <module>codec-diameter-base</module>
+        <module>codec-gtp-base</module>
         <module>codec-diameter-codegen</module>
         <module>codec-gtp-codegen</module>
         <module>codec-codegen-common</module>
@@ -90,6 +91,14 @@
             <dependency>
                 <groupId>io.snice.codecs</groupId>
                 <artifactId>codec-diameter-base</artifactId>
+                <version>${project.version}</version>
+                <type>jar</type>
+                <scope>compile</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>io.snice.codecs</groupId>
+                <artifactId>codec-gtp-base</artifactId>
                 <version>${project.version}</version>
                 <type>jar</type>
                 <scope>compile</scope>


### PR DESCRIPTION
* Generating both Type Value (TV) and Type Length Value (TLV) Information Elements (IEs).
* Generating framers for both the TV and TLV IEs.

Also, Updates to the ClassNameConverter and code generation.

* Changed the ClassNameConverter to also do Enums, which it didn't before.
* Changed the GTPv2 Info Element Enums to generate the name of the enum from the "friendly name", based on the output from the ClassNameConverter.
* Adopted the same strategy for generating GTPv1 Info Element Enums, i.e., the actual name of the enum is derived from the "friendly name"